### PR TITLE
Compute missing task centerpoint. Fixes #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@turf/bbox": "^5.1.5",
     "@turf/bbox-polygon": "^5.1.5",
+    "@turf/center": "^5.1.5",
     "bulma": "^0.6.0",
     "bulma-badge": "^0.1.0",
     "bulma-steps-component": "^0.5.3",

--- a/src/components/HOCs/WithTaskCenterPoint/WithTaskCenterPoint.js
+++ b/src/components/HOCs/WithTaskCenterPoint/WithTaskCenterPoint.js
@@ -1,18 +1,29 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import center from '@turf/center'
 import _get from 'lodash/get'
+import _isObject from 'lodash/isObject'
 import { latLng } from 'leaflet'
 
 export default function(WrappedComponent) {
   class WithTaskCenterPoint extends Component {
     render() {
-      // The server gives us the center-point of a task as a standard GeoJSON
-      // Point, which is (Lng, Lat), but Leaflet maps wants (Lat, Lng).
-      // Note: not all tasks include a location, so be resilient.
-      const centerPoint = latLng(
-        _get(this.props, 'task.location.coordinates[1]', 0),
-        _get(this.props, 'task.location.coordinates[0]', 0)
-      )
+      let centerPoint = _get(this.props, 'task.location.coordinates')
+
+      // Not all tasks have a center-point. In that case, we try to calculate
+      // one ourselves based on the task features.
+      if (!centerPoint && _isObject(_get(this.props, 'task.geometries'))) {
+        centerPoint = _get(center(this.props.task.geometries), 'geometry.coordinates')
+      }
+
+      // If all our efforts failed, default to (0, 0).
+      if (!centerPoint) {
+        centerPoint = [0, 0]
+      }
+
+      // Our centerpoint is a standard GeoJSON Point, which is (Lng, Lat), but
+      // Leaflet maps want (Lat, Lng).
+      centerPoint = latLng(centerPoint[1], centerPoint[0])
 
       return <WrappedComponent centerPoint={centerPoint} {...this.props} />
     }

--- a/src/components/HOCs/WithTaskCenterPoint/WithTaskCenterPoint.test.js
+++ b/src/components/HOCs/WithTaskCenterPoint/WithTaskCenterPoint.test.js
@@ -1,0 +1,51 @@
+import React, { Component } from 'react'
+import { point, featureCollection } from '@turf/helpers'
+import WithTaskCenterPoint from './WithTaskCenterPoint'
+
+const lat = 20
+const lng = 30
+let WrappedComponent = null
+let task = null
+
+beforeEach(() => {
+  task = {
+    id: 123,
+  }
+
+  WrappedComponent = WithTaskCenterPoint(() => <div className="child-control" />)
+})
+
+test("the task's location is passed through as (Lat,Lng) to the wrapped component", () => {
+  task.location = {
+    coordinates: [lng, lat],
+  }
+
+  const wrapper = shallow(
+    <WrappedComponent task={task} />
+  )
+
+  expect(wrapper.props().centerPoint).toEqual({lat, lng})
+})
+
+test("lacking a location, a centerpoint is computed from the task's features", () => {
+  task.geometries = featureCollection([
+    point([lng - 10, lat - 10]),
+    point([lng - 10, lat + 10]),
+    point([lng + 10, lat + 10]),
+    point([lng + 10, lat - 10])
+  ])
+ 
+  const wrapper = shallow(
+    <WrappedComponent task={task} />
+  )
+
+  expect(wrapper.props().centerPoint).toEqual({lat, lng})
+})
+
+test("lacking a location and features, centerpoint defaults to (0, 0)", () => {
+  const wrapper = shallow(
+    <WrappedComponent task={task} />
+  )
+
+  expect(wrapper.props().centerPoint).toEqual({lat: 0, lng: 0})
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,13 @@
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
 
+"@turf/center@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/center/-/center-5.1.5.tgz#44ab2cd954f63c0d37757f7158a99c3ef5114b80"
+  dependencies:
+    "@turf/bbox" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+
 "@turf/helpers@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"


### PR DESCRIPTION
If the task being worked upon is missing a location, compute the
center-point from the task's features if possible.