### PR TITLE
Make challenge instructions collapsible. Fixes #29.

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -86,6 +86,10 @@ const mapStateToProps = (state, ownProps) => {
         props.minimizeChallenge = _get(state.currentPreferences,
                                        `challenges.${challengeId}.minimize`,
                                        false)
+
+        props.collapseInstructions = _get(state.currentPreferences,
+                                       `challenges.${challengeId}.collapseInstructions`,
+                                       false)
       }
     }
   }
@@ -131,6 +135,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
     setChallengeMinimization: (challengeId, minimize=false) =>
       dispatch(setPreferences('challenges', {[challengeId]: {minimize}})),
+
+    setInstructionsCollapsed: (challengeId, collapseInstructions=false) =>
+      dispatch(setPreferences('challenges', {[challengeId]: {collapseInstructions}})),
   }
 }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.js
@@ -51,6 +51,13 @@ export class ActiveTaskDetails extends Component {
     }
   }
 
+  toggleInstructionsCollapsed = () => {
+    const challengeId = _get(this.props.task, 'parent.id')
+    if (_isNumber(challengeId)) {
+      this.props.setInstructionsCollapsed(challengeId, !this.props.collapseInstructions)
+    }
+  }
+
   render() {
     if (!this.props.task) {
       return null
@@ -162,11 +169,19 @@ export class ActiveTaskDetails extends Component {
               <div>
                 {!_isEmpty(taskInstructions) &&
                   <div className={classNames('active-task-details--instructions',
-                                              {'active-task-details--bordered': !isMinimized})}>
-                    <div className="active-task-details--sub-heading">
+                    {'active-task-details--bordered': !isMinimized,
+                     'is-collapsed': this.props.collapseInstructions})}>
+                     <div className="active-task-details--sub-heading collapsible"
+                          onClick={this.toggleInstructionsCollapsed} >
                       <FormattedMessage {...messages.instructions} />
+
+                      <a className="collapsible-icon" aria-label="more options">
+                        <span className="icon"></span>
+                      </a>
                     </div>
-                    <MarkdownContent markdown={taskInstructions} />
+                    {!this.props.collapseInstructions &&
+                     <MarkdownContent markdown={taskInstructions} />
+                    }
                   </div>
                 }
               </div>

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.scss
@@ -1,5 +1,4 @@
-@import '../../../variables.scss';
-@import '../../../mixins.scss';
+@import '../../../theme.scss';
 
 .active-task-details {
   background-color: $white;
@@ -62,6 +61,39 @@
 
   &--sub-heading {
     margin-bottom: 10px;
+
+    &.collapsible {
+      position: relative;
+      display: flex;
+      justify-content: space-between;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      .collapsible-icon {
+        height: 1em;
+
+        .icon {
+          @include arrow($minimizer-arrow-color);
+          @include dropdown-arrow();
+          position: static;
+        }
+      }
+    }
+  }
+
+  .is-collapsed {
+    .active-task-details--sub-heading {
+      margin-bottom: 0px;
+
+      .collapsible-icon {
+        .icon {
+          margin-top: 5px;
+          transform: rotate(135deg);
+        }
+      }
+    }
   }
 
   .content-block {


### PR DESCRIPTION
Users now have the ability to collapse (and re-expand) the challenge
instructions when completing tasks. This is especially useful for long
instructions, which can take up quite a bit of real-estate. The user's
selection is saved for the remainder of the challenge so that it's not
necessary to re-collapse the instructions for each task.