### PR TITLE
Show spinner while clustering tasks. Closes #64

### DIFF
--- a/src/components/EnhancedMap/MapPane/MapPane.scss
+++ b/src/components/EnhancedMap/MapPane/MapPane.scss
@@ -1,4 +1,4 @@
-@import '../../../variables.scss';
+@import '../../../mixins.scss';
 
 .map-pane {
   position: relative;
@@ -44,5 +44,15 @@
         }
       }
     }
+  }
+
+  .busy-spinner {
+    @include busy-spinner-color($grey);
+    @include busy-spinner-size(30px);
+
+    position: absolute;
+    top: calc(50% - 15px);
+    left: calc(50% - 15px);
+    z-index: $layer-map + $intralayer-bump;
   }
 }

--- a/src/components/HOCs/WithTaskClusters/WithTaskClusters.js
+++ b/src/components/HOCs/WithTaskClusters/WithTaskClusters.js
@@ -20,12 +20,17 @@ const WithTaskClusters = function(WrappedComponent) {
   return class extends Component {
     state = {
       tasks: [],
+      loadingClusteredTasks: false,
     }
 
     loadClusters = challengeId => {
       if (_isNumber(challengeId)) {
+        this.setState({tasks: [], loadingClusteredTasks: true})
+
         this.props.fetchClusteredTasks(challengeId).then(
-          tasks => this.setState({tasks})
+          tasks => this.setState({tasks, loadingClusteredTasks: false})
+        ).catch(error =>
+          this.setState({loadingClusteredTasks: false})
         )
       }
     }
@@ -48,13 +53,15 @@ const WithTaskClusters = function(WrappedComponent) {
 
       if (_isNumber(challengeId)) {
         clusteredTasks = _filter(this.state.tasks,
-                                 task => task.parent === challengeId && task.point
-        )
+                                 task => task.parent === challengeId && task.point)
       }
 
-      return <WrappedComponent clusteredTasks={clusteredTasks} 
-                               {..._omit(this.props,
-                                         ['entities', 'fetchClusteredTasks'])} />
+      return (
+        <WrappedComponent clusteredTasks={clusteredTasks}
+                          loadingClusteredTasks={this.state.loadingClusteredTasks}
+                          {..._omit(this.props,
+                                    ['entities', 'fetchClusteredTasks'])} />
+      )
     }
   }
 }

--- a/src/components/LocatorMap/LocatorMap.test.js
+++ b/src/components/LocatorMap/LocatorMap.test.js
@@ -75,6 +75,19 @@ test("rerenders if the challenge being browsed changes", () => {
   expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
 })
 
+test("rerenders if the challenge's clustered tasks have loaded", () => {
+  basicProps.loadingClusteredTasks = false
+
+  const wrapper = shallow(
+    <LocatorMap {...basicProps} />
+  )
+
+  const newProps = _cloneDeep(basicProps)
+  newProps.loadingClusteredTasks = true
+
+  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
+})
+
 test("moving the map signals that the locator map bounds should be updated", () => {
   const bounds = [0, 0, 0, 0]
   const zoom = 3
@@ -123,4 +136,30 @@ test("moving the map doesn't signal challenges updates if not filtering on map b
 
   wrapper.instance().updateBounds(bounds, zoom, false)
   expect(basicProps.updateBoundedChallenges).not.toBeCalled()
+})
+
+test("a busy indicator is displayed if clustered tasks are loading", () => {
+  basicProps.browsingChallenge = {id: 123}
+  basicProps.loadingClusteredTasks = true
+
+  const wrapper = shallow(
+    <LocatorMap {...basicProps} />
+  )
+
+  expect(wrapper.find('BusySpinner').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("the busy indicator is removed once tasks are done loading", () => {
+  basicProps.browsingChallenge = {id: 123}
+  basicProps.loadingClusteredTasks = false
+
+  const wrapper = shallow(
+    <LocatorMap {...basicProps} />
+  )
+
+  expect(wrapper.find('BusySpinner').exists()).toBe(false)
+
+  expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
+++ b/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
@@ -1,11 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it renders a full screen map 1`] = `
+exports[`a busy indicator is displayed if clustered tasks are loading 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <LocatorMap
+    browsingChallenge={
+        Object {
+            "id": 123,
+          }
+    }
     layerSourceName="foo"
+    loadingClusteredTasks={true}
     mapBounds={
         Object {
             "locator": Object {
@@ -34,12 +40,18 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "locator",
+    "key": "123",
     "nodeType": "host",
     "props": Object {
       "children": Array [
         <Connect(Component)
+          browsingChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
           layerSourceName="foo"
+          loadingClusteredTasks={true}
           mapBounds={
                     Object {
                               "locator": Object {
@@ -95,6 +107,7 @@ ShallowWrapper {
                     defaultLayer="foo"
           />
 </EnhancedMap>,
+        <BusySpinner />,
       ],
       "className": "full-screen-map",
     },
@@ -105,7 +118,11 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "browsingChallenge": Object {
+            "id": 123,
+          },
           "layerSourceName": "foo",
+          "loadingClusteredTasks": true,
           "mapBounds": Object {
             "locator": Object {
               "bounds": Object {
@@ -193,18 +210,33 @@ ShallowWrapper {
         ],
         "type": [Function],
       },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
     ],
     "type": "div",
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "locator",
+      "key": "123",
       "nodeType": "host",
       "props": Object {
         "children": Array [
           <Connect(Component)
+            browsingChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
             layerSourceName="foo"
+            loadingClusteredTasks={true}
             mapBounds={
                         Object {
                                     "locator": Object {
@@ -260,6 +292,7 @@ ShallowWrapper {
                         defaultLayer="foo"
             />
 </EnhancedMap>,
+          <BusySpinner />,
         ],
         "className": "full-screen-map",
       },
@@ -270,7 +303,11 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "browsingChallenge": Object {
+              "id": 123,
+            },
             "layerSourceName": "foo",
+            "loadingClusteredTasks": true,
             "mapBounds": Object {
               "locator": Object {
                 "bounds": Object {
@@ -358,6 +395,793 @@ ShallowWrapper {
           ],
           "type": [Function],
         },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {},
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`it renders a full screen map 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <LocatorMap
+    layerSourceName="foo"
+    mapBounds={
+        Object {
+            "locator": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+            },
+          }
+    }
+    setLocatorMapBounds={[Function]}
+    updateBoundedChallenges={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "locator",
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Component)
+          layerSourceName="foo"
+          mapBounds={
+                    Object {
+                              "locator": Object {
+                                "bounds": Object {
+                                  "_northEast": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                  "_southWest": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                },
+                              },
+                            }
+          }
+          setLocatorMapBounds={[Function]}
+          updateBoundedChallenges={[Function]}
+/>,
+        <EnhancedMap
+          animate={true}
+          center={
+                    Object {
+                              "lat": 0,
+                              "lng": 45,
+                            }
+          }
+          features={null}
+          initialBounds={
+                    Object {
+                              "_northEast": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                              "_southWest": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                            }
+          }
+          justFitFeatures={false}
+          maxZoom={18}
+          minZoom={2}
+          onBoundsChange={[Function]}
+          setInitialBounds={false}
+          zoom={3}
+          zoomControl={false}
+>
+          <ZoomControl
+                    position="topright"
+          />
+          <Connect(InjectIntl(SourcedTileLayer))
+                    defaultLayer="foo"
+          />
+</EnhancedMap>,
+        false,
+      ],
+      "className": "full-screen-map",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "layerSourceName": "foo",
+          "mapBounds": Object {
+            "locator": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+            },
+          },
+          "setLocatorMapBounds": [Function],
+          "updateBoundedChallenges": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "animate": true,
+          "center": Object {
+            "lat": 0,
+            "lng": 45,
+          },
+          "children": Array [
+            <ZoomControl
+              position="topright"
+/>,
+            <Connect(InjectIntl(SourcedTileLayer))
+              defaultLayer="foo"
+/>,
+            false,
+          ],
+          "features": null,
+          "initialBounds": Object {
+            "_northEast": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+            "_southWest": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+          },
+          "justFitFeatures": false,
+          "maxZoom": 18,
+          "minZoom": 2,
+          "onBoundsChange": [Function],
+          "setInitialBounds": false,
+          "zoom": 3,
+          "zoomControl": false,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "position": "topright",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultLayer": "foo",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": [Function],
+      },
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "locator",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Component)
+            layerSourceName="foo"
+            mapBounds={
+                        Object {
+                                    "locator": Object {
+                                      "bounds": Object {
+                                        "_northEast": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                        "_southWest": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            setLocatorMapBounds={[Function]}
+            updateBoundedChallenges={[Function]}
+/>,
+          <EnhancedMap
+            animate={true}
+            center={
+                        Object {
+                                    "lat": 0,
+                                    "lng": 45,
+                                  }
+            }
+            features={null}
+            initialBounds={
+                        Object {
+                                    "_northEast": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                    "_southWest": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                  }
+            }
+            justFitFeatures={false}
+            maxZoom={18}
+            minZoom={2}
+            onBoundsChange={[Function]}
+            setInitialBounds={false}
+            zoom={3}
+            zoomControl={false}
+>
+            <ZoomControl
+                        position="topright"
+            />
+            <Connect(InjectIntl(SourcedTileLayer))
+                        defaultLayer="foo"
+            />
+</EnhancedMap>,
+          false,
+        ],
+        "className": "full-screen-map",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "layerSourceName": "foo",
+            "mapBounds": Object {
+              "locator": Object {
+                "bounds": Object {
+                  "_northEast": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                  "_southWest": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+              },
+            },
+            "setLocatorMapBounds": [Function],
+            "updateBoundedChallenges": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "animate": true,
+            "center": Object {
+              "lat": 0,
+              "lng": 45,
+            },
+            "children": Array [
+              <ZoomControl
+                position="topright"
+/>,
+              <Connect(InjectIntl(SourcedTileLayer))
+                defaultLayer="foo"
+/>,
+              false,
+            ],
+            "features": null,
+            "initialBounds": Object {
+              "_northEast": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+              "_southWest": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+            },
+            "justFitFeatures": false,
+            "maxZoom": 18,
+            "minZoom": 2,
+            "onBoundsChange": [Function],
+            "setInitialBounds": false,
+            "zoom": 3,
+            "zoomControl": false,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "position": "topright",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultLayer": "foo",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": [Function],
+        },
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`the busy indicator is removed once tasks are done loading 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <LocatorMap
+    browsingChallenge={
+        Object {
+            "id": 123,
+          }
+    }
+    layerSourceName="foo"
+    loadingClusteredTasks={false}
+    mapBounds={
+        Object {
+            "locator": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+            },
+          }
+    }
+    setLocatorMapBounds={[Function]}
+    updateBoundedChallenges={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "123",
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Component)
+          browsingChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
+          layerSourceName="foo"
+          loadingClusteredTasks={false}
+          mapBounds={
+                    Object {
+                              "locator": Object {
+                                "bounds": Object {
+                                  "_northEast": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                  "_southWest": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                },
+                              },
+                            }
+          }
+          setLocatorMapBounds={[Function]}
+          updateBoundedChallenges={[Function]}
+/>,
+        <EnhancedMap
+          animate={true}
+          center={
+                    Object {
+                              "lat": 0,
+                              "lng": 45,
+                            }
+          }
+          features={undefined}
+          initialBounds={
+                    Object {
+                              "_northEast": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                              "_southWest": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                            }
+          }
+          justFitFeatures={false}
+          maxZoom={18}
+          minZoom={2}
+          onBoundsChange={[Function]}
+          setInitialBounds={false}
+          zoom={3}
+          zoomControl={false}
+>
+          <ZoomControl
+                    position="topright"
+          />
+          <Connect(InjectIntl(SourcedTileLayer))
+                    defaultLayer="foo"
+          />
+</EnhancedMap>,
+        false,
+      ],
+      "className": "full-screen-map",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "browsingChallenge": Object {
+            "id": 123,
+          },
+          "layerSourceName": "foo",
+          "loadingClusteredTasks": false,
+          "mapBounds": Object {
+            "locator": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+            },
+          },
+          "setLocatorMapBounds": [Function],
+          "updateBoundedChallenges": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "animate": true,
+          "center": Object {
+            "lat": 0,
+            "lng": 45,
+          },
+          "children": Array [
+            <ZoomControl
+              position="topright"
+/>,
+            <Connect(InjectIntl(SourcedTileLayer))
+              defaultLayer="foo"
+/>,
+            false,
+          ],
+          "features": undefined,
+          "initialBounds": Object {
+            "_northEast": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+            "_southWest": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+          },
+          "justFitFeatures": false,
+          "maxZoom": 18,
+          "minZoom": 2,
+          "onBoundsChange": [Function],
+          "setInitialBounds": false,
+          "zoom": 3,
+          "zoomControl": false,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "position": "topright",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultLayer": "foo",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": [Function],
+      },
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "123",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Component)
+            browsingChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
+            layerSourceName="foo"
+            loadingClusteredTasks={false}
+            mapBounds={
+                        Object {
+                                    "locator": Object {
+                                      "bounds": Object {
+                                        "_northEast": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                        "_southWest": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            setLocatorMapBounds={[Function]}
+            updateBoundedChallenges={[Function]}
+/>,
+          <EnhancedMap
+            animate={true}
+            center={
+                        Object {
+                                    "lat": 0,
+                                    "lng": 45,
+                                  }
+            }
+            features={undefined}
+            initialBounds={
+                        Object {
+                                    "_northEast": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                    "_southWest": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                  }
+            }
+            justFitFeatures={false}
+            maxZoom={18}
+            minZoom={2}
+            onBoundsChange={[Function]}
+            setInitialBounds={false}
+            zoom={3}
+            zoomControl={false}
+>
+            <ZoomControl
+                        position="topright"
+            />
+            <Connect(InjectIntl(SourcedTileLayer))
+                        defaultLayer="foo"
+            />
+</EnhancedMap>,
+          false,
+        ],
+        "className": "full-screen-map",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "browsingChallenge": Object {
+              "id": 123,
+            },
+            "layerSourceName": "foo",
+            "loadingClusteredTasks": false,
+            "mapBounds": Object {
+              "locator": Object {
+                "bounds": Object {
+                  "_northEast": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                  "_southWest": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+              },
+            },
+            "setLocatorMapBounds": [Function],
+            "updateBoundedChallenges": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "animate": true,
+            "center": Object {
+              "lat": 0,
+              "lng": 45,
+            },
+            "children": Array [
+              <ZoomControl
+                position="topright"
+/>,
+              <Connect(InjectIntl(SourcedTileLayer))
+                defaultLayer="foo"
+/>,
+              false,
+            ],
+            "features": undefined,
+            "initialBounds": Object {
+              "_northEast": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+              "_southWest": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+            },
+            "justFitFeatures": false,
+            "maxZoom": 18,
+            "minZoom": 2,
+            "onBoundsChange": [Function],
+            "setInitialBounds": false,
+            "zoom": 3,
+            "zoomControl": false,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "position": "topright",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultLayer": "foo",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": [Function],
+        },
+        false,
       ],
       "type": "div",
     },

--- a/src/mixins.scss
+++ b/src/mixins.scss
@@ -64,3 +64,18 @@
   word-break: break-word;
   hyphens: auto;
 }
+
+@mixin busy-spinner-color($color) {
+  .busy-spinner-icon {
+    border-color: $color;
+    border-right-color: transparent;
+    border-top-color: transparent;
+  }
+}
+
+@mixin busy-spinner-size($size) {
+  .busy-spinner-icon {
+    width: $size;
+    height: $size;
+  }
+}


### PR DESCRIPTION
When a user begins browsing a challenge, show a busy spinner on the
locator map while the clustered task data is being retrieved for
display.