### PR TITLE
Restyle task status to make more visually obvious.

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/TaskStatusIndicator.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/TaskStatusIndicator.js
@@ -60,9 +60,9 @@ export default class TaskStatusIndicator extends Component {
             <FormattedMessage {...messages.statusPrompt} />
           </div>
           <div>
-            <span className="task-status__label">
+            <div className="task-status__label">
               <FormattedMessage {...messagesByStatus[this.props.task.status]} />
-            </span>
+            </div>
           </div>
         </div>
       )

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/TaskStatusIndicator.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/TaskStatusIndicator.scss
@@ -1,7 +1,17 @@
 @import '../../../../../variables.scss';
 
 .active-task-details .task-status {
-  margin-bottom: 15px;
+  margin: 25px 0;
+  padding-bottom: 25px;
+  box-sizing: border-box;
+
+  .active-task-details--sub-heading {
+    background-color: $blue;
+    color: $white;
+    border-radius: $radius-medium $radius-medium 0 0;
+    padding: 10px 15px;
+    margin-bottom: 0;
+  }
 
   svg {
     height: 18px;
@@ -15,9 +25,29 @@
     font-weight: $weight-medium;
   }
 
+  .task-status__label {
+    width: 100%;
+    border: 2px solid rgba($blue, 0.33);
+    border-radius: 0 0 $radius-medium $radius-medium;
+    border-top: none;
+    padding: 10px 15px;
+    font-weight: $weight-semibold;
+    color: $grey;
+  }
+
   &.icon-only {
     .control-icon svg {
       fill: $yellow;
     }
   }
+}
+
+.is-minimized .button.task-status {
+  margin: 0px;
+  margin-bottom: 15px;
+  padding-bottom: 0;
+}
+
+.popout-content__body .task-status__label {
+  color: $grey;
 }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/__snapshots__/TaskStatusIndicator.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskStatusIndicator/__snapshots__/TaskStatusIndicator.test.js.snap
@@ -396,7 +396,7 @@ ShallowWrapper {
           />
 </div>,
         <div>
-          <span
+          <div
                     className="task-status__label"
           >
                     <FormattedMessage
@@ -404,7 +404,7 @@ ShallowWrapper {
                               id="Task.status.created"
                               values={Object {}}
                     />
-          </span>
+          </div>
 </div>,
       ],
       "className": "task-status active-task-controls__vertical-control-block active-task-details--bordered",
@@ -444,7 +444,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <span
+          "children": <div
             className="task-status__label"
 >
             <FormattedMessage
@@ -452,7 +452,7 @@ ShallowWrapper {
                         id="Task.status.created"
                         values={Object {}}
             />
-</span>,
+</div>,
         },
         "ref": null,
         "rendered": Object {
@@ -481,7 +481,7 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          "type": "span",
+          "type": "div",
         },
         "type": "div",
       },
@@ -505,7 +505,7 @@ ShallowWrapper {
             />
 </div>,
           <div>
-            <span
+            <div
                         className="task-status__label"
             >
                         <FormattedMessage
@@ -513,7 +513,7 @@ ShallowWrapper {
                                     id="Task.status.created"
                                     values={Object {}}
                         />
-            </span>
+            </div>
 </div>,
         ],
         "className": "task-status active-task-controls__vertical-control-block active-task-details--bordered",
@@ -553,7 +553,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <span
+            "children": <div
               className="task-status__label"
 >
               <FormattedMessage
@@ -561,7 +561,7 @@ ShallowWrapper {
                             id="Task.status.created"
                             values={Object {}}
               />
-</span>,
+</div>,
           },
           "ref": null,
           "rendered": Object {
@@ -590,7 +590,7 @@ ShallowWrapper {
               "rendered": null,
               "type": [Function],
             },
-            "type": "span",
+            "type": "div",
           },
           "type": "div",
         },


### PR DESCRIPTION
When completing a task, any existing task status is now more
visually obvious so that the user is more likely to notice it.