### PR TITLE
Mute icon badge color when no comments. Fixes #53

### DIFF
--- a/src/components/CommentList/CommentCountBadge/CommentCountBadge.js
+++ b/src/components/CommentList/CommentCountBadge/CommentCountBadge.js
@@ -17,7 +17,8 @@ export default class CommentCountBadge extends Component {
     return (
       <div className={classNames("comment-count-badge", this.props.className)}
            title={this.props.tooltip}>
-        <span className="badge is-badge-outlined"
+        <span className={classNames("badge is-badge-outlined",
+                                    {"is-empty": this.props.comments.length === 0})}
               data-badge={this.props.comments.length}>
           <SvgSymbol viewBox='0 0 20 20' sym="chat-icon" />
         </span>

--- a/src/components/CommentList/CommentCountBadge/CommentCountBadge.scss
+++ b/src/components/CommentList/CommentCountBadge/CommentCountBadge.scss
@@ -22,4 +22,8 @@
     border: none;
     left: calc(100% - ( 1.2rem / 2 ) - 1px) // move slightly to the left
   }
+
+  .badge.is-badge-outlined.is-empty[data-badge]::after {
+    background-color: $grey-light;
+  }
 }

--- a/src/components/CommentList/CommentCountBadge/CommentCountBadge.test.js
+++ b/src/components/CommentList/CommentCountBadge/CommentCountBadge.test.js
@@ -10,11 +10,11 @@ test('it renders a badge with the count of the given comments', () => {
   expect(wrapper).toMatchSnapshot()
 })
 
-test('it renders a badge with zero for empty comments', () => {
+test('it renders a badge with is-empty class for empty comments', () => {
   const wrapper = shallow(
     <CommentCountBadge />
   )
 
-  expect(wrapper.find('.badge[data-badge=0]').exists()).toBe(true)
+  expect(wrapper.find('.badge.is-empty[data-badge=0]').exists()).toBe(true)
   expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/CommentList/CommentCountBadge/__snapshots__/CommentCountBadge.test.js.snap
+++ b/src/components/CommentList/CommentCountBadge/__snapshots__/CommentCountBadge.test.js.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`it renders a badge with is-empty class for empty comments 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <CommentCountBadge
+    comments={Array []}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <span
+        className="badge is-badge-outlined is-empty"
+        data-badge={0}
+>
+        <SvgSymbol
+                sym="chat-icon"
+                viewBox="0 0 20 20"
+        />
+</span>,
+      "className": "comment-count-badge",
+      "title": undefined,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <SvgSymbol
+          sym="chat-icon"
+          viewBox="0 0 20 20"
+/>,
+        "className": "badge is-badge-outlined is-empty",
+        "data-badge": 0,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "sym": "chat-icon",
+          "viewBox": "0 0 20 20",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "span",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <span
+          className="badge is-badge-outlined is-empty"
+          data-badge={0}
+>
+          <SvgSymbol
+                    sym="chat-icon"
+                    viewBox="0 0 20 20"
+          />
+</span>,
+        "className": "comment-count-badge",
+        "title": undefined,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <SvgSymbol
+            sym="chat-icon"
+            viewBox="0 0 20 20"
+/>,
+          "className": "badge is-badge-outlined is-empty",
+          "data-badge": 0,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "sym": "chat-icon",
+            "viewBox": "0 0 20 20",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": "span",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
 exports[`it renders a badge with the count of the given comments 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -103,126 +223,6 @@ ShallowWrapper {
 />,
           "className": "badge is-badge-outlined",
           "data-badge": 3,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "sym": "chat-icon",
-            "viewBox": "0 0 20 20",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": "span",
-      },
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
-exports[`it renders a badge with zero for empty comments 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <CommentCountBadge
-    comments={Array []}
-/>,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": <span
-        className="badge is-badge-outlined"
-        data-badge={0}
->
-        <SvgSymbol
-                sym="chat-icon"
-                viewBox="0 0 20 20"
-        />
-</span>,
-      "className": "comment-count-badge",
-      "title": undefined,
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <SvgSymbol
-          sym="chat-icon"
-          viewBox="0 0 20 20"
-/>,
-        "className": "badge is-badge-outlined",
-        "data-badge": 0,
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "sym": "chat-icon",
-          "viewBox": "0 0 20 20",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      "type": "span",
-    },
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <span
-          className="badge is-badge-outlined"
-          data-badge={0}
->
-          <SvgSymbol
-                    sym="chat-icon"
-                    viewBox="0 0 20 20"
-          />
-</span>,
-        "className": "comment-count-badge",
-        "title": undefined,
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": <SvgSymbol
-            sym="chat-icon"
-            viewBox="0 0 20 20"
-/>,
-          "className": "badge is-badge-outlined",
-          "data-badge": 0,
         },
         "ref": null,
         "rendered": Object {


### PR DESCRIPTION
The badge on comment icons, which displays the count of the comments, is
now rendered in a muted grey color if there are no comments so as not to
be so visually distracting.