### PR TITLE
Restrict task statuses when editing task. Fixes #3

### DIFF
--- a/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
+++ b/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
@@ -92,7 +92,7 @@ export class EditTask extends Component {
           </nav>
         </div>
 
-        <Form schema={jsSchema(this.props.intl)}
+        <Form schema={jsSchema(this.props.intl, this.props.task)}
               uiSchema={uiSchema}
               FieldTemplate={CustomFieldTemplate}
               liveValidate

--- a/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTaskSchema.js
+++ b/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTaskSchema.js
@@ -1,8 +1,12 @@
 import { ChallengePriority, challengePriorityLabels }
        from '../../../../../services/Challenge/ChallengePriority/ChallengePriority'
-import { TaskStatus, statusLabels }
+import { TaskStatus,
+         messagesByStatus,
+         allowedStatusProgressions }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
-import { map as _map, values as _values } from 'lodash'
+import { map as _map,
+         values as _values,
+         isObject as _isObject } from 'lodash'
 import messages from './Messages'
 
 /**
@@ -16,9 +20,20 @@ import messages from './Messages'
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export const jsSchema = intl => {
+export const jsSchema = (intl, task) => {
   const localizedPriorityLabels = challengePriorityLabels(intl)
-  const localizedStatusLabels = statusLabels(intl)
+
+  // If the task exists, its status can limit the statuses allowed to be set
+  // during editing.
+  const allowedStatuses =
+    _isObject(task) ?
+    Array.from(allowedStatusProgressions(task.status, true)) :
+    _values(TaskStatus)
+
+  const allowedStatusLabels = _map(
+    allowedStatuses,
+    status => intl.formatMessage(messagesByStatus[status])
+  )
 
   const schemaFields = {
     "$schema": "http://json-schema.org/draft-06/schema#",
@@ -53,8 +68,8 @@ export const jsSchema = intl => {
         title: intl.formatMessage(messages.statusLabel),
         description: intl.formatMessage(messages.statusDescription),
         type: "number",
-        enum: _values(TaskStatus),
-        enumNames: _map(TaskStatus, (value, key) => localizedStatusLabels[key]),
+        enum: allowedStatuses,
+        enumNames: allowedStatusLabels,
         default: TaskStatus.created,
       },
     },

--- a/src/services/Task/TaskStatus/TaskStatus.js
+++ b/src/services/Task/TaskStatus/TaskStatus.js
@@ -29,31 +29,47 @@ export const keysByStatus = Object.freeze(_invert(TaskStatus))
  * for the given status. An empty Set is returned if no
  * progressions are allowed.
  *
+ * Set includeSelf to true if the given (presumed current) status should be
+ * also included in the results.
+ *
  * @returns a Set of allowed status progressions
  */
-export const allowedStatusProgressions = function(status) {
+export const allowedStatusProgressions = function(status, includeSelf = false) {
+  let progressions = null
   switch(status) {
     case TaskStatus.created:
-      return new Set([TaskStatus.fixed, TaskStatus.falsePositive,
-                      TaskStatus.skipped, TaskStatus.deleted,
-                      TaskStatus.alreadyFixed, TaskStatus.tooHard])
+      progressions = new Set([TaskStatus.fixed, TaskStatus.falsePositive,
+                              TaskStatus.skipped, TaskStatus.deleted,
+                              TaskStatus.alreadyFixed, TaskStatus.tooHard])
+      break
     case TaskStatus.fixed:
-      return new Set()
+      progressions = new Set()
+      break
     case TaskStatus.falsePositive:
-      return new Set([TaskStatus.fixed])
+      progressions = new Set([TaskStatus.fixed])
+      break
     case TaskStatus.skipped:
     case TaskStatus.tooHard:
-      return new Set([TaskStatus.fixed, TaskStatus.falsePositive,
-                      TaskStatus.skipped, TaskStatus.alreadyFixed,
-                      TaskStatus.tooHard])
+      progressions = new Set([TaskStatus.fixed, TaskStatus.falsePositive,
+                              TaskStatus.skipped, TaskStatus.alreadyFixed,
+                              TaskStatus.tooHard])
+      break
     case TaskStatus.deleted:
-      return new Set([TaskStatus.created])
+      progressions = new Set([TaskStatus.created])
+      break
     case TaskStatus.alreadyFixed:
-      return new Set()
+      progressions = new Set()
+      break
     default:
       throw new Error("unrecognized-task-status",
                       `Unrecognized task status ${status}`)
   }
+
+  if (includeSelf) {
+    progressions.add(status)
+  }
+
+  return progressions
 }
 
 /**


### PR DESCRIPTION
When editing a task, restrict choices of task statuses to progressions
allowed by the task's existing status.