### PR TITLE
Make initial challenge zoom values configurable.

### DIFF
--- a/.env
+++ b/.env
@@ -16,6 +16,11 @@ REACT_APP_FEATURE_SOCIAL_SHARING='enabled'
 REACT_APP_MAP_ROULETTE_SERVER_URL='http://localhost:9000'
 REACT_APP_SERVER_OAUTH_URL='/auth/authenticate?redirect=/mr3'
 
+# Initial zoom values to present when creating a new challenge
+REACT_APP_INITIAL_CHALLENGE_DEFAULT_ZOOM=18
+REACT_APP_INITIAL_CHALLENGE_MIN_ZOOM=3
+REACT_APP_INITIAL_CHALLENGE_MAX_ZOOM=19
+
 # iD editor base URL
 REACT_APP_ID_EDITOR_SERVER_URL='https://www.openstreetmap.org/edit'
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
@@ -1,4 +1,5 @@
 import { ZOOM_LEVELS,
+         MIN_ZOOM,
          MAX_ZOOM,
          DEFAULT_ZOOM }
        from '../../../../../services/Challenge/ChallengeZoom/ChallengeZoom'
@@ -6,6 +7,7 @@ import { CHALLENGE_BASEMAP_NONE,
          ChallengeBasemap,
          basemapLayerLabels }
        from '../../../../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
+import _get from 'lodash/get'
 import _values from 'lodash/values'
 import _map from 'lodash/map'
 import messages from './Messages'
@@ -44,21 +46,24 @@ export const jsSchema = intl => {
         description: intl.formatMessage(messages.defaultZoomDescription),
         type: "number",
         enum: ZOOM_LEVELS,
-        default: DEFAULT_ZOOM,
+        default: _get(process.env, 'REACT_APP_INITIAL_CHALLENGE_DEFAULT_ZOOM',
+                      DEFAULT_ZOOM),
       },
       minZoom: {
         title: intl.formatMessage(messages.minZoomLabel),
         description: intl.formatMessage(messages.minZoomDescription),
         type: "number",
         enum: ZOOM_LEVELS,
-        default: DEFAULT_ZOOM,
+        default: _get(process.env, 'REACT_APP_INITIAL_CHALLENGE_MIN_ZOOM',
+                      MIN_ZOOM),
       },
       maxZoom: {
         title: intl.formatMessage(messages.maxZoomLabel),
         description: intl.formatMessage(messages.maxZoomDescription),
         type: "number",
         enum: ZOOM_LEVELS,
-        default: MAX_ZOOM,
+        default: _get(process.env, 'REACT_APP_INITIAL_CHALLENGE_MAX_ZOOM',
+                      MAX_ZOOM),
       },
       defaultBasemap: {
         title: intl.formatMessage(messages.defaultBasemapLabel),


### PR DESCRIPTION
Allow the initial zoom values displayed when creating a new challenge to
be configured in the .env file.