### PR TITLE
Fit map for challenges missing bounding. Fixes #57.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@turf/bbox": "^5.1.5",
+    "@turf/bbox-polygon": "^5.1.5",
     "bulma": "^0.6.0",
     "bulma-badge": "^0.1.0",
     "bulma-steps-component": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@turf/bbox-polygon@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz#6aeba4ed51d85d296e0f7c38b88c339f01eee024"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
 "@turf/bbox@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"


### PR DESCRIPTION
If a challenge is missing a bounding polygon, one will now be built from
the clustered tasks (once they have been retrieved) so that the locator
map bounds can be fit to the clustered tasks as expected.