### PR TITLE
Make unit tests run consistently regardless of local timezone.

### DIFF
--- a/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimeline.js
+++ b/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimeline.js
@@ -37,9 +37,8 @@ export class UserActivityTimeline extends Component {
     // Begin by decorating the activity entries with supplemental data
     // that will make it easier for us to group and display.
     const decoratedActivities = _map(this.props.activity, entry => {
-      const normalizedDate = startOfDay(new Date(entry.created))
       return Object.assign({}, entry, {
-        normalizedISODate: normalizedDate.toISOString(),
+        normalizedISODate: this.props.startOfDay(new Date(entry.created)).toISOString(),
         description: `${localizedActionLabels[keysByAction[entry.action]]} ` +
                      localizedTypeLabels[keysByType[entry.typeId]] +
                      (_isNumber(entry.status) ?
@@ -130,10 +129,13 @@ UserActivityTimeline.propTypes = {
     typeId: PropTypes.number,
     status: PropTypes.number,
   })),
+  /** To more easily facilitate unit testing */
+  startOfDay: PropTypes.func,
 }
 
 UserActivityTimeline.defaultProps = {
   activity: [],
+  startOfDay,
 }
 
 export default injectIntl(UserActivityTimeline)

--- a/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimeline.test.js
+++ b/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimeline.test.js
@@ -32,16 +32,30 @@ beforeEach(() => {
         created: 1516200787649,
       },
     ],
-    intl:{
+    intl: {
       formatMessage: jest.fn(),
       formatDate: jest.fn(),
     },
   }
 })
 
+/**
+ * For consistency in unit tests regardless of local timezone
+ */
+const startOfUTCDay = function(date) {
+  const start = new Date(date.getTime())
+  start.setUTCHours(0)
+  start.setUTCMinutes(0)
+  start.setUTCSeconds(0)
+  start.setUTCMilliseconds(0)
+
+  return start
+}
+
+
 test("it renders a timeline of the activity", () => {
   const wrapper = shallow(
-    <UserActivityTimeline {...basicProps} />
+    <UserActivityTimeline startOfDay={startOfUTCDay} {...basicProps} />
   )
 
   expect(wrapper.find('.activity-timeline').exists()).toBe(true)
@@ -51,7 +65,7 @@ test("it renders a timeline of the activity", () => {
 
 test("it consolidates duplicate activities on the same day", () => {
   const wrapper = shallow(
-    <UserActivityTimeline {...basicProps} />
+    <UserActivityTimeline startOfDay={startOfUTCDay} {...basicProps} />
   )
 
   // First two activity entries are dups on the same day.
@@ -62,7 +76,7 @@ test("it consolidates duplicate activities on the same day", () => {
 
 test("it includes a count of the duplicate activities", () => {
   const wrapper = shallow(
-    <UserActivityTimeline {...basicProps} />
+    <UserActivityTimeline startOfDay={startOfUTCDay} {...basicProps} />
   )
 
   // First two activity entries are dups on the same day.
@@ -74,7 +88,7 @@ test("it includes a count of the duplicate activities", () => {
 test("it does not consolidate duplicate activities on different days", () => {
   basicProps.activity[0].created = 0
   const wrapper = shallow(
-    <UserActivityTimeline {...basicProps} />
+    <UserActivityTimeline startOfDay={startOfUTCDay} {...basicProps} />
   )
 
   // We have 3 activities, but the first two are duplicates on the
@@ -90,7 +104,7 @@ test("it indicates on the timeline if there is no activity", () => {
   basicProps.activity = []
 
   const wrapper = shallow(
-    <UserActivityTimeline {...basicProps} />
+    <UserActivityTimeline startOfDay={startOfUTCDay} {...basicProps} />
   )
 
   // First two activity entries are dups on the same day.

--- a/src/components/ActivityTimeline/UserActivityTimeline/__snapshots__/UserActivityTimeline.test.js.snap
+++ b/src/components/ActivityTimeline/UserActivityTimeline/__snapshots__/UserActivityTimeline.test.js.snap
@@ -33,6 +33,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    startOfDay={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -173,7 +174,7 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "1969-12-31T08:00:00.000Z",
+        "key": "1970-01-01T00:00:00.000Z",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -288,7 +289,7 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "2017-11-10T08:00:00.000Z",
+        "key": "2017-11-10T00:00:00.000Z",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -403,7 +404,7 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "2018-01-17T08:00:00.000Z",
+        "key": "2018-01-17T00:00:00.000Z",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -679,7 +680,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "1969-12-31T08:00:00.000Z",
+          "key": "1970-01-01T00:00:00.000Z",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -794,7 +795,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "2017-11-10T08:00:00.000Z",
+          "key": "2017-11-10T00:00:00.000Z",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -909,7 +910,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "2018-01-17T08:00:00.000Z",
+          "key": "2018-01-17T00:00:00.000Z",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -1075,6 +1076,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    startOfDay={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1422,6 +1424,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    startOfDay={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1538,7 +1541,7 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "2017-11-10T08:00:00.000Z",
+        "key": "2017-11-10T00:00:00.000Z",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1653,7 +1656,7 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "2018-01-17T08:00:00.000Z",
+        "key": "2018-01-17T00:00:00.000Z",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1905,7 +1908,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "2017-11-10T08:00:00.000Z",
+          "key": "2017-11-10T00:00:00.000Z",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -2020,7 +2023,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "2018-01-17T08:00:00.000Z",
+          "key": "2018-01-17T00:00:00.000Z",
           "nodeType": "host",
           "props": Object {
             "children": Array [


### PR DESCRIPTION
UserActivityTimeline groups together independent activity entries by day based on the user's local time, but that caused the unit tests to fail snapshot matching for other timezones. This switches to grouping by UTC day (in the unit test) to make the snapshots timezone agnostic.