### PR TITLE
Don't use stale data to drive searches. Fixes #20

### DIFF
--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { map as _map,
-         reject as _reject } from 'lodash'
+         reject as _reject,
+         get as _get } from 'lodash'
 import { injectIntl } from 'react-intl'
 import NavDropdown from '../../Bulma/NavDropdown'
 import { ChallengeLocation,
@@ -35,10 +36,11 @@ export class FilterByLocation extends Component {
       if (value === ChallengeLocation.nearMe) {
         this.props.locateMapToUser(this.props.user)
       }
+      else if (value === ChallengeLocation.withinMapBounds) {
+        this.props.updateBoundedChallenges(
+          _get(this.props, 'mapBounds.locator.bounds'))
+      }
     }
-
-    // Let the system know that the relevant map bounds probably just changed.
-    this.props.updateMapBoundedChallenges()
   }
 
   render() {
@@ -75,14 +77,16 @@ export class FilterByLocation extends Component {
 }
 
 FilterByLocation.propTypes = {
+  /** The current map bounds */
+  mapBounds: PropTypes.object,
   /** Invoked to update the challenge location filter */
   setChallengeFilters: PropTypes.func.isRequired,
   /** Invoked to clear the challenge location filter */
   removeChallengeFilters: PropTypes.func.isRequired,
   /** Invoked when the user chooses the 'near me' option */
   locateMapToUser: PropTypes.func.isRequired,
-  /** Invoked when the location filter is changed */
-  updateMapBoundedChallenges: PropTypes.func.isRequired,
+  /** Invoked when the user chooses 'within map bounds' option */
+  updateBoundedChallenges: PropTypes.func.isRequired,
   /** The current value of the challenge filter */
   challengeFilter: PropTypes.object,
   /** The current logged-in user, if any */

--- a/src/components/LocatorMap/LocatorMap.js
+++ b/src/components/LocatorMap/LocatorMap.js
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { get as _get } from 'lodash'
 import { latLng } from 'leaflet'
+import { ChallengeLocation }
+       from '../../services/Challenge/ChallengeLocation/ChallengeLocation'
 import EnhancedMap from '../EnhancedMap/EnhancedMap'
 import SourcedTileLayer from '../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import LayerToggle from '../EnhancedMap/LayerToggle/LayerToggle'
+import WithChallengeFilters from '../HOCs/WithChallengeFilters/WithChallengeFilters'
 import WithVisibleLayer from '../HOCs/WithVisibleLayer/WithVisibleLayer'
 import WithMapBoundsState from '../HOCs/WithMapBounds/WithMapBoundsState'
 import WithMapBoundsDispatch from '../HOCs/WithMapBounds/WithMapBoundsDispatch'
@@ -51,6 +54,23 @@ export class LocatorMap extends Component {
     return false
   }
 
+  /**
+   * Signal a change to the current locator map bounds in response to a change
+   * to the map (panning or zooming). If searching within map bounds is also
+   * active, then signal that the map-bounded challenges also need to be
+   * refreshed.
+   *
+   * @private
+   */
+  updateBounds = (bounds, zoom, fromUserAction=false) => {
+    this.props.setLocatorMapBounds(bounds, zoom, fromUserAction)
+
+    if (_get(this.props, 'challengeFilter.location') ===
+        ChallengeLocation.withinMapBounds) {
+      this.props.updateBoundedChallenges(bounds)
+    }
+  }
+
   render() {
     return (
       <div className={classNames('default-map full-screen-map', this.props.className)}>
@@ -58,7 +78,7 @@ export class LocatorMap extends Component {
         <EnhancedMap center={latLng(0, 45)} zoom={3} minZoom={3} setInitialBounds={false}
                      initialBounds = {_get(this.props, 'mapBounds.locator.bounds')}
                      zoomControl={false} animate={true}
-                     onBoundsChange={this.props.setLocatorMapBounds}>
+                     onBoundsChange={this.updateBounds}>
           <ZoomControl position='topright' />
           <VisibleTileLayer defaultLayer={this.props.layerSourceName} />
         </EnhancedMap>
@@ -81,4 +101,4 @@ LocatorMap.propTypes = {
 }
 
 export default
-  WithMapBoundsState(WithMapBoundsDispatch(LocatorMap))
+  WithChallengeFilters(WithMapBoundsState(WithMapBoundsDispatch(LocatorMap)))

--- a/src/services/MapBounds/MapBounds.js
+++ b/src/services/MapBounds/MapBounds.js
@@ -3,6 +3,14 @@ import { isEmpty as _isEmpty,
          isArray as _isArray } from 'lodash'
 import { LatLngBounds, LatLng } from 'leaflet'
 
+/** Default map bounds in absence of any state */
+export const DEFAULT_MAP_BOUNDS = [
+  -6.152343750000001, // west
+  -22.512556954051437, // south
+  96.15234375, // east
+  22.51255695405145, // north
+]
+
 // utility functions
 
 /**
@@ -120,7 +128,13 @@ export const setTaskMapBounds = function(bounds, zoom, fromUserAction=false) {
 
 // redux reducers
 
-export const currentMapBounds = function(state={}, action) {
+const defaultState = {
+  locator: {
+    bounds: DEFAULT_MAP_BOUNDS,
+  }
+}
+
+export const currentMapBounds = function(state=defaultState, action) {
   if (action.type === SET_LOCATOR_MAP_BOUNDS) {
     return Object.assign(
       {},


### PR DESCRIPTION
WithMapBoundsDispatch was referencing fixed state data when determining
whether to initiate searches for map-bounded challenges, resulting in
erroneous searches when that data became out of sync with the current
app state.