### PR TITLE
Fixes #8 - Allow comment after editing task.

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -19,11 +19,14 @@ import TaskDoneControls from './TaskDoneControls/TaskDoneControls'
 export class ActiveTaskControls extends Component {
   state = {
     taskBeingCompleted: null,
+    comment: "",
   }
 
-  setTaskBeingCompleted = (taskId) => {
+  setTaskBeingCompleted = taskId => {
     this.setState({taskBeingCompleted: taskId})
   }
+
+  setComment = comment => this.setState({comment})
 
   render() {
     if (!this.props.task) {
@@ -40,6 +43,8 @@ export class ActiveTaskControls extends Component {
     else if (isEditingTask) {
       // Editor is open, show completion options
       return <TaskCompletionControls setTaskBeingCompleted={this.setTaskBeingCompleted}
+                                     comment={this.state.comment}
+                                     setComment={this.setComment}
                                      {...this.props} />
     }
     else if (_get(this.props, 'editor.taskId') !== this.props.task.id &&
@@ -49,6 +54,8 @@ export class ActiveTaskControls extends Component {
     }
     else {
       return <TaskEditControls setTaskBeingCompleted={this.setTaskBeingCompleted}
+                               comment={this.state.comment}
+                               setComment={this.setComment}
                                {...this.props} />
     }
   }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/TaskCompletionControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/TaskCompletionControls.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import { omit as _omit } from 'lodash'
 import { FormattedMessage } from 'react-intl'
 import { TaskStatus } from '../../../../../services/Task/TaskStatus/TaskStatus'
 import SvgSymbol from '../../../../SvgSymbol/SvgSymbol'
+import TaskCommentInput from '../TaskCommentInput/TaskCommentInput'
 import messages from './Messages'
 import './TaskCompletionControls.css'
 
@@ -18,7 +20,8 @@ import './TaskCompletionControls.css'
 export default class TaskCompletionControls extends Component {
   complete = (taskStatus) => {
     this.props.setTaskBeingCompleted(this.props.task.id)
-    this.props.completeTask(this.props.task.id, this.props.task.parent.id, taskStatus)
+    this.props.completeTask(this.props.task.id, this.props.task.parent.id,
+                            taskStatus, this.props.comment)
     this.props.closeEditor()
   }
 
@@ -51,6 +54,11 @@ export default class TaskCompletionControls extends Component {
   render() {
     return (
       <div className={classNames('task-completion-controls', this.props.className)}>
+        <TaskCommentInput className="task-completion-controls__task-comment"
+                          value={this.props.comment}
+                          commentChanged={this.props.setComment}
+                          {..._omit(this.props, 'className')} />
+
         <button className="button task-completion-controls__fix"
                 onClick={() => this.complete(TaskStatus.fixed)}>
           <FormattedMessage {...messages.fixed} />
@@ -80,10 +88,14 @@ export default class TaskCompletionControls extends Component {
 TaskCompletionControls.propTypes = {
   /** The task being completed */
   task: PropTypes.object.isRequired,
+  /** The current completion comment */
+  comment: PropTypes.string,
   /** Invoked when the user indicates a completion status */
   completeTask: PropTypes.func.isRequired,
   /** Invoked to cancel completion of the current task */
   setTaskBeingCompleted: PropTypes.func.isRequired,
+  /** Invoked to set a completion comment */
+  setComment: PropTypes.func.isRequired,
   /** Invoked if the user cancels and the editor is to be closed */
   closeEditor: PropTypes.func.isRequired,
   /** The keyboard shortcuts to be offered on this step */
@@ -92,4 +104,8 @@ TaskCompletionControls.propTypes = {
   activateKeyboardShortcuts: PropTypes.func.isRequired,
   /** Invoked when keyboard shortcuts should no longer be active  */
   deactivateKeyboardShortcuts: PropTypes.func.isRequired,
+}
+
+TaskCompletionControls.defaultProps = {
+  comment: "",
 }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/TaskCompletionControls.test.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/TaskCompletionControls.test.js
@@ -1,34 +1,32 @@
 import React from 'react'
-import { omit as _omit, cloneDeep as _cloneDeep } from 'lodash'
 import TaskCompletionControls from './TaskCompletionControls'
 import keyMappings from '../../../../../KeyMappings'
 import { TaskStatus } from '../../../../../services/Task/TaskStatus/TaskStatus'
 
-const propsFixture = {
-  task: {
-    id: 123,
-    parent: {
-      id: 321,
-    }
-  },
-  keyboardShortcutGroups: keyMappings,
-  user: {
-    id: 357,
-    settings: {defaultEditor: 1},
-    isLoggedIn: true,
-  },
-}
-
 let basicProps = null
 
 beforeEach(() => {
-  basicProps = _cloneDeep(propsFixture)
-
-  basicProps.completeTask = jest.fn()
-  basicProps.setTaskBeingCompleted = jest.fn()
-  basicProps.closeEditor = jest.fn()
-  basicProps.activateKeyboardShortcuts = jest.fn()
-  basicProps.deactivateKeyboardShortcuts = jest.fn()
+  basicProps = {
+    task: {
+      id: 123,
+      parent: {
+        id: 321,
+      }
+    },
+    comment: "Foo",
+    keyboardShortcutGroups: keyMappings,
+    user: {
+      id: 357,
+      settings: {defaultEditor: 1},
+      isLoggedIn: true,
+    },
+    completeTask: jest.fn(),
+    setTaskBeingCompleted: jest.fn(),
+    setComment: jest.fn(),
+    closeEditor: jest.fn(),
+    activateKeyboardShortcuts: jest.fn(),
+    deactivateKeyboardShortcuts: jest.fn(),
+  }
 })
 
 test("it renders completion controls", () => {
@@ -41,6 +39,16 @@ test("it renders completion controls", () => {
   expect(wrapper).toMatchSnapshot()
 })
 
+test("presents a completion comment field", () => {
+  const wrapper = shallow(
+    <TaskCompletionControls {...basicProps} />
+  )
+
+  expect(wrapper.find(
+    `TaskCommentInput[value="${basicProps.comment}"]`
+  ).exists()).toBe(true)
+})
+
 test("clicking the fixed button signals task completion with fixed status", () => {
   const wrapper = shallow(
     <TaskCompletionControls {...basicProps} />
@@ -48,12 +56,14 @@ test("clicking the fixed button signals task completion with fixed status", () =
 
   wrapper.find('.task-completion-controls__fix').simulate('click')
 
-  expect(basicProps.closeEditor.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls[0][0]).toBe(basicProps.task.id)
-  expect(basicProps.completeTask.mock.calls[0][1]).toBe(basicProps.task.parent.id)
-  expect(basicProps.completeTask.mock.calls[0][2]).toBe(TaskStatus.fixed)
+  expect(basicProps.closeEditor).toBeCalled()
 
+  expect(basicProps.completeTask).toBeCalledWith(basicProps.task.id,
+                                                 basicProps.task.parent.id,
+                                                 TaskStatus.fixed,
+                                                 basicProps.comment)
+
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
 })
 
 test("clicking the too-hard button signals task completion with too-hard status", () => {
@@ -63,11 +73,14 @@ test("clicking the too-hard button signals task completion with too-hard status"
 
   wrapper.find('.task-completion-controls__too-hard').simulate('click')
 
-  expect(basicProps.closeEditor.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls[0][0]).toBe(basicProps.task.id)
-  expect(basicProps.completeTask.mock.calls[0][1]).toBe(basicProps.task.parent.id)
-  expect(basicProps.completeTask.mock.calls[0][2]).toBe(TaskStatus.tooHard)
+  expect(basicProps.closeEditor).toBeCalled()
+
+  expect(basicProps.completeTask).toBeCalledWith(basicProps.task.id,
+                                                 basicProps.task.parent.id,
+                                                 TaskStatus.tooHard,
+                                                 basicProps.comment)
+
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
 })
 
 test("clicking the already-fixed button signals task completion with already-fixed status", () => {
@@ -77,11 +90,14 @@ test("clicking the already-fixed button signals task completion with already-fix
 
   wrapper.find('.task-completion-controls__already-fixed').simulate('click')
 
-  expect(basicProps.closeEditor.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls[0][0]).toBe(basicProps.task.id)
-  expect(basicProps.completeTask.mock.calls[0][1]).toBe(basicProps.task.parent.id)
-  expect(basicProps.completeTask.mock.calls[0][2]).toBe(TaskStatus.alreadyFixed)
+  expect(basicProps.closeEditor).toBeCalled()
+
+  expect(basicProps.completeTask).toBeCalledWith(basicProps.task.id,
+                                                 basicProps.task.parent.id,
+                                                 TaskStatus.alreadyFixed,
+                                                 basicProps.comment)
+
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
 })
 
 test("clicking the cancel button aborts completion of the task", () => {
@@ -91,7 +107,6 @@ test("clicking the cancel button aborts completion of the task", () => {
 
   wrapper.find('.task-completion-controls__cancel').simulate('click')
 
-  expect(basicProps.closeEditor.mock.calls.length).toBe(1)
-  expect(basicProps.setTaskBeingCompleted.mock.calls.length).toBe(1)
-  expect(basicProps.setTaskBeingCompleted.mock.calls[0][0]).toBe(null)
+  expect(basicProps.closeEditor).toBeCalled()
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(null)
 })

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/__snapshots__/TaskCompletionControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionControls/__snapshots__/TaskCompletionControls.test.js.snap
@@ -7,6 +7,7 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <TaskCompletionControls
     activateKeyboardShortcuts={[Function]}
     closeEditor={[Function]}
+    comment="Foo"
     completeTask={[Function]}
     deactivateKeyboardShortcuts={[Function]}
     keyboardShortcutGroups={
@@ -42,6 +43,7 @@ ShallowWrapper {
             },
           }
     }
+    setComment={[Function]}
     setTaskBeingCompleted={[Function]}
     task={
         Object {
@@ -74,6 +76,68 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
+        <TaskCommentInput
+          activateKeyboardShortcuts={[Function]}
+          className="task-completion-controls__task-comment"
+          closeEditor={[Function]}
+          comment="Foo"
+          commentChanged={[Function]}
+          completeTask={[Function]}
+          deactivateKeyboardShortcuts={[Function]}
+          keyboardShortcutGroups={
+                    Object {
+                              "taskCompletion": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": "ESC",
+                                  "label": "Cancel Editing",
+                                },
+                              },
+                              "taskEditing": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": "Edit in Id",
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": "Edit in JOSM",
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": "Edit in new JOSM layer",
+                                },
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": "Not an Issue",
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": "Skip",
+                                },
+                              },
+                            }
+          }
+          setComment={[Function]}
+          setTaskBeingCompleted={[Function]}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+          value="Foo"
+/>,
         <button
           className="button task-completion-controls__fix"
           onClick={[Function]}
@@ -127,6 +191,70 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcuts": [Function],
+          "className": "task-completion-controls__task-comment",
+          "closeEditor": [Function],
+          "comment": "Foo",
+          "commentChanged": [Function],
+          "completeTask": [Function],
+          "deactivateKeyboardShortcuts": [Function],
+          "keyboardShortcutGroups": Object {
+            "taskCompletion": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": "ESC",
+                "label": "Cancel Editing",
+              },
+            },
+            "taskEditing": Object {
+              "editId": Object {
+                "key": "e",
+                "label": "Edit in Id",
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": "Edit in JOSM",
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": "Edit in new JOSM layer",
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": "Not an Issue",
+              },
+              "skip": Object {
+                "key": "w",
+                "label": "Skip",
+              },
+            },
+          },
+          "setComment": [Function],
+          "setTaskBeingCompleted": [Function],
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+          "value": "Foo",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
       Object {
         "instance": null,
         "key": undefined,
@@ -297,6 +425,68 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
+          <TaskCommentInput
+            activateKeyboardShortcuts={[Function]}
+            className="task-completion-controls__task-comment"
+            closeEditor={[Function]}
+            comment="Foo"
+            commentChanged={[Function]}
+            completeTask={[Function]}
+            deactivateKeyboardShortcuts={[Function]}
+            keyboardShortcutGroups={
+                        Object {
+                                    "taskCompletion": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": "ESC",
+                                        "label": "Cancel Editing",
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": "Edit in Id",
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": "Edit in JOSM",
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": "Edit in new JOSM layer",
+                                      },
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": "Not an Issue",
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": "Skip",
+                                      },
+                                    },
+                                  }
+            }
+            setComment={[Function]}
+            setTaskBeingCompleted={[Function]}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+            value="Foo"
+/>,
           <button
             className="button task-completion-controls__fix"
             onClick={[Function]}
@@ -350,6 +540,70 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcuts": [Function],
+            "className": "task-completion-controls__task-comment",
+            "closeEditor": [Function],
+            "comment": "Foo",
+            "commentChanged": [Function],
+            "completeTask": [Function],
+            "deactivateKeyboardShortcuts": [Function],
+            "keyboardShortcutGroups": Object {
+              "taskCompletion": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": "ESC",
+                  "label": "Cancel Editing",
+                },
+              },
+              "taskEditing": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": "Edit in Id",
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": "Edit in JOSM",
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": "Edit in new JOSM layer",
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": "Not an Issue",
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": "Skip",
+                },
+              },
+            },
+            "setComment": [Function],
+            "setTaskBeingCompleted": [Function],
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+            "value": "Foo",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
         Object {
           "instance": null,
           "key": undefined,

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/TaskEditControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/TaskEditControls.js
@@ -29,10 +29,6 @@ const DeactivatableDropdownButton = WithDeactivateOnOutsideClick(DropdownButton)
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskEditControls extends Component {
-  state = {
-    comment: "",
-  }
-
   /** Choose which editor to launch for fixing a task */
   pickEditor = ({ value }) => {
     this.props.setTaskBeingCompleted(this.props.task.id)
@@ -43,7 +39,7 @@ export default class TaskEditControls extends Component {
   complete = (taskStatus) => {
     this.props.setTaskBeingCompleted(this.props.task.id)
     this.props.completeTask(this.props.task.id, this.props.task.parent.id,
-                            taskStatus, this.state.comment)
+                            taskStatus, this.props.comment)
   }
 
   /** Process keyboard shortcuts for the edit controls */
@@ -145,8 +141,8 @@ export default class TaskEditControls extends Component {
                                  {'is-minimized': this.props.isMinimized})}>
 
         <TaskCommentInput className="task-edit-controls__task-comment"
-                          value={this.state.comment}
-                          commentChanged={(comment) => this.setState({comment})}
+                          value={this.props.comment}
+                          commentChanged={this.props.setComment}
                           {..._omit(this.props, 'className')} />
 
         <div className="columns">
@@ -190,16 +186,24 @@ TaskEditControls.propTypes = {
   task: PropTypes.object.isRequired,
   /** The current map bounds (for editing) */
   mapBounds: PropTypes.object,
+  /** The current completion comment */
+  comment: PropTypes.string,
   /** Invoked if the user wishes to edit the task */
   editTask: PropTypes.func.isRequired,
   /** Invoked if the user immediately completes the task (false positive) */
   completeTask: PropTypes.func.isRequired,
   /** Invoked if the user initiates the task completion process */
   setTaskBeingCompleted: PropTypes.func.isRequired,
+  /** Invoked to set a completion comment */
+  setComment: PropTypes.func.isRequired,
   /** The keyboard shortcuts to be offered on this step */
   keyboardShortcutGroups: PropTypes.object.isRequired,
   /** Invoked when keyboard shortcuts are to be active */
   activateKeyboardShortcuts: PropTypes.func.isRequired,
   /** Invoked when keyboard shortcuts should no longer be active  */
   deactivateKeyboardShortcuts: PropTypes.func.isRequired,
+}
+
+TaskEditControls.defaultProps = {
+  comment: "",
 }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/TaskEditControls.test.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/TaskEditControls.test.js
@@ -1,40 +1,38 @@
 import React from 'react'
-import { omit as _omit, cloneDeep as _cloneDeep } from 'lodash'
 import TaskEditControls from './TaskEditControls'
 import keyMappings from '../../../../../KeyMappings'
 import { TaskStatus } from '../../../../../services/Task/TaskStatus/TaskStatus'
 
-const propsFixture = {
-  task: {
-    id: 123,
-    parent: {
-      id: 321,
-    }
-  },
-  mapBounds: {
-    task: {
-      bounds: [0, 0, 0, 0],
-    }
-  },
-  keyboardShortcutGroups: keyMappings,
-  user: {
-    id: 357,
-    settings: {defaultEditor: 1},
-    isLoggedIn: true,
-  },
-}
-
 let basicProps = null
 
 beforeEach(() => {
-  basicProps = _cloneDeep(propsFixture)
-
-  basicProps.editTask = jest.fn()
-  basicProps.completeTask = jest.fn()
-  basicProps.setTaskBeingCompleted = jest.fn()
-  basicProps.activateKeyboardShortcuts = jest.fn()
-  basicProps.deactivateKeyboardShortcuts = jest.fn()
-  basicProps.intl = {formatMessage: jest.fn()}
+  basicProps = {
+    task: {
+      id: 123,
+      parent: {
+        id: 321,
+      }
+    },
+    comment: "Foo",
+    mapBounds: {
+      task: {
+        bounds: [0, 0, 0, 0],
+      }
+    },
+    keyboardShortcutGroups: keyMappings,
+    user: {
+      id: 357,
+      settings: {defaultEditor: 1},
+      isLoggedIn: true,
+    },
+    editTask: jest.fn(),
+    completeTask: jest.fn(),
+    setComment: jest.fn(),
+    setTaskBeingCompleted: jest.fn(),
+    activateKeyboardShortcuts: jest.fn(),
+    deactivateKeyboardShortcuts: jest.fn(),
+    intl: {formatMessage: jest.fn()},
+  }
 })
 
 test("shows only a sign-in button if the user is not logged in", () => {
@@ -79,8 +77,10 @@ test("clicking the edit button signals opening of the editor", () => {
 
   wrapper.find('.task-edit-controls__edit-control').simulate('click')
 
-  expect(basicProps.editTask.mock.calls.length).toBe(1)
-  expect(basicProps.editTask.mock.calls[0][0]).toBe(basicProps.user.settings.defaultEditor)
+  expect(basicProps.editTask).toBeCalled()
+  expect(
+    basicProps.editTask.mock.calls[0][0]
+  ).toBe(basicProps.user.settings.defaultEditor)
 })
 
 test("clicking the edit button signals that task completion has begun", () => {
@@ -90,8 +90,17 @@ test("clicking the edit button signals that task completion has begun", () => {
 
   wrapper.find('.task-edit-controls__edit-control').simulate('click')
 
-  expect(basicProps.setTaskBeingCompleted.mock.calls.length).toBe(1)
-  expect(basicProps.setTaskBeingCompleted.mock.calls[0][0]).toBe(basicProps.task.id)
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
+})
+
+test("presents a completion comment field", () => {
+  const wrapper = shallow(
+    <TaskEditControls {...basicProps} />
+  )
+
+  expect(wrapper.find(
+    `TaskCommentInput[value="${basicProps.comment}"]`
+  ).exists()).toBe(true)
 })
 
 test("shows a dropdown of editor choices if user has not configured an editor", () => {
@@ -113,13 +122,12 @@ test("clicking the false positive button signals task completion with correct st
 
   wrapper.find('.task-edit-controls__false-positive-control').simulate('click')
 
-  expect(basicProps.completeTask.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls[0][0]).toBe(basicProps.task.id)
-  expect(basicProps.completeTask.mock.calls[0][1]).toBe(basicProps.task.parent.id)
-  expect(basicProps.completeTask.mock.calls[0][2]).toBe(TaskStatus.falsePositive)
+  expect(basicProps.completeTask).toBeCalledWith(basicProps.task.id,
+                                                 basicProps.task.parent.id,
+                                                 TaskStatus.falsePositive,
+                                                 basicProps.comment)
 
-  expect(basicProps.setTaskBeingCompleted.mock.calls.length).toBe(1)
-  expect(basicProps.setTaskBeingCompleted.mock.calls[0][0]).toBe(basicProps.task.id)
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
 })
 
 test("clicking the skip button signals task completion with correct status", () => {
@@ -129,11 +137,11 @@ test("clicking the skip button signals task completion with correct status", () 
 
   wrapper.find('.task-edit-controls__skip-control').simulate('click')
 
-  expect(basicProps.completeTask.mock.calls.length).toBe(1)
-  expect(basicProps.completeTask.mock.calls[0][0]).toBe(basicProps.task.id)
-  expect(basicProps.completeTask.mock.calls[0][1]).toBe(basicProps.task.parent.id)
-  expect(basicProps.completeTask.mock.calls[0][2]).toBe(TaskStatus.skipped)
 
-  expect(basicProps.setTaskBeingCompleted.mock.calls.length).toBe(1)
-  expect(basicProps.setTaskBeingCompleted.mock.calls[0][0]).toBe(basicProps.task.id)
+  expect(basicProps.completeTask).toBeCalledWith(basicProps.task.id,
+                                                 basicProps.task.parent.id,
+                                                 TaskStatus.skipped,
+                                                 basicProps.comment)
+
+  expect(basicProps.setTaskBeingCompleted).toBeCalledWith(basicProps.task.id)
 })

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/__snapshots__/TaskEditControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControls/__snapshots__/TaskEditControls.test.js.snap
@@ -6,6 +6,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <TaskEditControls
     activateKeyboardShortcuts={[Function]}
+    comment="Foo"
     completeTask={[Function]}
     deactivateKeyboardShortcuts={[Function]}
     editTask={[Function]}
@@ -59,6 +60,7 @@ ShallowWrapper {
             },
           }
     }
+    setComment={[Function]}
     setTaskBeingCompleted={[Function]}
     task={
         Object {
@@ -92,6 +94,7 @@ ShallowWrapper {
         <TaskCommentInput
           activateKeyboardShortcuts={[Function]}
           className="task-edit-controls__task-comment"
+          comment="Foo"
           commentChanged={[Function]}
           completeTask={[Function]}
           deactivateKeyboardShortcuts={[Function]}
@@ -146,6 +149,7 @@ ShallowWrapper {
                               },
                             }
           }
+          setComment={[Function]}
           setTaskBeingCompleted={[Function]}
           task={
                     Object {
@@ -162,7 +166,7 @@ ShallowWrapper {
                               "settings": Object {},
                             }
           }
-          value=""
+          value="Foo"
 />,
         <div
           className="columns"
@@ -297,6 +301,7 @@ ShallowWrapper {
         "props": Object {
           "activateKeyboardShortcuts": [Function],
           "className": "task-edit-controls__task-comment",
+          "comment": "Foo",
           "commentChanged": [Function],
           "completeTask": [Function],
           "deactivateKeyboardShortcuts": [Function],
@@ -345,6 +350,7 @@ ShallowWrapper {
               ],
             },
           },
+          "setComment": [Function],
           "setTaskBeingCompleted": [Function],
           "task": Object {
             "id": 123,
@@ -357,7 +363,7 @@ ShallowWrapper {
             "isLoggedIn": true,
             "settings": Object {},
           },
-          "value": "",
+          "value": "Foo",
         },
         "ref": null,
         "rendered": null,
@@ -973,6 +979,7 @@ ShallowWrapper {
           <TaskCommentInput
             activateKeyboardShortcuts={[Function]}
             className="task-edit-controls__task-comment"
+            comment="Foo"
             commentChanged={[Function]}
             completeTask={[Function]}
             deactivateKeyboardShortcuts={[Function]}
@@ -1027,6 +1034,7 @@ ShallowWrapper {
                                     },
                                   }
             }
+            setComment={[Function]}
             setTaskBeingCompleted={[Function]}
             task={
                         Object {
@@ -1043,7 +1051,7 @@ ShallowWrapper {
                                     "settings": Object {},
                                   }
             }
-            value=""
+            value="Foo"
 />,
           <div
             className="columns"
@@ -1178,6 +1186,7 @@ ShallowWrapper {
           "props": Object {
             "activateKeyboardShortcuts": [Function],
             "className": "task-edit-controls__task-comment",
+            "comment": "Foo",
             "commentChanged": [Function],
             "completeTask": [Function],
             "deactivateKeyboardShortcuts": [Function],
@@ -1226,6 +1235,7 @@ ShallowWrapper {
                 ],
               },
             },
+            "setComment": [Function],
             "setTaskBeingCompleted": [Function],
             "task": Object {
               "id": 123,
@@ -1238,7 +1248,7 @@ ShallowWrapper {
               "isLoggedIn": true,
               "settings": Object {},
             },
-            "value": "",
+            "value": "Foo",
           },
           "ref": null,
           "rendered": null,
@@ -1861,6 +1871,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <TaskEditControls
     activateKeyboardShortcuts={[Function]}
+    comment="Foo"
     completeTask={[Function]}
     deactivateKeyboardShortcuts={[Function]}
     editTask={[Function]}
@@ -1914,6 +1925,7 @@ ShallowWrapper {
             },
           }
     }
+    setComment={[Function]}
     setTaskBeingCompleted={[Function]}
     task={
         Object {
@@ -1949,6 +1961,7 @@ ShallowWrapper {
         <TaskCommentInput
           activateKeyboardShortcuts={[Function]}
           className="task-edit-controls__task-comment"
+          comment="Foo"
           commentChanged={[Function]}
           completeTask={[Function]}
           deactivateKeyboardShortcuts={[Function]}
@@ -2003,6 +2016,7 @@ ShallowWrapper {
                               },
                             }
           }
+          setComment={[Function]}
           setTaskBeingCompleted={[Function]}
           task={
                     Object {
@@ -2021,7 +2035,7 @@ ShallowWrapper {
                               },
                             }
           }
-          value=""
+          value="Foo"
 />,
         <div
           className="columns"
@@ -2123,6 +2137,7 @@ ShallowWrapper {
         "props": Object {
           "activateKeyboardShortcuts": [Function],
           "className": "task-edit-controls__task-comment",
+          "comment": "Foo",
           "commentChanged": [Function],
           "completeTask": [Function],
           "deactivateKeyboardShortcuts": [Function],
@@ -2171,6 +2186,7 @@ ShallowWrapper {
               ],
             },
           },
+          "setComment": [Function],
           "setTaskBeingCompleted": [Function],
           "task": Object {
             "id": 123,
@@ -2185,7 +2201,7 @@ ShallowWrapper {
               "defaultEditor": 1,
             },
           },
-          "value": "",
+          "value": "Foo",
         },
         "ref": null,
         "rendered": null,
@@ -2677,6 +2693,7 @@ ShallowWrapper {
           <TaskCommentInput
             activateKeyboardShortcuts={[Function]}
             className="task-edit-controls__task-comment"
+            comment="Foo"
             commentChanged={[Function]}
             completeTask={[Function]}
             deactivateKeyboardShortcuts={[Function]}
@@ -2731,6 +2748,7 @@ ShallowWrapper {
                                     },
                                   }
             }
+            setComment={[Function]}
             setTaskBeingCompleted={[Function]}
             task={
                         Object {
@@ -2749,7 +2767,7 @@ ShallowWrapper {
                                     },
                                   }
             }
-            value=""
+            value="Foo"
 />,
           <div
             className="columns"
@@ -2851,6 +2869,7 @@ ShallowWrapper {
           "props": Object {
             "activateKeyboardShortcuts": [Function],
             "className": "task-edit-controls__task-comment",
+            "comment": "Foo",
             "commentChanged": [Function],
             "completeTask": [Function],
             "deactivateKeyboardShortcuts": [Function],
@@ -2899,6 +2918,7 @@ ShallowWrapper {
                 ],
               },
             },
+            "setComment": [Function],
             "setTaskBeingCompleted": [Function],
             "task": Object {
               "id": 123,
@@ -2913,7 +2933,7 @@ ShallowWrapper {
                 "defaultEditor": 1,
               },
             },
-            "value": "",
+            "value": "Foo",
           },
           "ref": null,
           "rendered": null,
@@ -3412,6 +3432,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <TaskEditControls
     activateKeyboardShortcuts={[Function]}
+    comment="Foo"
     completeTask={[Function]}
     deactivateKeyboardShortcuts={[Function]}
     editTask={[Function]}
@@ -3465,6 +3486,7 @@ ShallowWrapper {
             },
           }
     }
+    setComment={[Function]}
     setTaskBeingCompleted={[Function]}
     task={
         Object {
@@ -3500,6 +3522,7 @@ ShallowWrapper {
         <TaskCommentInput
           activateKeyboardShortcuts={[Function]}
           className="task-edit-controls__task-comment"
+          comment="Foo"
           commentChanged={[Function]}
           completeTask={[Function]}
           deactivateKeyboardShortcuts={[Function]}
@@ -3554,6 +3577,7 @@ ShallowWrapper {
                               },
                             }
           }
+          setComment={[Function]}
           setTaskBeingCompleted={[Function]}
           task={
                     Object {
@@ -3572,7 +3596,7 @@ ShallowWrapper {
                               },
                             }
           }
-          value=""
+          value="Foo"
 />,
         <div
           className="columns"
@@ -3674,6 +3698,7 @@ ShallowWrapper {
         "props": Object {
           "activateKeyboardShortcuts": [Function],
           "className": "task-edit-controls__task-comment",
+          "comment": "Foo",
           "commentChanged": [Function],
           "completeTask": [Function],
           "deactivateKeyboardShortcuts": [Function],
@@ -3722,6 +3747,7 @@ ShallowWrapper {
               ],
             },
           },
+          "setComment": [Function],
           "setTaskBeingCompleted": [Function],
           "task": Object {
             "id": 123,
@@ -3736,7 +3762,7 @@ ShallowWrapper {
               "defaultEditor": 1,
             },
           },
-          "value": "",
+          "value": "Foo",
         },
         "ref": null,
         "rendered": null,
@@ -4228,6 +4254,7 @@ ShallowWrapper {
           <TaskCommentInput
             activateKeyboardShortcuts={[Function]}
             className="task-edit-controls__task-comment"
+            comment="Foo"
             commentChanged={[Function]}
             completeTask={[Function]}
             deactivateKeyboardShortcuts={[Function]}
@@ -4282,6 +4309,7 @@ ShallowWrapper {
                                     },
                                   }
             }
+            setComment={[Function]}
             setTaskBeingCompleted={[Function]}
             task={
                         Object {
@@ -4300,7 +4328,7 @@ ShallowWrapper {
                                     },
                                   }
             }
-            value=""
+            value="Foo"
 />,
           <div
             className="columns"
@@ -4402,6 +4430,7 @@ ShallowWrapper {
           "props": Object {
             "activateKeyboardShortcuts": [Function],
             "className": "task-edit-controls__task-comment",
+            "comment": "Foo",
             "commentChanged": [Function],
             "completeTask": [Function],
             "deactivateKeyboardShortcuts": [Function],
@@ -4450,6 +4479,7 @@ ShallowWrapper {
                 ],
               },
             },
+            "setComment": [Function],
             "setTaskBeingCompleted": [Function],
             "task": Object {
               "id": 123,
@@ -4464,7 +4494,7 @@ ShallowWrapper {
                 "defaultEditor": 1,
               },
             },
-            "value": "",
+            "value": "Foo",
           },
           "ref": null,
           "rendered": null,
@@ -4963,6 +4993,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <TaskEditControls
     activateKeyboardShortcuts={[Function]}
+    comment="Foo"
     completeTask={[Function]}
     deactivateKeyboardShortcuts={[Function]}
     editTask={[Function]}
@@ -5016,6 +5047,7 @@ ShallowWrapper {
             },
           }
     }
+    setComment={[Function]}
     setTaskBeingCompleted={[Function]}
     task={
         Object {
@@ -5053,6 +5085,7 @@ ShallowWrapper {
         <Connect(SignInButton)
                 activateKeyboardShortcuts={[Function]}
                 className="task-edit-controls--signin"
+                comment="Foo"
                 completeTask={[Function]}
                 deactivateKeyboardShortcuts={[Function]}
                 editTask={[Function]}
@@ -5106,6 +5139,7 @@ ShallowWrapper {
                                 },
                               }
                 }
+                setComment={[Function]}
                 setTaskBeingCompleted={[Function]}
                 task={
                         Object {
@@ -5137,6 +5171,7 @@ ShallowWrapper {
         "children": <Connect(SignInButton)
           activateKeyboardShortcuts={[Function]}
           className="task-edit-controls--signin"
+          comment="Foo"
           completeTask={[Function]}
           deactivateKeyboardShortcuts={[Function]}
           editTask={[Function]}
@@ -5190,6 +5225,7 @@ ShallowWrapper {
                               },
                             }
           }
+          setComment={[Function]}
           setTaskBeingCompleted={[Function]}
           task={
                     Object {
@@ -5219,6 +5255,7 @@ ShallowWrapper {
         "props": Object {
           "activateKeyboardShortcuts": [Function],
           "className": "task-edit-controls--signin",
+          "comment": "Foo",
           "completeTask": [Function],
           "deactivateKeyboardShortcuts": [Function],
           "editTask": [Function],
@@ -5266,6 +5303,7 @@ ShallowWrapper {
               ],
             },
           },
+          "setComment": [Function],
           "setTaskBeingCompleted": [Function],
           "task": Object {
             "id": 123,
@@ -5301,6 +5339,7 @@ ShallowWrapper {
           <Connect(SignInButton)
                     activateKeyboardShortcuts={[Function]}
                     className="task-edit-controls--signin"
+                    comment="Foo"
                     completeTask={[Function]}
                     deactivateKeyboardShortcuts={[Function]}
                     editTask={[Function]}
@@ -5354,6 +5393,7 @@ ShallowWrapper {
                                         },
                                       }
                     }
+                    setComment={[Function]}
                     setTaskBeingCompleted={[Function]}
                     task={
                               Object {
@@ -5385,6 +5425,7 @@ ShallowWrapper {
           "children": <Connect(SignInButton)
             activateKeyboardShortcuts={[Function]}
             className="task-edit-controls--signin"
+            comment="Foo"
             completeTask={[Function]}
             deactivateKeyboardShortcuts={[Function]}
             editTask={[Function]}
@@ -5438,6 +5479,7 @@ ShallowWrapper {
                                     },
                                   }
             }
+            setComment={[Function]}
             setTaskBeingCompleted={[Function]}
             task={
                         Object {
@@ -5467,6 +5509,7 @@ ShallowWrapper {
           "props": Object {
             "activateKeyboardShortcuts": [Function],
             "className": "task-edit-controls--signin",
+            "comment": "Foo",
             "completeTask": [Function],
             "deactivateKeyboardShortcuts": [Function],
             "editTask": [Function],
@@ -5514,6 +5557,7 @@ ShallowWrapper {
                 ],
               },
             },
+            "setComment": [Function],
             "setTaskBeingCompleted": [Function],
             "task": Object {
               "id": 123,

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
@@ -453,6 +453,7 @@ ShallowWrapper {
     "props": Object {
       "activateKeyboardShortcuts": [Function],
       "closeEditor": [Function],
+      "comment": "",
       "completeTask": [Function],
       "deactivateKeyboardShortcuts": [Function],
       "editTask": [Function],
@@ -505,6 +506,7 @@ ShallowWrapper {
         },
       },
       "nextTask": [Function],
+      "setComment": [Function],
       "setTaskBeingCompleted": [Function],
       "task": Object {
         "id": 123,
@@ -529,6 +531,7 @@ ShallowWrapper {
       "props": Object {
         "activateKeyboardShortcuts": [Function],
         "closeEditor": [Function],
+        "comment": "",
         "completeTask": [Function],
         "deactivateKeyboardShortcuts": [Function],
         "editTask": [Function],
@@ -581,6 +584,7 @@ ShallowWrapper {
           },
         },
         "nextTask": [Function],
+        "setComment": [Function],
         "setTaskBeingCompleted": [Function],
         "task": Object {
           "id": 123,
@@ -700,6 +704,7 @@ ShallowWrapper {
     "props": Object {
       "activateKeyboardShortcuts": [Function],
       "closeEditor": [Function],
+      "comment": "",
       "completeTask": [Function],
       "deactivateKeyboardShortcuts": [Function],
       "editTask": [Function],
@@ -749,6 +754,7 @@ ShallowWrapper {
         },
       },
       "nextTask": [Function],
+      "setComment": [Function],
       "setTaskBeingCompleted": [Function],
       "task": Object {
         "id": 123,
@@ -773,6 +779,7 @@ ShallowWrapper {
       "props": Object {
         "activateKeyboardShortcuts": [Function],
         "closeEditor": [Function],
+        "comment": "",
         "completeTask": [Function],
         "deactivateKeyboardShortcuts": [Function],
         "editTask": [Function],
@@ -822,6 +829,7 @@ ShallowWrapper {
           },
         },
         "nextTask": [Function],
+        "setComment": [Function],
         "setTaskBeingCompleted": [Function],
         "task": Object {
           "id": 123,


### PR DESCRIPTION
A completion comment can now be provided even after a user opens a task
in an editor.