### PR TITLE
Use a dedicated route for browsing challenges.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,6 +57,7 @@ export class App extends Component {
         <TopNav />
 
         <Route exact path='/' component={ChallengePane} />
+        <Route path='/browse/challenges/:challengeId?' component={ChallengePane} />
         <Route exact path='/challenge/:challengeId/task/:taskId' component={CurrentTaskPane} />
         <Route exact path='/challenge/:challengeId' component={LoadRandomChallengeTask} />
         <Route exact path='/task/:taskId' component={CurrentTaskPane} />

--- a/src/PersistedStore.js
+++ b/src/PersistedStore.js
@@ -8,6 +8,7 @@ import { currentUser, userEntities } from './services/User/User'
 import { projectEntities } from './services/Project/Project'
 import { challengeEntities } from './services/Challenge/Challenge'
 import { taskEntities } from './services/Task/Task'
+import { currentClusteredTasks } from './services/Task/ClusteredTask'
 import { commentEntities } from './services/Comment/Comment'
 import { placeEntities } from './services/Place/Place'
 import { currentFilters } from './services/Filter/Filter'
@@ -77,6 +78,12 @@ export const initializePersistedStore = callback => {
     version: process.env.REACT_APP_VERSION_DATAMODEL,
     migrate: createMigrate(dataMigrations, { debug: false }),
     debug: false,
+    blacklist: [ // don't persist
+      'currentStatus',
+      'currentErrors',
+      'openEditor',
+      'currentClusteredTasks',
+    ],
   }
 
   // Create a top-level 'entities' redux reducer that groups together the
@@ -103,6 +110,7 @@ export const initializePersistedStore = callback => {
       currentErrors,
       adminContext,
       currentPreferences,
+      currentClusteredTasks,
       entities,
   })
 

--- a/src/components/ChallengeMap/ChallengeMap.js
+++ b/src/components/ChallengeMap/ChallengeMap.js
@@ -1,0 +1,189 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { ZoomControl } from 'react-leaflet'
+import MarkerClusterGroup from 'react-leaflet-markercluster'
+import { point, featureCollection } from '@turf/helpers'
+import bbox from '@turf/bbox'
+import bboxPolygon from '@turf/bbox-polygon'
+import _get from 'lodash/get'
+import _each from 'lodash/each'
+import _map from 'lodash/map'
+import { latLng } from 'leaflet'
+import { TaskStatus } from '../../services/Task/TaskStatus/TaskStatus'
+import EnhancedMap from '../EnhancedMap/EnhancedMap'
+import SourcedTileLayer from '../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
+import LayerToggle from '../EnhancedMap/LayerToggle/LayerToggle'
+import WithVisibleLayer from '../HOCs/WithVisibleLayer/WithVisibleLayer'
+import WithMapBounds from '../HOCs/WithMapBounds/WithMapBounds'
+import WithStatus from '../HOCs/WithStatus/WithStatus'
+import BusySpinner from '../BusySpinner/BusySpinner'
+
+// Setup child components with necessary HOCs
+const VisibleTileLayer = WithVisibleLayer(SourcedTileLayer)
+
+/**
+ * ChallengeMap allows a user to browse a challenge and its tasks
+ * geographically. Tasks are shown in clusters when appropriate, and
+ * a bounding box is displayed while the tasks load.
+ *
+ * As the map is moved, its current bounds are updated in the redux store so
+ * that other components can make use of the bounds if desired (e.g.,
+ * starting a challenge will begin with a task that is currently visible to
+ * the user on the challenge map).
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export class ChallengeMap extends Component {
+  currentBounds = null
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // We want to be careful about not constantly re-rendering, so we only
+    // re-render if something meaningful changes:
+
+    // the layer has been changed, or
+    if (nextProps.layerSourceName !== this.props.layerSourceName) {
+      return true
+    }
+
+    // the browsed challenge has changed, or
+    if (_get(nextProps, 'browsedChallenge.id') !== 
+        _get(this.props, 'browsedChallenge.id')) {
+      return true
+    }
+
+    // the challenge id of the clustered tasks change
+    if (_get(nextProps, 'clusteredTasks.challengeId') !==
+        _get(this.props, 'clusteredTasks.challengeId')) {
+      return true
+    }
+
+    // the loading status of clustered tasks change
+    if (_get(nextProps, 'clusteredTasks.loading') !==
+        _get(this.props, 'clusteredTasks.loading')) {
+      return true
+    }
+
+    // the clustered tasks themselves change
+    if (_get(nextProps, 'clusteredTasks.tasks.length') !==
+        _get(this.props, 'clusteredTasks.tasks.length')) {
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Signal a change to the current challenge map bounds in response to a
+   * change to the map (panning or zooming).
+   *
+   * @private
+   */
+  updateBounds = (bounds, zoom) => {
+    // If the new bounds are the same as the old, do nothing.
+    if (this.currentBounds && this.currentBounds.equals(bounds)) {
+      return
+    }
+
+    this.currentBounds = bounds
+    this.props.setChallengeMapBounds(this.props.browsedChallenge.id,
+                                     bounds, zoom)
+  }
+
+  /**
+   * Invoked when an individual task marker is clicked by the user.
+   */
+  markerClicked = marker => {
+    if (this.props.onTaskClick) {
+      this.props.onTaskClick(marker.options.challengeId, marker.options.taskId)
+    }
+    else {
+      this.props.history.push(
+        `/challenge/${marker.options.challengeId}/task/${marker.options.taskId}`)
+    }
+  }
+
+  render() {
+    if (!this.props.browsedChallenge) {
+      return null
+    }
+
+    let fetchingClusteredTasks = false
+    const markers = []
+    let bounding = null
+
+    // If we have clustered tasks for our challenge, create markers for them.
+    if (_get(this.props, 'clusteredTasks.challengeId') ===
+        this.props.browsedChallenge.id) {
+      fetchingClusteredTasks = this.props.clusteredTasks.loading
+
+      if (_get(this.props, 'clusteredTasks.tasks.length') > 0) {
+        _each(this.props.clusteredTasks.tasks, task => {
+          // Only show created or skipped tasks
+          if (task.status === TaskStatus.created ||
+              task.status === TaskStatus.skipped) {
+            markers.push({
+              position: [task.point.lat, task.point.lng],
+              options: {
+                challengeId: task.parent,
+                taskId: task.id,
+              },
+            })
+          }
+        })
+      }
+    }
+
+    // Get the challenge bounding so we know which part of the map to display.
+    // Right now API double-nests bounding, but that will likely change.
+    bounding = _get(this.props, 'browsedChallenge.bounding.bounding') ||
+               _get(this.props, 'browsedChallenge.bounding')
+
+
+    // If the challenge doesn't have a bounding polygon, build one from the
+    // markers instead. This is extra work and requires waiting for the clustered
+    // task data to arrive, so not ideal.
+    if (!bounding && markers.length > 0) {
+      bounding = bboxPolygon(
+        bbox(featureCollection(
+          _map(markers, marker => point([marker.position[1], marker.position[0]]))
+        ))
+      )
+    }
+
+    return (
+      <div key={this.props.browsedChallenge.id}
+           className={classNames('full-screen-map', this.props.className)}>
+        <LayerToggle {...this.props} />
+        <EnhancedMap center={latLng(0, 45)} zoom={3} minZoom={2} maxZoom={18}
+                     setInitialBounds={false}
+                     initialBounds = {this.currentBounds}
+                     zoomControl={false} animate={true}
+                     features={bounding}
+                     justFitFeatures={markers.length > 0}
+                     onBoundsChange={this.updateBounds}>
+          <ZoomControl position='topright' />
+          <VisibleTileLayer defaultLayer={this.props.layerSourceName} />
+          {markers.length > 0 &&
+           <MarkerClusterGroup markers={markers} onMarkerClick={this.markerClicked} />
+          }
+        </EnhancedMap>
+
+        {fetchingClusteredTasks && <BusySpinner />}
+      </div>
+    )
+  }
+}
+
+ChallengeMap.propTypes = {
+  /** The current challenge being browsed */
+  browsedChallenge: PropTypes.object.isRequired,
+  /** Invoked when the user moves the map */
+  setChallengeMapBounds: PropTypes.func.isRequired,
+  /** Invoked when the user clicks on an individual task marker */
+  onTaskClick: PropTypes.func,
+  /** Name of default layer to display */
+  layerSourceName: PropTypes.string,
+}
+
+export default WithMapBounds(WithStatus(ChallengeMap))

--- a/src/components/ChallengeMap/ChallengeMap.test.js
+++ b/src/components/ChallengeMap/ChallengeMap.test.js
@@ -1,0 +1,123 @@
+import React from 'react'
+import _cloneDeep from 'lodash/cloneDeep'
+import { toLatLngBounds } from '../../services/MapBounds/MapBounds'
+import { ChallengeLocation }
+       from '../../services/Challenge/ChallengeLocation/ChallengeLocation'
+import { ChallengeMap } from './ChallengeMap'
+
+let basicProps = null
+let challenge = null
+
+beforeEach(() => {
+  challenge = {id: 123}
+
+  basicProps = {
+    browsedChallenge: challenge,
+    mapBounds: {
+      challenge: {
+        challengeId: challenge.id,
+        bounds: toLatLngBounds([0, 0, 0, 0]),
+      }
+    },
+    layerSourceName: "foo",
+    clusteredTasks: {
+      challengeId: challenge.id,
+      loading: false,
+    },
+    setChallengeMapBounds: jest.fn(),
+    updateBoundedChallenges: jest.fn(),
+  }
+})
+
+test("it renders a full screen map", () => {
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  expect(wrapper.find('.full-screen-map').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("doesn't rerender simply because the map bounds change", () => {
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  const newProps = _cloneDeep(basicProps)
+  newProps.mapBounds.challenge.bounds = toLatLngBounds([-20, -20, 20, 20])
+
+  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(false)
+})
+
+test("rerenders if the default layer name changes", () => {
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  const newProps = _cloneDeep(basicProps)
+  newProps.layerSourceName = 'bar'
+
+  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
+})
+
+test("rerenders if the challenge being browsed changes", () => {
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  const newProps = _cloneDeep(basicProps)
+  newProps.browsedChallenge = {id: 456}
+
+  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
+})
+
+test("rerenders if the challenge's clustered tasks have loaded", () => {
+  basicProps.clusteredTasks.loading = true
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  const newProps = _cloneDeep(basicProps)
+  newProps.clusteredTasks.loading = false
+
+  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
+})
+
+test("moving the map signals that the challenge bounds are to be updated", () => {
+  const bounds = [0, 0, 0, 0]
+  const zoom = 3
+
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  wrapper.instance().updateBounds(bounds, zoom, false)
+  expect(
+    basicProps.setChallengeMapBounds
+  ).toBeCalledWith(basicProps.browsedChallenge.id, bounds, zoom)
+})
+
+test("a busy indicator is displayed if clustered tasks are loading", () => {
+  basicProps.clusteredTasks.loading = true
+
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  expect(wrapper.find('BusySpinner').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("the busy indicator is removed once tasks are done loading", () => {
+  basicProps.clusteredTasks.loading = false
+
+  const wrapper = shallow(
+    <ChallengeMap {...basicProps} />
+  )
+
+  expect(wrapper.find('BusySpinner').exists()).toBe(false)
+
+  expect(wrapper).toMatchSnapshot()
+})

--- a/src/components/ChallengeMap/__snapshots__/ChallengeMap.test.js.snap
+++ b/src/components/ChallengeMap/__snapshots__/ChallengeMap.test.js.snap
@@ -1,0 +1,1181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`a busy indicator is displayed if clustered tasks are loading 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengeMap
+    browsedChallenge={
+        Object {
+            "id": 123,
+          }
+    }
+    clusteredTasks={
+        Object {
+            "challengeId": 123,
+            "loading": true,
+          }
+    }
+    layerSourceName="foo"
+    mapBounds={
+        Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          }
+    }
+    setChallengeMapBounds={[Function]}
+    updateBoundedChallenges={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "123",
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Component)
+          browsedChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
+          clusteredTasks={
+                    Object {
+                              "challengeId": 123,
+                              "loading": true,
+                            }
+          }
+          layerSourceName="foo"
+          mapBounds={
+                    Object {
+                              "challenge": Object {
+                                "bounds": Object {
+                                  "_northEast": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                  "_southWest": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                },
+                                "challengeId": 123,
+                              },
+                            }
+          }
+          setChallengeMapBounds={[Function]}
+          updateBoundedChallenges={[Function]}
+/>,
+        <EnhancedMap
+          animate={true}
+          center={
+                    Object {
+                              "lat": 0,
+                              "lng": 45,
+                            }
+          }
+          features={undefined}
+          initialBounds={null}
+          justFitFeatures={false}
+          maxZoom={18}
+          minZoom={2}
+          onBoundsChange={[Function]}
+          setInitialBounds={false}
+          zoom={3}
+          zoomControl={false}
+>
+          <ZoomControl
+                    position="topright"
+          />
+          <Connect(InjectIntl(SourcedTileLayer))
+                    defaultLayer="foo"
+          />
+</EnhancedMap>,
+        <BusySpinner />,
+      ],
+      "className": "full-screen-map",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "browsedChallenge": Object {
+            "id": 123,
+          },
+          "clusteredTasks": Object {
+            "challengeId": 123,
+            "loading": true,
+          },
+          "layerSourceName": "foo",
+          "mapBounds": Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          },
+          "setChallengeMapBounds": [Function],
+          "updateBoundedChallenges": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "animate": true,
+          "center": Object {
+            "lat": 0,
+            "lng": 45,
+          },
+          "children": Array [
+            <ZoomControl
+              position="topright"
+/>,
+            <Connect(InjectIntl(SourcedTileLayer))
+              defaultLayer="foo"
+/>,
+            false,
+          ],
+          "features": undefined,
+          "initialBounds": null,
+          "justFitFeatures": false,
+          "maxZoom": 18,
+          "minZoom": 2,
+          "onBoundsChange": [Function],
+          "setInitialBounds": false,
+          "zoom": 3,
+          "zoomControl": false,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "position": "topright",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultLayer": "foo",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "123",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Component)
+            browsedChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
+            clusteredTasks={
+                        Object {
+                                    "challengeId": 123,
+                                    "loading": true,
+                                  }
+            }
+            layerSourceName="foo"
+            mapBounds={
+                        Object {
+                                    "challenge": Object {
+                                      "bounds": Object {
+                                        "_northEast": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                        "_southWest": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                      },
+                                      "challengeId": 123,
+                                    },
+                                  }
+            }
+            setChallengeMapBounds={[Function]}
+            updateBoundedChallenges={[Function]}
+/>,
+          <EnhancedMap
+            animate={true}
+            center={
+                        Object {
+                                    "lat": 0,
+                                    "lng": 45,
+                                  }
+            }
+            features={undefined}
+            initialBounds={null}
+            justFitFeatures={false}
+            maxZoom={18}
+            minZoom={2}
+            onBoundsChange={[Function]}
+            setInitialBounds={false}
+            zoom={3}
+            zoomControl={false}
+>
+            <ZoomControl
+                        position="topright"
+            />
+            <Connect(InjectIntl(SourcedTileLayer))
+                        defaultLayer="foo"
+            />
+</EnhancedMap>,
+          <BusySpinner />,
+        ],
+        "className": "full-screen-map",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "browsedChallenge": Object {
+              "id": 123,
+            },
+            "clusteredTasks": Object {
+              "challengeId": 123,
+              "loading": true,
+            },
+            "layerSourceName": "foo",
+            "mapBounds": Object {
+              "challenge": Object {
+                "bounds": Object {
+                  "_northEast": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                  "_southWest": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+                "challengeId": 123,
+              },
+            },
+            "setChallengeMapBounds": [Function],
+            "updateBoundedChallenges": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "animate": true,
+            "center": Object {
+              "lat": 0,
+              "lng": 45,
+            },
+            "children": Array [
+              <ZoomControl
+                position="topright"
+/>,
+              <Connect(InjectIntl(SourcedTileLayer))
+                defaultLayer="foo"
+/>,
+              false,
+            ],
+            "features": undefined,
+            "initialBounds": null,
+            "justFitFeatures": false,
+            "maxZoom": 18,
+            "minZoom": 2,
+            "onBoundsChange": [Function],
+            "setInitialBounds": false,
+            "zoom": 3,
+            "zoomControl": false,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "position": "topright",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultLayer": "foo",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {},
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`it renders a full screen map 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengeMap
+    browsedChallenge={
+        Object {
+            "id": 123,
+          }
+    }
+    clusteredTasks={
+        Object {
+            "challengeId": 123,
+            "loading": false,
+          }
+    }
+    layerSourceName="foo"
+    mapBounds={
+        Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          }
+    }
+    setChallengeMapBounds={[Function]}
+    updateBoundedChallenges={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "123",
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Component)
+          browsedChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
+          clusteredTasks={
+                    Object {
+                              "challengeId": 123,
+                              "loading": false,
+                            }
+          }
+          layerSourceName="foo"
+          mapBounds={
+                    Object {
+                              "challenge": Object {
+                                "bounds": Object {
+                                  "_northEast": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                  "_southWest": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                },
+                                "challengeId": 123,
+                              },
+                            }
+          }
+          setChallengeMapBounds={[Function]}
+          updateBoundedChallenges={[Function]}
+/>,
+        <EnhancedMap
+          animate={true}
+          center={
+                    Object {
+                              "lat": 0,
+                              "lng": 45,
+                            }
+          }
+          features={undefined}
+          initialBounds={null}
+          justFitFeatures={false}
+          maxZoom={18}
+          minZoom={2}
+          onBoundsChange={[Function]}
+          setInitialBounds={false}
+          zoom={3}
+          zoomControl={false}
+>
+          <ZoomControl
+                    position="topright"
+          />
+          <Connect(InjectIntl(SourcedTileLayer))
+                    defaultLayer="foo"
+          />
+</EnhancedMap>,
+        false,
+      ],
+      "className": "full-screen-map",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "browsedChallenge": Object {
+            "id": 123,
+          },
+          "clusteredTasks": Object {
+            "challengeId": 123,
+            "loading": false,
+          },
+          "layerSourceName": "foo",
+          "mapBounds": Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          },
+          "setChallengeMapBounds": [Function],
+          "updateBoundedChallenges": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "animate": true,
+          "center": Object {
+            "lat": 0,
+            "lng": 45,
+          },
+          "children": Array [
+            <ZoomControl
+              position="topright"
+/>,
+            <Connect(InjectIntl(SourcedTileLayer))
+              defaultLayer="foo"
+/>,
+            false,
+          ],
+          "features": undefined,
+          "initialBounds": null,
+          "justFitFeatures": false,
+          "maxZoom": 18,
+          "minZoom": 2,
+          "onBoundsChange": [Function],
+          "setInitialBounds": false,
+          "zoom": 3,
+          "zoomControl": false,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "position": "topright",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultLayer": "foo",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": [Function],
+      },
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "123",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Component)
+            browsedChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
+            clusteredTasks={
+                        Object {
+                                    "challengeId": 123,
+                                    "loading": false,
+                                  }
+            }
+            layerSourceName="foo"
+            mapBounds={
+                        Object {
+                                    "challenge": Object {
+                                      "bounds": Object {
+                                        "_northEast": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                        "_southWest": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                      },
+                                      "challengeId": 123,
+                                    },
+                                  }
+            }
+            setChallengeMapBounds={[Function]}
+            updateBoundedChallenges={[Function]}
+/>,
+          <EnhancedMap
+            animate={true}
+            center={
+                        Object {
+                                    "lat": 0,
+                                    "lng": 45,
+                                  }
+            }
+            features={undefined}
+            initialBounds={null}
+            justFitFeatures={false}
+            maxZoom={18}
+            minZoom={2}
+            onBoundsChange={[Function]}
+            setInitialBounds={false}
+            zoom={3}
+            zoomControl={false}
+>
+            <ZoomControl
+                        position="topright"
+            />
+            <Connect(InjectIntl(SourcedTileLayer))
+                        defaultLayer="foo"
+            />
+</EnhancedMap>,
+          false,
+        ],
+        "className": "full-screen-map",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "browsedChallenge": Object {
+              "id": 123,
+            },
+            "clusteredTasks": Object {
+              "challengeId": 123,
+              "loading": false,
+            },
+            "layerSourceName": "foo",
+            "mapBounds": Object {
+              "challenge": Object {
+                "bounds": Object {
+                  "_northEast": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                  "_southWest": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+                "challengeId": 123,
+              },
+            },
+            "setChallengeMapBounds": [Function],
+            "updateBoundedChallenges": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "animate": true,
+            "center": Object {
+              "lat": 0,
+              "lng": 45,
+            },
+            "children": Array [
+              <ZoomControl
+                position="topright"
+/>,
+              <Connect(InjectIntl(SourcedTileLayer))
+                defaultLayer="foo"
+/>,
+              false,
+            ],
+            "features": undefined,
+            "initialBounds": null,
+            "justFitFeatures": false,
+            "maxZoom": 18,
+            "minZoom": 2,
+            "onBoundsChange": [Function],
+            "setInitialBounds": false,
+            "zoom": 3,
+            "zoomControl": false,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "position": "topright",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultLayer": "foo",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": [Function],
+        },
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`the busy indicator is removed once tasks are done loading 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengeMap
+    browsedChallenge={
+        Object {
+            "id": 123,
+          }
+    }
+    clusteredTasks={
+        Object {
+            "challengeId": 123,
+            "loading": false,
+          }
+    }
+    layerSourceName="foo"
+    mapBounds={
+        Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          }
+    }
+    setChallengeMapBounds={[Function]}
+    updateBoundedChallenges={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "123",
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Component)
+          browsedChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
+          clusteredTasks={
+                    Object {
+                              "challengeId": 123,
+                              "loading": false,
+                            }
+          }
+          layerSourceName="foo"
+          mapBounds={
+                    Object {
+                              "challenge": Object {
+                                "bounds": Object {
+                                  "_northEast": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                  "_southWest": Object {
+                                    "lat": 0,
+                                    "lng": 0,
+                                  },
+                                },
+                                "challengeId": 123,
+                              },
+                            }
+          }
+          setChallengeMapBounds={[Function]}
+          updateBoundedChallenges={[Function]}
+/>,
+        <EnhancedMap
+          animate={true}
+          center={
+                    Object {
+                              "lat": 0,
+                              "lng": 45,
+                            }
+          }
+          features={undefined}
+          initialBounds={null}
+          justFitFeatures={false}
+          maxZoom={18}
+          minZoom={2}
+          onBoundsChange={[Function]}
+          setInitialBounds={false}
+          zoom={3}
+          zoomControl={false}
+>
+          <ZoomControl
+                    position="topright"
+          />
+          <Connect(InjectIntl(SourcedTileLayer))
+                    defaultLayer="foo"
+          />
+</EnhancedMap>,
+        false,
+      ],
+      "className": "full-screen-map",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "browsedChallenge": Object {
+            "id": 123,
+          },
+          "clusteredTasks": Object {
+            "challengeId": 123,
+            "loading": false,
+          },
+          "layerSourceName": "foo",
+          "mapBounds": Object {
+            "challenge": Object {
+              "bounds": Object {
+                "_northEast": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+                "_southWest": Object {
+                  "lat": 0,
+                  "lng": 0,
+                },
+              },
+              "challengeId": 123,
+            },
+          },
+          "setChallengeMapBounds": [Function],
+          "updateBoundedChallenges": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "animate": true,
+          "center": Object {
+            "lat": 0,
+            "lng": 45,
+          },
+          "children": Array [
+            <ZoomControl
+              position="topright"
+/>,
+            <Connect(InjectIntl(SourcedTileLayer))
+              defaultLayer="foo"
+/>,
+            false,
+          ],
+          "features": undefined,
+          "initialBounds": null,
+          "justFitFeatures": false,
+          "maxZoom": 18,
+          "minZoom": 2,
+          "onBoundsChange": [Function],
+          "setInitialBounds": false,
+          "zoom": 3,
+          "zoomControl": false,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "position": "topright",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultLayer": "foo",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": [Function],
+      },
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "123",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Component)
+            browsedChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
+            clusteredTasks={
+                        Object {
+                                    "challengeId": 123,
+                                    "loading": false,
+                                  }
+            }
+            layerSourceName="foo"
+            mapBounds={
+                        Object {
+                                    "challenge": Object {
+                                      "bounds": Object {
+                                        "_northEast": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                        "_southWest": Object {
+                                          "lat": 0,
+                                          "lng": 0,
+                                        },
+                                      },
+                                      "challengeId": 123,
+                                    },
+                                  }
+            }
+            setChallengeMapBounds={[Function]}
+            updateBoundedChallenges={[Function]}
+/>,
+          <EnhancedMap
+            animate={true}
+            center={
+                        Object {
+                                    "lat": 0,
+                                    "lng": 45,
+                                  }
+            }
+            features={undefined}
+            initialBounds={null}
+            justFitFeatures={false}
+            maxZoom={18}
+            minZoom={2}
+            onBoundsChange={[Function]}
+            setInitialBounds={false}
+            zoom={3}
+            zoomControl={false}
+>
+            <ZoomControl
+                        position="topright"
+            />
+            <Connect(InjectIntl(SourcedTileLayer))
+                        defaultLayer="foo"
+            />
+</EnhancedMap>,
+          false,
+        ],
+        "className": "full-screen-map",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "browsedChallenge": Object {
+              "id": 123,
+            },
+            "clusteredTasks": Object {
+              "challengeId": 123,
+              "loading": false,
+            },
+            "layerSourceName": "foo",
+            "mapBounds": Object {
+              "challenge": Object {
+                "bounds": Object {
+                  "_northEast": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                  "_southWest": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+                "challengeId": 123,
+              },
+            },
+            "setChallengeMapBounds": [Function],
+            "updateBoundedChallenges": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "animate": true,
+            "center": Object {
+              "lat": 0,
+              "lng": 45,
+            },
+            "children": Array [
+              <ZoomControl
+                position="topright"
+/>,
+              <Connect(InjectIntl(SourcedTileLayer))
+                defaultLayer="foo"
+/>,
+              false,
+            ],
+            "features": undefined,
+            "initialBounds": null,
+            "justFitFeatures": false,
+            "maxZoom": 18,
+            "minZoom": 2,
+            "onBoundsChange": [Function],
+            "setInitialBounds": false,
+            "zoom": 3,
+            "zoomControl": false,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "position": "topright",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultLayer": "foo",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": [Function],
+        },
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -5,8 +5,11 @@ import ChallengeFilterSubnav from './ChallengeFilterSubnav/ChallengeFilterSubnav
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import Sidebar from '../Sidebar/Sidebar'
 import LocatorMap from '../LocatorMap/LocatorMap'
+import ChallengeMap from '../ChallengeMap/ChallengeMap'
 import ChallengeResultList from './ChallengeResultList/ChallengeResultList'
+import WithChallenges from '../HOCs/WithChallenges/WithChallenges'
 import WithBrowsedChallenge from '../HOCs/WithBrowsedChallenge/WithBrowsedChallenge'
+import WithMapBounds from '../HOCs/WithMapBounds/WithMapBounds'
 import WithStatus from '../HOCs/WithStatus/WithStatus'
 import './ChallengePane.css'
 
@@ -34,6 +37,7 @@ export class ChallengePane extends Component {
   }
 
   render() {
+    const Map = this.props.browsedChallenge ? ChallengeMap : LocatorMap
     return (
       <span>
         <ChallengeFilterSubnav {...this.props} />
@@ -45,7 +49,7 @@ export class ChallengePane extends Component {
           </Sidebar>
 
           <MapPane>
-            <LocatorMap layerSourceName={MAPBOX_STREETS} {...this.props} />
+            <Map layerSourceName={MAPBOX_STREETS} {...this.props} />
           </MapPane>
         </div>
       </span>
@@ -53,4 +57,4 @@ export class ChallengePane extends Component {
   }
 }
 
-export default WithBrowsedChallenge(ChallengePane)
+export default WithMapBounds(WithChallenges(WithBrowsedChallenge(ChallengePane)))

--- a/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
+++ b/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import _isObject from 'lodash/isObject'
 import _findIndex from 'lodash/findIndex'
 import _startCase from 'lodash/startCase'
+import _isEqual from 'lodash/isEqual'
 import _get from 'lodash/get'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import classNames from 'classnames'
@@ -44,11 +45,51 @@ export class ChallengeResultItem extends Component {
     isStarting: false,
   }
 
+  componentDidMount() {
+    if (_get(this.props, 'browsedChallenge.id') === this.props.challenge.id) {
+      if (this.node) {
+        this.node.scrollIntoView()
+      }
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // Only re-render under specific conditions:
+
+    // if our state changed, or
+    if (!_isEqual(nextState, this.state)) {
+      return true
+    }
+
+    // if the user object changed, or
+    if (!_isEqual(nextProps.user, this.props.user)) {
+      return true
+    }
+
+    // if the challenge object itself changed, or
+    if (!_isEqual(nextProps.challenge, this.props.challenge)) {
+      return true
+    }
+
+    // if the browsedChallenge changed and it either references our challenge now
+    // or used to before.
+    if (_get(nextProps, 'browsedChallenge.id') !== _get(this.props, 'browsedChallenge.id') &&
+        (_get(nextProps, 'browsedChallenge.id') === this.props.challenge.id ||
+         _get(this.props, 'browsedChallenge.id') === this.props.challenge.id)) {
+      return true
+    }
+
+    return false
+  }
+
   componentWillReceiveProps(nextProps) {
     // Ensure isBrowsing state stays synced with browsedChallenge prop.
-    this.setState({
-      isBrowsing: _get(nextProps, 'browsedChallenge.id') === this.props.challenge.id
-    })
+    const isBrowsing =
+      _get(nextProps, 'browsedChallenge.id') === this.props.challenge.id
+
+    if (this.state.isBrowsing !== isBrowsing) {
+      this.setState({isBrowsing})
+    }
   }
 
   /**
@@ -138,7 +179,8 @@ export class ChallengeResultItem extends Component {
       </div>
 
     return (
-      <div className={classNames('card', 'challenge-list__item',
+      <div ref={node => this.node = node}
+           className={classNames('card', 'challenge-list__item',
                                  {'is-active': this.state.isBrowsing})}>
         {featuredIndicator}
         <header className="card-header" onClick={this.toggleActive}>

--- a/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.scss
+++ b/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.scss
@@ -7,10 +7,6 @@
   margin-top: 20px;
   border-radius: $radius-medium;
 
-  &:hover {
-    cursor: pointer;
-  }
-
   .challenge-list__item--featured-indicator {
     background-color: $grey-light;
     border-radius: $radius-medium 0 $radius-medium 0;
@@ -103,6 +99,10 @@
         @include arrow($minimizer-arrow-color);
         @include dropdown-arrow();
       }
+    }
+
+    &:hover {
+      cursor: pointer;
     }
   }
 

--- a/src/components/ChallengePane/ChallengeResultItem/__snapshots__/ChallengeResultItem.test.js.snap
+++ b/src/components/ChallengePane/ChallengeResultItem/__snapshots__/ChallengeResultItem.test.js.snap
@@ -145,7 +145,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -707,7 +707,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -1345,7 +1345,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       Object {
         "instance": null,
@@ -2034,7 +2034,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         Object {
           "instance": null,
@@ -2766,7 +2766,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -3417,7 +3417,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -4120,7 +4120,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -4771,7 +4771,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -5485,7 +5485,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item is-active",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -6136,7 +6136,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item is-active",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -6839,7 +6839,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -7490,7 +7490,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -8193,7 +8193,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -8844,7 +8844,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {
@@ -9556,7 +9556,7 @@ ShallowWrapper {
       ],
       "className": "card challenge-list__item",
     },
-    "ref": null,
+    "ref": [Function],
     "rendered": Array [
       null,
       Object {
@@ -10241,7 +10241,7 @@ ShallowWrapper {
         ],
         "className": "card challenge-list__item",
       },
-      "ref": null,
+      "ref": [Function],
       "rendered": Array [
         null,
         Object {

--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import _get from 'lodash/get'
+import _map from 'lodash/map'
+import _findIndex from 'lodash/findIndex'
+import _isObject from 'lodash/isObject'
 import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import WithCurrentUser from '../../HOCs/WithCurrentUser/WithCurrentUser'
 import WithChallengeFilters from '../../HOCs/WithChallengeFilters/WithChallengeFilters'
-import WithMapBounds from '../../HOCs/WithMapBounds/WithMapBounds'
-import WithChallenges from '../../HOCs/WithChallenges/WithChallenges'
+import WithStartChallenge from '../../HOCs/WithStartChallenge/WithStartChallenge'
 import WithFilteredChallenges from '../../HOCs/WithFilteredChallenges/WithFilteredChallenges'
 import WithSortedChallenges from '../../HOCs/WithSortedChallenges/WithSortedChallenges'
 import WithSearchResults from '../../HOCs/WithSearchResults/WithSearchResults'
@@ -26,8 +28,18 @@ import './ChallengeResultList.css'
  */
 export class ChallengeResultList extends Component {
   render() {
+    const challengeResults = this.props.challenges
+
+    // If the user is actively browsing a challenge, include that challenge even if
+    // it didn't pass the filters.
+    if (_isObject(this.props.browsedChallenge)) {
+      if (_findIndex(challengeResults, {id: this.props.browsedChallenge.id}) === -1) {
+        challengeResults.push(this.props.browsedChallenge)
+      }
+    }
+
     let results = null
-    if (this.props.challenges.length === 0) {
+    if (challengeResults.length === 0) {
       results = (
         <div className='challenge-result-list__challenge-list no-results'>
           <span><FormattedMessage {...messages.noResults} /></span>
@@ -38,7 +50,7 @@ export class ChallengeResultList extends Component {
       )
     }
     else {
-      const challenges = this.props.challenges.map(challenge => (
+      const challenges = _map(challengeResults, challenge => (
         <li key={challenge.id}>
           <ChallengeResultItem challenge={challenge} {...this.props} />
         </li>
@@ -77,18 +89,16 @@ ChallengeResultList.propTypes = {
 
 export default function(searchName='challenges') {
   return WithCurrentUser(
-    WithMapBounds(
-      WithChallenges(
-        WithChallengeFilters(
-          WithFilteredChallenges(
-            WithSearchResults(
-              WithSortedChallenges(
-                ChallengeResultList
-              ),
-              searchName,
-              'challenges'
+    WithStartChallenge(
+      WithChallengeFilters(
+        WithFilteredChallenges(
+          WithSearchResults(
+            WithSortedChallenges(
+              ChallengeResultList
             ),
-          )
+            searchName,
+            'challenges'
+          ),
         )
       )
     )

--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.test.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.test.js
@@ -4,43 +4,41 @@ import { ChallengeDifficulty }
 import { ChallengeResultList } from './ChallengeResultList'
 import _cloneDeep from 'lodash/cloneDeep'
 
-const propsFixture = {
-  user: {
-    id: 11,
-    savedChallenges: [],
-  },
-  challenges: [
-    {
-      id: 309,
-      name: "Challenge 309",
-      blurb: "Challenge 309 blurb",
-      description: "Challenge 309 description",
-      difficulty: ChallengeDifficulty.expert,
-      parent: {
-        displayName: "foo",
-      }
-    },
-    {
-      id: 311,
-      name: "Challenge 311",
-      blurb: "Challenge 311 blurb",
-      description: "Challenge 311 description",
-      difficulty: ChallengeDifficulty.expert,
-      parent: {
-        displayName: "bar",
-      }
-    },
-  ],
-}
-
 let basicProps = null
 
 beforeEach(() => {
-  basicProps = _cloneDeep(propsFixture)
-  basicProps.startChallenge = jest.fn()
-  basicProps.saveChallenge = jest.fn()
-  basicProps.unsaveChallenge = jest.fn()
-  basicProps.intl = {formatMessage: jest.fn()}
+  basicProps = {
+    user: {
+      id: 11,
+      savedChallenges: [],
+    },
+    challenges: [
+      {
+        id: 309,
+        name: "Challenge 309",
+        blurb: "Challenge 309 blurb",
+        description: "Challenge 309 description",
+        difficulty: ChallengeDifficulty.expert,
+        parent: {
+          displayName: "foo",
+        }
+      },
+      {
+        id: 311,
+        name: "Challenge 311",
+        blurb: "Challenge 311 blurb",
+        description: "Challenge 311 description",
+        difficulty: ChallengeDifficulty.expert,
+        parent: {
+          displayName: "bar",
+        }
+      },
+    ],
+    startChallenge: jest.fn(),
+    saveChallenge: jest.fn(),
+    unsaveChallenge: jest.fn(),
+    intl: {formatMessage: jest.fn()},
+  }
 })
 
 test("renders with props as expected", () => {
@@ -81,5 +79,33 @@ test("renders with a busySpinner if props fetchingChallenges", () => {
   )
 
   expect(wrapper.find('BusySpinner').exists()).toBe(true)
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("always includes actively browsed challenge in the result list", () => {
+  const browsed = basicProps.challenges[0]
+  basicProps.challenges = []
+
+  const wrapper = shallow(
+    <ChallengeResultList {...basicProps} browsedChallenge={browsed} />
+  )
+
+  expect(wrapper.find('.challenge-result-list__challenge-list').exists()).toBe(true)
+  expect(wrapper.find('InjectIntl(ChallengeResultItem)').length).toBe(1)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("doesn't duplicate actively browsed challenge in the result list", () => {
+  const browsed = basicProps.challenges[0]
+  basicProps.challenges = [browsed]
+
+  const wrapper = shallow(
+    <ChallengeResultList {...basicProps} browsedChallenge={browsed} />
+  )
+
+  expect(wrapper.find('.challenge-result-list__challenge-list').exists()).toBe(true)
+  expect(wrapper.find('InjectIntl(ChallengeResultItem)').length).toBe(1)
+
   expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/ChallengePane/ChallengeResultList/__snapshots__/ChallengeResultList.test.js.snap
+++ b/src/components/ChallengePane/ChallengeResultList/__snapshots__/ChallengeResultList.test.js.snap
@@ -1,5 +1,1519 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`always includes actively browsed challenge in the result list 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengeResultList
+    browsedChallenge={
+        Object {
+            "blurb": "Challenge 309 blurb",
+            "description": "Challenge 309 description",
+            "difficulty": 3,
+            "id": 309,
+            "name": "Challenge 309",
+            "parent": Object {
+              "displayName": "foo",
+            },
+          }
+    }
+    challenges={
+        Array [
+            Object {
+              "blurb": "Challenge 309 blurb",
+              "description": "Challenge 309 description",
+              "difficulty": 3,
+              "id": 309,
+              "name": "Challenge 309",
+              "parent": Object {
+                "displayName": "foo",
+              },
+            },
+          ]
+    }
+    intl={
+        Object {
+            "formatMessage": [Function],
+          }
+    }
+    saveChallenge={[Function]}
+    startChallenge={[Function]}
+    unsaveChallenge={[Function]}
+    user={
+        Object {
+            "id": 11,
+            "savedChallenges": Array [],
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="level challenge-result-list--heading"
+>
+          <div
+                    className="level-left"
+          >
+                    <h2
+                              className="title is-4"
+                    >
+                              <FormattedMessage
+                                        defaultMessage="Challenges"
+                                        id="Challenge.results.heading"
+                                        values={Object {}}
+                              />
+                    </h2>
+          </div>
+</div>,
+        <ul
+          className="challenge-result-list__challenge-list"
+>
+          <li>
+                    <InjectIntl(ChallengeResultItem)
+                              browsedChallenge={
+                                        Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                }
+                              }
+                              challenge={
+                                        Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                }
+                              }
+                              challenges={
+                                        Array [
+                                                  Object {
+                                                    "blurb": "Challenge 309 blurb",
+                                                    "description": "Challenge 309 description",
+                                                    "difficulty": 3,
+                                                    "id": 309,
+                                                    "name": "Challenge 309",
+                                                    "parent": Object {
+                                                      "displayName": "foo",
+                                                    },
+                                                  },
+                                                ]
+                              }
+                              intl={
+                                        Object {
+                                                  "formatMessage": [Function],
+                                                }
+                              }
+                              saveChallenge={[Function]}
+                              startChallenge={[Function]}
+                              unsaveChallenge={[Function]}
+                              user={
+                                        Object {
+                                                  "id": 11,
+                                                  "savedChallenges": Array [],
+                                                }
+                              }
+                    />
+          </li>
+</ul>,
+      ],
+      "className": "challenge-result-list",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="level-left"
+>
+            <h2
+                        className="title is-4"
+            >
+                        <FormattedMessage
+                                    defaultMessage="Challenges"
+                                    id="Challenge.results.heading"
+                                    values={Object {}}
+                        />
+            </h2>
+</div>,
+          "className": "level challenge-result-list--heading",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <h2
+              className="title is-4"
+>
+              <FormattedMessage
+                            defaultMessage="Challenges"
+                            id="Challenge.results.heading"
+                            values={Object {}}
+              />
+</h2>,
+            "className": "level-left",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <FormattedMessage
+                defaultMessage="Challenges"
+                id="Challenge.results.heading"
+                values={Object {}}
+/>,
+              "className": "title is-4",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultMessage": "Challenges",
+                "id": "Challenge.results.heading",
+                "values": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "h2",
+          },
+          "type": "div",
+        },
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li>
+              <InjectIntl(ChallengeResultItem)
+                            browsedChallenge={
+                                          Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      }
+                            }
+                            challenge={
+                                          Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      }
+                            }
+                            challenges={
+                                          Array [
+                                                        Object {
+                                                          "blurb": "Challenge 309 blurb",
+                                                          "description": "Challenge 309 description",
+                                                          "difficulty": 3,
+                                                          "id": 309,
+                                                          "name": "Challenge 309",
+                                                          "parent": Object {
+                                                            "displayName": "foo",
+                                                          },
+                                                        },
+                                                      ]
+                            }
+                            intl={
+                                          Object {
+                                                        "formatMessage": [Function],
+                                                      }
+                            }
+                            saveChallenge={[Function]}
+                            startChallenge={[Function]}
+                            unsaveChallenge={[Function]}
+                            user={
+                                          Object {
+                                                        "id": 11,
+                                                        "savedChallenges": Array [],
+                                                      }
+                            }
+              />
+</li>,
+          ],
+          "className": "challenge-result-list__challenge-list",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "309",
+            "nodeType": "host",
+            "props": Object {
+              "children": <InjectIntl(ChallengeResultItem)
+                browsedChallenge={
+                                Object {
+                                                "blurb": "Challenge 309 blurb",
+                                                "description": "Challenge 309 description",
+                                                "difficulty": 3,
+                                                "id": 309,
+                                                "name": "Challenge 309",
+                                                "parent": Object {
+                                                  "displayName": "foo",
+                                                },
+                                              }
+                }
+                challenge={
+                                Object {
+                                                "blurb": "Challenge 309 blurb",
+                                                "description": "Challenge 309 description",
+                                                "difficulty": 3,
+                                                "id": 309,
+                                                "name": "Challenge 309",
+                                                "parent": Object {
+                                                  "displayName": "foo",
+                                                },
+                                              }
+                }
+                challenges={
+                                Array [
+                                                Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                },
+                                              ]
+                }
+                intl={
+                                Object {
+                                                "formatMessage": [Function],
+                                              }
+                }
+                saveChallenge={[Function]}
+                startChallenge={[Function]}
+                unsaveChallenge={[Function]}
+                user={
+                                Object {
+                                                "id": 11,
+                                                "savedChallenges": Array [],
+                                              }
+                }
+/>,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "browsedChallenge": Object {
+                  "blurb": "Challenge 309 blurb",
+                  "description": "Challenge 309 description",
+                  "difficulty": 3,
+                  "id": 309,
+                  "name": "Challenge 309",
+                  "parent": Object {
+                    "displayName": "foo",
+                  },
+                },
+                "challenge": Object {
+                  "blurb": "Challenge 309 blurb",
+                  "description": "Challenge 309 description",
+                  "difficulty": 3,
+                  "id": 309,
+                  "name": "Challenge 309",
+                  "parent": Object {
+                    "displayName": "foo",
+                  },
+                },
+                "challenges": Array [
+                  Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                ],
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "saveChallenge": [Function],
+                "startChallenge": [Function],
+                "unsaveChallenge": [Function],
+                "user": Object {
+                  "id": 11,
+                  "savedChallenges": Array [],
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="level challenge-result-list--heading"
+>
+            <div
+                        className="level-left"
+            >
+                        <h2
+                                    className="title is-4"
+                        >
+                                    <FormattedMessage
+                                                defaultMessage="Challenges"
+                                                id="Challenge.results.heading"
+                                                values={Object {}}
+                                    />
+                        </h2>
+            </div>
+</div>,
+          <ul
+            className="challenge-result-list__challenge-list"
+>
+            <li>
+                        <InjectIntl(ChallengeResultItem)
+                                    browsedChallenge={
+                                                Object {
+                                                            "blurb": "Challenge 309 blurb",
+                                                            "description": "Challenge 309 description",
+                                                            "difficulty": 3,
+                                                            "id": 309,
+                                                            "name": "Challenge 309",
+                                                            "parent": Object {
+                                                              "displayName": "foo",
+                                                            },
+                                                          }
+                                    }
+                                    challenge={
+                                                Object {
+                                                            "blurb": "Challenge 309 blurb",
+                                                            "description": "Challenge 309 description",
+                                                            "difficulty": 3,
+                                                            "id": 309,
+                                                            "name": "Challenge 309",
+                                                            "parent": Object {
+                                                              "displayName": "foo",
+                                                            },
+                                                          }
+                                    }
+                                    challenges={
+                                                Array [
+                                                            Object {
+                                                              "blurb": "Challenge 309 blurb",
+                                                              "description": "Challenge 309 description",
+                                                              "difficulty": 3,
+                                                              "id": 309,
+                                                              "name": "Challenge 309",
+                                                              "parent": Object {
+                                                                "displayName": "foo",
+                                                              },
+                                                            },
+                                                          ]
+                                    }
+                                    intl={
+                                                Object {
+                                                            "formatMessage": [Function],
+                                                          }
+                                    }
+                                    saveChallenge={[Function]}
+                                    startChallenge={[Function]}
+                                    unsaveChallenge={[Function]}
+                                    user={
+                                                Object {
+                                                            "id": 11,
+                                                            "savedChallenges": Array [],
+                                                          }
+                                    }
+                        />
+            </li>
+</ul>,
+        ],
+        "className": "challenge-result-list",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <div
+              className="level-left"
+>
+              <h2
+                            className="title is-4"
+              >
+                            <FormattedMessage
+                                          defaultMessage="Challenges"
+                                          id="Challenge.results.heading"
+                                          values={Object {}}
+                            />
+              </h2>
+</div>,
+            "className": "level challenge-result-list--heading",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h2
+                className="title is-4"
+>
+                <FormattedMessage
+                                defaultMessage="Challenges"
+                                id="Challenge.results.heading"
+                                values={Object {}}
+                />
+</h2>,
+              "className": "level-left",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <FormattedMessage
+                  defaultMessage="Challenges"
+                  id="Challenge.results.heading"
+                  values={Object {}}
+/>,
+                "className": "title is-4",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "defaultMessage": "Challenges",
+                  "id": "Challenge.results.heading",
+                  "values": Object {},
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "h2",
+            },
+            "type": "div",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <InjectIntl(ChallengeResultItem)
+                                browsedChallenge={
+                                                Object {
+                                                                "blurb": "Challenge 309 blurb",
+                                                                "description": "Challenge 309 description",
+                                                                "difficulty": 3,
+                                                                "id": 309,
+                                                                "name": "Challenge 309",
+                                                                "parent": Object {
+                                                                  "displayName": "foo",
+                                                                },
+                                                              }
+                                }
+                                challenge={
+                                                Object {
+                                                                "blurb": "Challenge 309 blurb",
+                                                                "description": "Challenge 309 description",
+                                                                "difficulty": 3,
+                                                                "id": 309,
+                                                                "name": "Challenge 309",
+                                                                "parent": Object {
+                                                                  "displayName": "foo",
+                                                                },
+                                                              }
+                                }
+                                challenges={
+                                                Array [
+                                                                Object {
+                                                                  "blurb": "Challenge 309 blurb",
+                                                                  "description": "Challenge 309 description",
+                                                                  "difficulty": 3,
+                                                                  "id": 309,
+                                                                  "name": "Challenge 309",
+                                                                  "parent": Object {
+                                                                    "displayName": "foo",
+                                                                  },
+                                                                },
+                                                              ]
+                                }
+                                intl={
+                                                Object {
+                                                                "formatMessage": [Function],
+                                                              }
+                                }
+                                saveChallenge={[Function]}
+                                startChallenge={[Function]}
+                                unsaveChallenge={[Function]}
+                                user={
+                                                Object {
+                                                                "id": 11,
+                                                                "savedChallenges": Array [],
+                                                              }
+                                }
+                />
+</li>,
+            ],
+            "className": "challenge-result-list__challenge-list",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "309",
+              "nodeType": "host",
+              "props": Object {
+                "children": <InjectIntl(ChallengeResultItem)
+                  browsedChallenge={
+                                    Object {
+                                                      "blurb": "Challenge 309 blurb",
+                                                      "description": "Challenge 309 description",
+                                                      "difficulty": 3,
+                                                      "id": 309,
+                                                      "name": "Challenge 309",
+                                                      "parent": Object {
+                                                        "displayName": "foo",
+                                                      },
+                                                    }
+                  }
+                  challenge={
+                                    Object {
+                                                      "blurb": "Challenge 309 blurb",
+                                                      "description": "Challenge 309 description",
+                                                      "difficulty": 3,
+                                                      "id": 309,
+                                                      "name": "Challenge 309",
+                                                      "parent": Object {
+                                                        "displayName": "foo",
+                                                      },
+                                                    }
+                  }
+                  challenges={
+                                    Array [
+                                                      Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      },
+                                                    ]
+                  }
+                  intl={
+                                    Object {
+                                                      "formatMessage": [Function],
+                                                    }
+                  }
+                  saveChallenge={[Function]}
+                  startChallenge={[Function]}
+                  unsaveChallenge={[Function]}
+                  user={
+                                    Object {
+                                                      "id": 11,
+                                                      "savedChallenges": Array [],
+                                                    }
+                  }
+/>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "browsedChallenge": Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                  "challenge": Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                  "challenges": Array [
+                    Object {
+                      "blurb": "Challenge 309 blurb",
+                      "description": "Challenge 309 description",
+                      "difficulty": 3,
+                      "id": 309,
+                      "name": "Challenge 309",
+                      "parent": Object {
+                        "displayName": "foo",
+                      },
+                    },
+                  ],
+                  "intl": Object {
+                    "formatMessage": [Function],
+                  },
+                  "saveChallenge": [Function],
+                  "startChallenge": [Function],
+                  "unsaveChallenge": [Function],
+                  "user": Object {
+                    "id": 11,
+                    "savedChallenges": Array [],
+                  },
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`doesn't duplicate actively browsed challenge in the result list 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengeResultList
+    browsedChallenge={
+        Object {
+            "blurb": "Challenge 309 blurb",
+            "description": "Challenge 309 description",
+            "difficulty": 3,
+            "id": 309,
+            "name": "Challenge 309",
+            "parent": Object {
+              "displayName": "foo",
+            },
+          }
+    }
+    challenges={
+        Array [
+            Object {
+              "blurb": "Challenge 309 blurb",
+              "description": "Challenge 309 description",
+              "difficulty": 3,
+              "id": 309,
+              "name": "Challenge 309",
+              "parent": Object {
+                "displayName": "foo",
+              },
+            },
+          ]
+    }
+    intl={
+        Object {
+            "formatMessage": [Function],
+          }
+    }
+    saveChallenge={[Function]}
+    startChallenge={[Function]}
+    unsaveChallenge={[Function]}
+    user={
+        Object {
+            "id": 11,
+            "savedChallenges": Array [],
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="level challenge-result-list--heading"
+>
+          <div
+                    className="level-left"
+          >
+                    <h2
+                              className="title is-4"
+                    >
+                              <FormattedMessage
+                                        defaultMessage="Challenges"
+                                        id="Challenge.results.heading"
+                                        values={Object {}}
+                              />
+                    </h2>
+          </div>
+</div>,
+        <ul
+          className="challenge-result-list__challenge-list"
+>
+          <li>
+                    <InjectIntl(ChallengeResultItem)
+                              browsedChallenge={
+                                        Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                }
+                              }
+                              challenge={
+                                        Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                }
+                              }
+                              challenges={
+                                        Array [
+                                                  Object {
+                                                    "blurb": "Challenge 309 blurb",
+                                                    "description": "Challenge 309 description",
+                                                    "difficulty": 3,
+                                                    "id": 309,
+                                                    "name": "Challenge 309",
+                                                    "parent": Object {
+                                                      "displayName": "foo",
+                                                    },
+                                                  },
+                                                ]
+                              }
+                              intl={
+                                        Object {
+                                                  "formatMessage": [Function],
+                                                }
+                              }
+                              saveChallenge={[Function]}
+                              startChallenge={[Function]}
+                              unsaveChallenge={[Function]}
+                              user={
+                                        Object {
+                                                  "id": 11,
+                                                  "savedChallenges": Array [],
+                                                }
+                              }
+                    />
+          </li>
+</ul>,
+      ],
+      "className": "challenge-result-list",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="level-left"
+>
+            <h2
+                        className="title is-4"
+            >
+                        <FormattedMessage
+                                    defaultMessage="Challenges"
+                                    id="Challenge.results.heading"
+                                    values={Object {}}
+                        />
+            </h2>
+</div>,
+          "className": "level challenge-result-list--heading",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <h2
+              className="title is-4"
+>
+              <FormattedMessage
+                            defaultMessage="Challenges"
+                            id="Challenge.results.heading"
+                            values={Object {}}
+              />
+</h2>,
+            "className": "level-left",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <FormattedMessage
+                defaultMessage="Challenges"
+                id="Challenge.results.heading"
+                values={Object {}}
+/>,
+              "className": "title is-4",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultMessage": "Challenges",
+                "id": "Challenge.results.heading",
+                "values": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "h2",
+          },
+          "type": "div",
+        },
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li>
+              <InjectIntl(ChallengeResultItem)
+                            browsedChallenge={
+                                          Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      }
+                            }
+                            challenge={
+                                          Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      }
+                            }
+                            challenges={
+                                          Array [
+                                                        Object {
+                                                          "blurb": "Challenge 309 blurb",
+                                                          "description": "Challenge 309 description",
+                                                          "difficulty": 3,
+                                                          "id": 309,
+                                                          "name": "Challenge 309",
+                                                          "parent": Object {
+                                                            "displayName": "foo",
+                                                          },
+                                                        },
+                                                      ]
+                            }
+                            intl={
+                                          Object {
+                                                        "formatMessage": [Function],
+                                                      }
+                            }
+                            saveChallenge={[Function]}
+                            startChallenge={[Function]}
+                            unsaveChallenge={[Function]}
+                            user={
+                                          Object {
+                                                        "id": 11,
+                                                        "savedChallenges": Array [],
+                                                      }
+                            }
+              />
+</li>,
+          ],
+          "className": "challenge-result-list__challenge-list",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "309",
+            "nodeType": "host",
+            "props": Object {
+              "children": <InjectIntl(ChallengeResultItem)
+                browsedChallenge={
+                                Object {
+                                                "blurb": "Challenge 309 blurb",
+                                                "description": "Challenge 309 description",
+                                                "difficulty": 3,
+                                                "id": 309,
+                                                "name": "Challenge 309",
+                                                "parent": Object {
+                                                  "displayName": "foo",
+                                                },
+                                              }
+                }
+                challenge={
+                                Object {
+                                                "blurb": "Challenge 309 blurb",
+                                                "description": "Challenge 309 description",
+                                                "difficulty": 3,
+                                                "id": 309,
+                                                "name": "Challenge 309",
+                                                "parent": Object {
+                                                  "displayName": "foo",
+                                                },
+                                              }
+                }
+                challenges={
+                                Array [
+                                                Object {
+                                                  "blurb": "Challenge 309 blurb",
+                                                  "description": "Challenge 309 description",
+                                                  "difficulty": 3,
+                                                  "id": 309,
+                                                  "name": "Challenge 309",
+                                                  "parent": Object {
+                                                    "displayName": "foo",
+                                                  },
+                                                },
+                                              ]
+                }
+                intl={
+                                Object {
+                                                "formatMessage": [Function],
+                                              }
+                }
+                saveChallenge={[Function]}
+                startChallenge={[Function]}
+                unsaveChallenge={[Function]}
+                user={
+                                Object {
+                                                "id": 11,
+                                                "savedChallenges": Array [],
+                                              }
+                }
+/>,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "browsedChallenge": Object {
+                  "blurb": "Challenge 309 blurb",
+                  "description": "Challenge 309 description",
+                  "difficulty": 3,
+                  "id": 309,
+                  "name": "Challenge 309",
+                  "parent": Object {
+                    "displayName": "foo",
+                  },
+                },
+                "challenge": Object {
+                  "blurb": "Challenge 309 blurb",
+                  "description": "Challenge 309 description",
+                  "difficulty": 3,
+                  "id": 309,
+                  "name": "Challenge 309",
+                  "parent": Object {
+                    "displayName": "foo",
+                  },
+                },
+                "challenges": Array [
+                  Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                ],
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "saveChallenge": [Function],
+                "startChallenge": [Function],
+                "unsaveChallenge": [Function],
+                "user": Object {
+                  "id": 11,
+                  "savedChallenges": Array [],
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="level challenge-result-list--heading"
+>
+            <div
+                        className="level-left"
+            >
+                        <h2
+                                    className="title is-4"
+                        >
+                                    <FormattedMessage
+                                                defaultMessage="Challenges"
+                                                id="Challenge.results.heading"
+                                                values={Object {}}
+                                    />
+                        </h2>
+            </div>
+</div>,
+          <ul
+            className="challenge-result-list__challenge-list"
+>
+            <li>
+                        <InjectIntl(ChallengeResultItem)
+                                    browsedChallenge={
+                                                Object {
+                                                            "blurb": "Challenge 309 blurb",
+                                                            "description": "Challenge 309 description",
+                                                            "difficulty": 3,
+                                                            "id": 309,
+                                                            "name": "Challenge 309",
+                                                            "parent": Object {
+                                                              "displayName": "foo",
+                                                            },
+                                                          }
+                                    }
+                                    challenge={
+                                                Object {
+                                                            "blurb": "Challenge 309 blurb",
+                                                            "description": "Challenge 309 description",
+                                                            "difficulty": 3,
+                                                            "id": 309,
+                                                            "name": "Challenge 309",
+                                                            "parent": Object {
+                                                              "displayName": "foo",
+                                                            },
+                                                          }
+                                    }
+                                    challenges={
+                                                Array [
+                                                            Object {
+                                                              "blurb": "Challenge 309 blurb",
+                                                              "description": "Challenge 309 description",
+                                                              "difficulty": 3,
+                                                              "id": 309,
+                                                              "name": "Challenge 309",
+                                                              "parent": Object {
+                                                                "displayName": "foo",
+                                                              },
+                                                            },
+                                                          ]
+                                    }
+                                    intl={
+                                                Object {
+                                                            "formatMessage": [Function],
+                                                          }
+                                    }
+                                    saveChallenge={[Function]}
+                                    startChallenge={[Function]}
+                                    unsaveChallenge={[Function]}
+                                    user={
+                                                Object {
+                                                            "id": 11,
+                                                            "savedChallenges": Array [],
+                                                          }
+                                    }
+                        />
+            </li>
+</ul>,
+        ],
+        "className": "challenge-result-list",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <div
+              className="level-left"
+>
+              <h2
+                            className="title is-4"
+              >
+                            <FormattedMessage
+                                          defaultMessage="Challenges"
+                                          id="Challenge.results.heading"
+                                          values={Object {}}
+                            />
+              </h2>
+</div>,
+            "className": "level challenge-result-list--heading",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h2
+                className="title is-4"
+>
+                <FormattedMessage
+                                defaultMessage="Challenges"
+                                id="Challenge.results.heading"
+                                values={Object {}}
+                />
+</h2>,
+              "className": "level-left",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <FormattedMessage
+                  defaultMessage="Challenges"
+                  id="Challenge.results.heading"
+                  values={Object {}}
+/>,
+                "className": "title is-4",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "defaultMessage": "Challenges",
+                  "id": "Challenge.results.heading",
+                  "values": Object {},
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "h2",
+            },
+            "type": "div",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <InjectIntl(ChallengeResultItem)
+                                browsedChallenge={
+                                                Object {
+                                                                "blurb": "Challenge 309 blurb",
+                                                                "description": "Challenge 309 description",
+                                                                "difficulty": 3,
+                                                                "id": 309,
+                                                                "name": "Challenge 309",
+                                                                "parent": Object {
+                                                                  "displayName": "foo",
+                                                                },
+                                                              }
+                                }
+                                challenge={
+                                                Object {
+                                                                "blurb": "Challenge 309 blurb",
+                                                                "description": "Challenge 309 description",
+                                                                "difficulty": 3,
+                                                                "id": 309,
+                                                                "name": "Challenge 309",
+                                                                "parent": Object {
+                                                                  "displayName": "foo",
+                                                                },
+                                                              }
+                                }
+                                challenges={
+                                                Array [
+                                                                Object {
+                                                                  "blurb": "Challenge 309 blurb",
+                                                                  "description": "Challenge 309 description",
+                                                                  "difficulty": 3,
+                                                                  "id": 309,
+                                                                  "name": "Challenge 309",
+                                                                  "parent": Object {
+                                                                    "displayName": "foo",
+                                                                  },
+                                                                },
+                                                              ]
+                                }
+                                intl={
+                                                Object {
+                                                                "formatMessage": [Function],
+                                                              }
+                                }
+                                saveChallenge={[Function]}
+                                startChallenge={[Function]}
+                                unsaveChallenge={[Function]}
+                                user={
+                                                Object {
+                                                                "id": 11,
+                                                                "savedChallenges": Array [],
+                                                              }
+                                }
+                />
+</li>,
+            ],
+            "className": "challenge-result-list__challenge-list",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "309",
+              "nodeType": "host",
+              "props": Object {
+                "children": <InjectIntl(ChallengeResultItem)
+                  browsedChallenge={
+                                    Object {
+                                                      "blurb": "Challenge 309 blurb",
+                                                      "description": "Challenge 309 description",
+                                                      "difficulty": 3,
+                                                      "id": 309,
+                                                      "name": "Challenge 309",
+                                                      "parent": Object {
+                                                        "displayName": "foo",
+                                                      },
+                                                    }
+                  }
+                  challenge={
+                                    Object {
+                                                      "blurb": "Challenge 309 blurb",
+                                                      "description": "Challenge 309 description",
+                                                      "difficulty": 3,
+                                                      "id": 309,
+                                                      "name": "Challenge 309",
+                                                      "parent": Object {
+                                                        "displayName": "foo",
+                                                      },
+                                                    }
+                  }
+                  challenges={
+                                    Array [
+                                                      Object {
+                                                        "blurb": "Challenge 309 blurb",
+                                                        "description": "Challenge 309 description",
+                                                        "difficulty": 3,
+                                                        "id": 309,
+                                                        "name": "Challenge 309",
+                                                        "parent": Object {
+                                                          "displayName": "foo",
+                                                        },
+                                                      },
+                                                    ]
+                  }
+                  intl={
+                                    Object {
+                                                      "formatMessage": [Function],
+                                                    }
+                  }
+                  saveChallenge={[Function]}
+                  startChallenge={[Function]}
+                  unsaveChallenge={[Function]}
+                  user={
+                                    Object {
+                                                      "id": 11,
+                                                      "savedChallenges": Array [],
+                                                    }
+                  }
+/>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "browsedChallenge": Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                  "challenge": Object {
+                    "blurb": "Challenge 309 blurb",
+                    "description": "Challenge 309 description",
+                    "difficulty": 3,
+                    "id": 309,
+                    "name": "Challenge 309",
+                    "parent": Object {
+                      "displayName": "foo",
+                    },
+                  },
+                  "challenges": Array [
+                    Object {
+                      "blurb": "Challenge 309 blurb",
+                      "description": "Challenge 309 description",
+                      "difficulty": 3,
+                      "id": 309,
+                      "name": "Challenge 309",
+                      "parent": Object {
+                        "displayName": "foo",
+                      },
+                    },
+                  ],
+                  "intl": Object {
+                    "formatMessage": [Function],
+                  },
+                  "saveChallenge": [Function],
+                  "startChallenge": [Function],
+                  "unsaveChallenge": [Function],
+                  "user": Object {
+                    "id": 11,
+                    "savedChallenges": Array [],
+                  },
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
 exports[`renders with a busySpinner if props fetchingChallenges 1`] = `
 ShallowWrapper {
   "length": 1,

--- a/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
+++ b/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
@@ -56,7 +56,7 @@ ShallowWrapper {
                     className="inline full-screen-height with-shadow challenge-pane__results"
                     isActive={true}
           >
-                    <Connect(Connect(Connect(Connect(Connect(Component)))))
+                    <Connect(Connect(Connect(Connect(Component))))
                               intl={
                                         Object {
                                                   "formatMessage": [Function],
@@ -127,7 +127,7 @@ ShallowWrapper {
               className="inline full-screen-height with-shadow challenge-pane__results"
               isActive={true}
 >
-              <Connect(Connect(Connect(Connect(Connect(Component)))))
+              <Connect(Connect(Connect(Connect(Component))))
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
@@ -173,7 +173,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
-              "children": <Connect(Connect(Connect(Connect(Connect(Component)))))
+              "children": <Connect(Connect(Connect(Connect(Component))))
                 intl={
                                 Object {
                                                 "formatMessage": [Function],
@@ -298,7 +298,7 @@ ShallowWrapper {
                         className="inline full-screen-height with-shadow challenge-pane__results"
                         isActive={true}
             >
-                        <Connect(Connect(Connect(Connect(Connect(Component)))))
+                        <Connect(Connect(Connect(Connect(Component))))
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
@@ -369,7 +369,7 @@ ShallowWrapper {
                 className="inline full-screen-height with-shadow challenge-pane__results"
                 isActive={true}
 >
-                <Connect(Connect(Connect(Connect(Connect(Component)))))
+                <Connect(Connect(Connect(Connect(Component))))
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
@@ -415,7 +415,7 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "class",
               "props": Object {
-                "children": <Connect(Connect(Connect(Connect(Connect(Component)))))
+                "children": <Connect(Connect(Connect(Connect(Component))))
                   intl={
                                     Object {
                                                       "formatMessage": [Function],

--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -1,39 +1,16 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { LatLng } from 'leaflet'
 import _get from 'lodash/get'
-import _isNumber from 'lodash/isNumber'
 import _isObject from 'lodash/isObject'
-import _filter from 'lodash/filter'
-import _each from 'lodash/each'
-import _sample from 'lodash/sample'
+import _find from 'lodash/find'
 import _omit from 'lodash/omit'
-import _isEqual from 'lodash/isEqual'
-import { loadRandomTaskFromChallenge,
-         fetchClusteredTasks } from '../../../services/Task/Task'
-import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
-import { BasemapLayerSources }
-       from '../../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
-import { changeVisibleLayer } from '../../../services/VisibleLayer/VisibleLayer'
-import { buildError, addError } from '../../../services/Error/Error'
-import WithMapBounds from '../WithMapBounds/WithMapBounds'
+import WithClusteredTasks from '../WithClusteredTasks/WithClusteredTasks'
 
 /**
- * WithBrowsedChallenge provides functions for starting and stopping browsing of
- * a challenge, and passes down the challenge being actively browsed (if any).
- * Once browsing begins, the clustered tasks for the challenge are fetched and
- * passed down once loaded.
- *
- * A startChallenge function is also provided, and can be used to begin work
- * on the given challenge. Typically this will be the same as the actively
- * browsed challenge, but it doesn't need to be. If it is the same, and if
- * valid bounds of the challenge map are available, then an attempt is made to
- * begin with a task that is currently visible to the user on the map; otherwise
- * a random task from the challenge is simply loaded.
- *
- * > Note: unlike most data retrievals, clustered tasks are not stored in the
- * > redux store due to their potentially very large size. Instead they're
- * > simply represented here in local state.
+ * WithBrowsedChallenge provides functions for starting and stopping browsing
+ * of a challenge, and passes down the challenge being actively browsed (if
+ * any). Once browsing begins, fetching of the challenge's clustered tasks is
+ * initiated.
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
@@ -41,13 +18,42 @@ export const WithBrowsedChallenge = function(WrappedComponent) {
   return class extends Component {
     state = {
       browsedChallenge: null,
-      tasks: [],
-      loadingClusteredTasks: false,
     }
-    
-    shouldComponentUpdate(nextProps, nextState) {
-      // Only re-render if our state changes.
-      return !_isEqual(nextState, this.state)
+
+    /**
+     * Updates the local state to set the browsedChallenge to that indicated in
+     * the current route (if it's different), as well as kicking off loading of
+     * the challenge's clustered tasks.
+     *
+     * @private
+     */
+    updateBrowsedChallenge = props => {
+      const challengeId = parseInt(_get(props, 'match.params.challengeId'), 10)
+
+      if (!isNaN(challengeId)) {
+        if (_get(this.state, 'browsedChallenge.id') !== challengeId) {
+          const challenge = _find(props.challenges, {id: challengeId})
+
+          if (_isObject(challenge)) {
+            this.setState({browsedChallenge: challenge})
+
+            if (challenge.id !== _get(this.props, 'clusteredTasks.challengeId')) {
+              this.props.fetchClusteredTasks(challenge.id)
+            }
+          }
+        }
+      }
+      else if (_isObject(this.state.browsedChallenge)) {
+        this.setState({browsedChallenge: null})
+      }
+    }
+
+    componentWillMount() {
+      this.updateBrowsedChallenge(this.props)
+    }
+
+    componentWillReceiveProps(nextProps) {
+      this.updateBrowsedChallenge(nextProps)
     }
 
     /**
@@ -55,16 +61,7 @@ export const WithBrowsedChallenge = function(WrappedComponent) {
      * during challenge discovery.
      */
     startBrowsingChallenge = challenge => {
-      if (_isObject(challenge)) {
-        this.setState({browsedChallenge: challenge,
-                       tasks: [], loadingClusteredTasks: true})
-
-        this.props.fetchClusteredTasks(challenge.id).then(
-          tasks => this.setState({tasks, loadingClusteredTasks: false})
-        ).catch(error =>
-          this.setState({loadingClusteredTasks: false})
-        )
-      }
+      this.props.history.push(`/browse/challenges/${challenge.id}`)
     }
 
     /**
@@ -72,108 +69,15 @@ export const WithBrowsedChallenge = function(WrappedComponent) {
      * challenge during challenge discovery.
      */
     stopBrowsingChallenge = () => {
-      this.setState({browsedChallenge: null,
-                     tasks: [], loadingClusteredTasks: false})
-    }
-
-    /**
-     * Start working on the given challenge. It doesn't necessarily have to be the
-     * current browsed challenge, but if it is then we'll try to start with a
-     * task that is visible within the current challenge map bounds.
-     */
-    startChallenge = challenge => {
-      const visibleTask = this.chooseVisibleTask(challenge)
-      if (visibleTask) {
-        this.workOnTask(challenge, visibleTask)
-      }
-      else {
-        this.props.loadRandomTaskFromChallenge(challenge.id).then(task => {
-          this.workOnTask(challenge, task)
-        })
-      }
-    }
-
-    /**
-     * Choose a task within the given challenge that is visible within the
-     * challenge map bounds, if possible (and if the given challenge is the
-     * one we're actively browsing).
-     *
-     * @private
-     */
-    chooseVisibleTask = challenge => {
-      const challengeBounds = _get(this.props, 'mapBounds.challenge')
-
-      if (challenge.id !== _get(this.state, 'browsedChallenge.id') ||
-          challenge.id !== _get(challengeBounds, 'challengeId') ||
-          _get(this.state, 'tasks.length', 0) === 0) {
-        return null
-      }
-
-      const createdTasks = []
-      const skippedTasks = []
-
-      _each(this.state.tasks, task => {
-        if (task.point &&
-            challengeBounds.bounds.contains(new LatLng(task.point.lat, task.point.lng))) {
-          if (task.status === TaskStatus.created) {
-            createdTasks.push(task)
-          }
-          else if(task.status === TaskStatus.skipped) {
-            skippedTasks.push(task)
-          }
-        }
-      })
-
-      // Choose created tasks over skipped tasks, when possible
-      return createdTasks.length > 0 ? _sample(createdTasks) : _sample(skippedTasks)
-    }
-
-    /**
-     * Opens the given task to begin work on.
-     *
-     * @private
-     */
-    workOnTask = (challenge, task) => {
-      if (task) {
-        this.props.history.push(`/challenge/${task.parent}/task/${task.id}`)
-
-        // If the challenge defines a default basemap layer, use it.
-        const defaultLayer = BasemapLayerSources[challenge.defaultBasemap]
-        if (defaultLayer) {
-          this.props.changeVisibleLayer(defaultLayer)
-        }
-      }
-      else {
-        // No tasks left in this challenge, back to challenges.
-        this.props.addError(buildError(
-          "Task.none", "No tasks remain in this challenge."
-        ))
-      }
+      this.props.history.push('/browse/challenges')
     }
 
     render() {
-      const challengeId = _get(this.state, 'browsedChallenge.id')
-      let clusteredTasks = []
-
-      if (_isNumber(challengeId)) {
-        clusteredTasks = _filter(this.state.tasks,
-                                 task => task.parent === challengeId && task.point)
-      }
-
       return (
-        <WrappedComponent clusteredTasks={clusteredTasks}
+        <WrappedComponent browsedChallenge = {this.state.browsedChallenge}
                           startBrowsingChallenge={this.startBrowsingChallenge}
                           stopBrowsingChallenge={this.stopBrowsingChallenge}
-                          startChallenge={this.startChallenge}
-                          browsedChallenge = {this.state.browsedChallenge}
-                          loadingClusteredTasks={this.state.loadingClusteredTasks}
-                          {..._omit(this.props, [
-                            'entities',
-                            'fetchClusteredTasks',
-                            'loadRandomTaskFromChallenge',
-                            'changeVisibleLayer',
-                            'addError',
-                          ])} />
+                          {..._omit(this.props, 'entities')} />
       )
     }
   }
@@ -183,20 +87,5 @@ const mapStateToProps = state => ({
   entities: state.entities,
 })
 
-const mapDispatchToProps = dispatch => ({
-  fetchClusteredTasks: challengeId =>
-    dispatch(fetchClusteredTasks(challengeId)),
-
-  loadRandomTaskFromChallenge: challengeId =>
-    dispatch(loadRandomTaskFromChallenge(challengeId)),
-
-  changeVisibleLayer: layer =>
-    dispatch(changeVisibleLayer(layer)),
-
-  addError: error => dispatch(addError),
-})
-
 export default WrappedComponent =>
-  connect(mapStateToProps,
-          mapDispatchToProps)(WithMapBounds(WithBrowsedChallenge(WrappedComponent)))
-
+  connect(mapStateToProps)(WithClusteredTasks(WithBrowsedChallenge(WrappedComponent)))

--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.test.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.test.js
@@ -6,26 +6,31 @@ import { WithBrowsedChallenge,
          mapStateToProps, mapDispatchToProps, } from './WithBrowsedChallenge'
 import AsEndUser from '../../../services/User/AsEndUser'
 import { denormalize } from 'normalizr'
-import { loadRandomTaskFromChallenge,
-         fetchClusteredTasks } from '../../../services/Task/Task'
-import { changeVisibleLayer } from '../../../services/VisibleLayer/VisibleLayer'
-import { buildError, addError } from '../../../services/Error/Error'
+import { loadRandomTaskFromChallenge } from '../../../services/Task/Task'
 import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
-
-jest.mock('../../../services/Task/Task')
-jest.mock('../../../services/VisibleLayer/VisibleLayer')
-jest.mock('../../../services/Error/Error')
 
 let basicState = null
 let challenge = null
-let taskInBoundsCreated = null
-let taskInBoundsSkipped = null
-let taskOutOfBounds = null
-let tasks = null
+let challenges = null
 let WrappedComponent = null
+let history = null
+let match = null
+let fetchTasks = null
 
 beforeEach(() => {
-  challenge = {id: 123}
+  challenges = [
+    {
+      id: 123,
+    },
+    {
+      id: 456,
+    },
+    {
+      id: 789,
+    },
+  ]
+
+  challenge = challenges[0]
 
   basicState = {
     mapBounds: {
@@ -37,134 +42,41 @@ beforeEach(() => {
     },
   }
 
-  taskInBoundsCreated = {
-    id: 987,
-    parent: challenge.id,
-    point: {lng: 7, lat: 8},
-    status: TaskStatus.created,
+  match = {
+    params: {
+      challengeId: challenge.id,
+    }
   }
 
-  taskInBoundsSkipped = {
-    id: 654,
-    parent: challenge.id,
-    point: {lng: -1, lat: -5},
-    status: TaskStatus.skipped,
+  history = {
+    push: jest.fn(),
   }
 
-  taskOutOfBounds = {
-    id: 321,
-    parent: challenge.id,
-    point: {lng: 20, lat: 30},
-    status: TaskStatus.created,
-  }
-
-  tasks = [
-    taskInBoundsCreated,
-    taskInBoundsSkipped,
-    taskOutOfBounds,
-  ]
+  fetchTasks = jest.fn()
 
   WrappedComponent = WithBrowsedChallenge(() => <div className="child" />)
 })
 
-test("startBrowsing causes the given challenge to be passed down", () => {
+test("the browsed challenge from the route match is passed down", () => {
   const challenge = {id: 123}
-  const fetchTasks = jest.fn(challengeId => Promise.resolve([]))
 
   const wrapper = shallow(
-    <WrappedComponent fetchClusteredTasks={fetchTasks} />
+    <WrappedComponent match={match}
+                      fetchClusteredTasks={fetchTasks}
+                      history={history}
+                      challenges={challenges} />
   )
-
-  wrapper.instance().startBrowsingChallenge(challenge)
-  wrapper.update()
 
   expect(wrapper.props().browsedChallenge).toEqual(challenge)
 })
 
-test("startBrowsing causes clustered tasks to be loaded", async () => {
-  const fetchTasks = jest.fn(challengeId => Promise.resolve(tasks))
-
+test("clustered task loading is kicked off for a new browsed challenge", async () => {
   const wrapper = shallow(
-    <WrappedComponent fetchClusteredTasks={fetchTasks} />
+    <WrappedComponent match={match}
+                      fetchClusteredTasks={fetchTasks}
+                      history={history}
+                      challenges={challenges} />
   )
-
-  await wrapper.instance().startBrowsingChallenge(challenge)
-  wrapper.update()
 
   expect(fetchTasks).toHaveBeenCalledWith(challenge.id)
-  expect(wrapper.instance().state.tasks).toEqual(tasks)
-})
-
-test("clustered tasks are passed down", async () => {
-  const fetchTasks = jest.fn(challengeId => Promise.resolve(tasks))
-
-  const wrapper = shallow(
-    <WrappedComponent fetchClusteredTasks={fetchTasks} />
-  )
-
-  await wrapper.instance().startBrowsingChallenge(challenge)
-  wrapper.update()
-
-  expect(fetchTasks).toHaveBeenCalledWith(challenge.id)
-  expect(wrapper.props().clusteredTasks).toEqual(tasks)
-})
-
-test("stopBrowsing removes the browsed challenge and tasks", async () => {
-  const fetchTasks = jest.fn(challengeId => Promise.resolve(tasks))
-
-  const wrapper = shallow(
-    <WrappedComponent fetchClusteredTasks={fetchTasks} />
-  )
-
-  await wrapper.instance().startBrowsingChallenge(challenge)
-  wrapper.update()
-  expect(wrapper.instance().state.browsedChallenge).toEqual(challenge)
-  expect(wrapper.instance().state.tasks).toEqual(tasks)
-
-  wrapper.instance().stopBrowsingChallenge(challenge)
-  wrapper.update()
-  expect(wrapper.instance().state.browsedChallenge).toEqual(null)
-  expect(wrapper.instance().state.tasks).toEqual([])
-})
-
-test("chooseVisibleTask opts for a created task within the challenge bounds", () => {
-  const wrapper = shallow(
-    <WrappedComponent mapBounds={basicState.mapBounds} />
-  )
-
-  wrapper.instance().setState({browsedChallenge: challenge, tasks: tasks})
-  wrapper.update()
-
-  expect(
-    wrapper.instance().chooseVisibleTask(challenge)
-  ).toEqual(taskInBoundsCreated)
-})
-
-test("chooseVisibleTask will choose a skipped status if no created are available", () => {
-  const wrapper = shallow(
-    <WrappedComponent mapBounds={basicState.mapBounds} />
-  )
-
-  taskInBoundsCreated.status = TaskStatus.alreadyFixed
-  wrapper.instance().setState({browsedChallenge: challenge, tasks: tasks})
-  wrapper.update()
-
-  expect(
-    wrapper.instance().chooseVisibleTask(challenge)
-  ).toEqual(taskInBoundsSkipped)
-})
-
-test("chooseVisibleTask skips tasks not in a created or skipped status", () => {
-  const wrapper = shallow(
-    <WrappedComponent mapBounds={basicState.mapBounds} />
-  )
-
-  taskInBoundsCreated.status = TaskStatus.alreadyFixed
-  taskInBoundsSkipped.status = TaskStatus.alreadyFixed
-  wrapper.instance().setState({browsedChallenge: challenge, tasks: tasks})
-  wrapper.update()
-
-  expect(
-    wrapper.instance().chooseVisibleTask(challenge)
-  ).toBeFalsy()
 })

--- a/src/components/HOCs/WithClusteredTasks/WithClusteredTasks.js
+++ b/src/components/HOCs/WithClusteredTasks/WithClusteredTasks.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux'
+import { fetchClusteredTasks }
+       from '../../../services/Task/ClusteredTask'
+
+/**
+ * WithClusteredTasks provides a clusteredTasks prop containing the current
+ * clustered task data from the redux store, as well as a fetchClusteredTasks
+ * function for retrieving the clustered tasks for a given challenge.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+const WithClusteredTasks = WrappedComponent =>
+  connect(mapStateToProps, mapDispatchToProps)(WrappedComponent)
+
+export const mapStateToProps = state => ({
+  clusteredTasks: state.currentClusteredTasks,
+})
+
+export const mapDispatchToProps = dispatch => ({
+  fetchClusteredTasks: challengeId =>
+    dispatch(fetchClusteredTasks(challengeId)),
+})
+
+export default WithClusteredTasks

--- a/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
+++ b/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
@@ -1,0 +1,103 @@
+import { connect } from 'react-redux'
+import { LatLng } from 'leaflet'
+import _get from 'lodash/get'
+import _sample from 'lodash/sample'
+import { loadRandomTaskFromChallenge} from '../../../services/Task/Task'
+import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
+import { BasemapLayerSources }
+       from '../../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
+import { changeVisibleLayer } from '../../../services/VisibleLayer/VisibleLayer'
+import { buildError, addError } from '../../../services/Error/Error'
+
+/**
+ * WithStartChallenge passes down a startChallenge function that, when invoked,
+ * will load a task from the given challenge for the user to work on. If the
+ * challenge is being actively browsed, then an attempt is made to begin the
+ * with a task that is currently visible to the user in the challenge map;
+ * otherwise a random task from the challenge is loaded.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export const WithStartChallenge = WrappedComponent =>
+  connect(null, mapDispatchToProps)(WrappedComponent)
+
+/**
+ * Return a task within the given challenge that is visible within the
+ * challenge map bounds, if possible. Only tasks in a created or skipped
+ * status are considered.
+ *
+ * @private
+ */
+export const chooseVisibleTask = (challenge, challengeBounds, clusteredTasks) => {
+  if (challenge.id !== clusteredTasks.challengeId ||
+      _get(clusteredTasks, 'tasks.length', 0) === 0) {
+    return null
+  }
+
+  const createdTasks = []
+  const skippedTasks = []
+  let task = null
+
+  for (let i = 0; i < clusteredTasks.tasks.length; i++) {
+    task = clusteredTasks.tasks[i]
+
+    if (task.point &&
+        challengeBounds.bounds.contains(new LatLng(task.point.lat, task.point.lng))) {
+      if (task.status === TaskStatus.created) {
+        createdTasks.push(task)
+      }
+      else if(task.status === TaskStatus.skipped) {
+        skippedTasks.push(task)
+      }
+    }
+  }
+
+  // Choose created tasks over skipped tasks, when possible
+  return createdTasks.length > 0 ? _sample(createdTasks) : _sample(skippedTasks)
+}
+
+/**
+ * Opens the given task to begin work on.
+ *
+ * @private
+ */
+export const openTask = (dispatch, challenge, task, history) => {
+  if (task) {
+    history.push(`/challenge/${task.parent}/task/${task.id}`)
+
+    // If the challenge defines a default basemap layer, use it.
+    const defaultLayer = BasemapLayerSources[challenge.defaultBasemap]
+    if (defaultLayer) {
+      dispatch(changeVisibleLayer(defaultLayer))
+    }
+  }
+  else {
+    // No tasks left in this challenge, back to challenges.
+    dispatch(addError(buildError(
+      "Task.none", "No tasks remain in this challenge."
+    )))
+  }
+}
+
+export const mapDispatchToProps = (dispatch, ownProps) => ({
+  /**
+   * Start working on the given challenge. If it's the currently browsed
+   * challenge, an attempt is made to start with a task that is visible within
+   * the current challenge map bounds. Otherwise a random task is loaded.
+   */
+  startChallenge: challenge => {
+    const visibleTask = chooseVisibleTask(challenge,
+                                          _get(ownProps, 'mapBounds.challenge'),
+                                          ownProps.clusteredTasks)
+    if (visibleTask) {
+      openTask(dispatch, challenge, visibleTask, ownProps.history)
+    }
+    else {
+      dispatch(loadRandomTaskFromChallenge(challenge.id)).then(task => {
+        openTask(dispatch, challenge, task, ownProps.history)
+      })
+    }
+  }
+})
+
+export default WithStartChallenge

--- a/src/components/HOCs/WithStartChallenge/WithStartChallenge.test.js
+++ b/src/components/HOCs/WithStartChallenge/WithStartChallenge.test.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react'
+import { LatLngBounds } from 'leaflet'
+import _get from 'lodash/get'
+import _find from 'lodash/find'
+import { chooseVisibleTask, mapDispatchToProps, } from './WithStartChallenge'
+import AsEndUser from '../../../services/User/AsEndUser'
+import { denormalize } from 'normalizr'
+import { loadRandomTaskFromChallenge,
+         fetchClusteredTasks } from '../../../services/Task/Task'
+import { changeVisibleLayer } from '../../../services/VisibleLayer/VisibleLayer'
+import { buildError, addError } from '../../../services/Error/Error'
+import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
+
+jest.mock('../../../services/Task/Task')
+jest.mock('../../../services/VisibleLayer/VisibleLayer')
+jest.mock('../../../services/Error/Error')
+
+let basicState = null
+let challenge = null
+let taskInBoundsCreated = null
+let taskInBoundsSkipped = null
+let taskOutOfBounds = null
+let clusteredTasks = null
+let WrappedComponent = null
+
+beforeEach(() => {
+  challenge = {id: 123}
+
+  basicState = {
+    mapBounds: {
+      challenge: {
+        challengeId: challenge.id,
+        bounds: new LatLngBounds({lng: -10, lat: 10}, {lng: 10, lat: -10}),
+        zoom: 3,
+      }
+    },
+  }
+
+  taskInBoundsCreated = {
+    id: 987,
+    parent: challenge.id,
+    point: {lng: 7, lat: 8},
+    status: TaskStatus.created,
+  }
+
+  taskInBoundsSkipped = {
+    id: 654,
+    parent: challenge.id,
+    point: {lng: -1, lat: -5},
+    status: TaskStatus.skipped,
+  }
+
+  taskOutOfBounds = {
+    id: 321,
+    parent: challenge.id,
+    point: {lng: 20, lat: 30},
+    status: TaskStatus.created,
+  }
+
+  clusteredTasks = {
+    challengeId: challenge.id,
+    loading: false,
+    tasks: [
+      taskInBoundsCreated,
+      taskInBoundsSkipped,
+      taskOutOfBounds,
+    ],
+  }
+})
+
+test("chooseVisibleTask opts for a created task within the challenge bounds", () => {
+  expect(
+    chooseVisibleTask(challenge,
+                      basicState.mapBounds.challenge,
+                      clusteredTasks)
+).toEqual(taskInBoundsCreated)
+})
+
+test("chooseVisibleTask will choose a skipped status if no created are available", () => {
+  taskInBoundsCreated.status = TaskStatus.alreadyFixed
+
+  expect(
+    chooseVisibleTask(challenge,
+                      basicState.mapBounds.challenge,
+                      clusteredTasks)
+  ).toEqual(taskInBoundsSkipped)
+})
+
+test("chooseVisibleTask skips tasks not in a created or skipped status", () => {
+  taskInBoundsCreated.status = TaskStatus.alreadyFixed
+  taskInBoundsSkipped.status = TaskStatus.alreadyFixed
+
+  expect(
+   chooseVisibleTask(challenge,
+                     basicState.mapBounds.challenge,
+                     clusteredTasks)
+  ).toBeFalsy()
+})
+

--- a/src/components/LocatorMap/LocatorMap.js
+++ b/src/components/LocatorMap/LocatorMap.js
@@ -2,16 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { ZoomControl } from 'react-leaflet'
-import MarkerClusterGroup from 'react-leaflet-markercluster'
-import { point, featureCollection } from '@turf/helpers'
-import bbox from '@turf/bbox'
-import bboxPolygon from '@turf/bbox-polygon'
 import _get from 'lodash/get'
-import _isObject from 'lodash/isObject'
-import _each from 'lodash/each'
-import _map from 'lodash/map'
 import { latLng } from 'leaflet'
-import { TaskStatus } from '../../services/Task/TaskStatus/TaskStatus'
 import { ChallengeLocation }
        from '../../services/Challenge/ChallengeLocation/ChallengeLocation'
 import EnhancedMap from '../EnhancedMap/EnhancedMap'
@@ -20,7 +12,6 @@ import LayerToggle from '../EnhancedMap/LayerToggle/LayerToggle'
 import WithChallengeFilters from '../HOCs/WithChallengeFilters/WithChallengeFilters'
 import WithVisibleLayer from '../HOCs/WithVisibleLayer/WithVisibleLayer'
 import WithMapBounds from '../HOCs/WithMapBounds/WithMapBounds'
-import BusySpinner from '../BusySpinner/BusySpinner'
 
 // Setup child components with necessary HOCs
 const VisibleTileLayer = WithVisibleLayer(SourcedTileLayer)
@@ -39,8 +30,8 @@ const VisibleTileLayer = WithVisibleLayer(SourcedTileLayer)
  * > Note: because this map both updates bounds and accepts bounds, it must be
  * > careful to avoid an infinite loop. To do this, it treats the accepted
  * > mapBounds as initial bounds and only honors new bounds if they have the
- * > fromUserAction flag set to true. This component never sets that flag when
- * > dispatching new map bounds.
+ * > fromUserAction flag set to true. This component never sets that flag
+ * > itself when dispatching new map bounds.
  *
  * @see See EnhancedMap
  *
@@ -55,16 +46,6 @@ export class LocatorMap extends Component {
 
     // the layer has been changed, or
     if (nextProps.layerSourceName !== this.props.layerSourceName) {
-      return true
-    }
-
-    // the browsed challenge has changed, or
-    if (nextProps.browsedChallenge !== this.props.browsedChallenge) {
-      return true
-    }
-
-    // the loading status of clustered tasks change, or
-    if (nextProps.loadingClusteredTasks !== this.props.loadingClusteredTasks) {
       return true
     }
 
@@ -97,90 +78,27 @@ export class LocatorMap extends Component {
     }
 
     this.currentBounds = bounds
+    this.props.setLocatorMapBounds(bounds, zoom, fromUserAction)
 
-    // Update either the challenge bounds, if we're actively browsing a
-    // challenge, or the locator bounds if not.
-    if (_isObject(this.props.browsedChallenge)) {
-      this.props.setChallengeMapBounds(this.props.browsedChallenge.id,
-                                       bounds, zoom)
+    if (_get(this.props, 'challengeFilter.location') ===
+        ChallengeLocation.withinMapBounds) {
+      this.props.updateBoundedChallenges(bounds)
     }
-    else {
-      this.props.setLocatorMapBounds(bounds, zoom, fromUserAction)
-
-      if (_get(this.props, 'challengeFilter.location') ===
-          ChallengeLocation.withinMapBounds) {
-        this.props.updateBoundedChallenges(bounds)
-      }
-    }
-  }
-
-  markerClicked = marker => {
-    this.props.history.push(
-      `/challenge/${marker.options.challengeId}/task/${marker.options.taskId}`)
   }
 
   render() {
-    const isBrowsingChallenge = _isObject(this.props.browsedChallenge)
-    const isLoadingData = isBrowsingChallenge && this.props.loadingClusteredTasks
-
-    const markers = []
-    let bounding = null
-    if (isBrowsingChallenge) {
-      // Build the clustered task markers if we have clustered tasks
-      if (_get(this.props, 'clusteredTasks.length') > 0) {
-        _each(this.props.clusteredTasks, task => {
-          // Only show created or skipped tasks
-          if (task.status === TaskStatus.created ||
-              task.status === TaskStatus.skipped) {
-            markers.push({
-              position: [task.point.lat, task.point.lng],
-              options: {
-                challengeId: task.parent,
-                taskId: task.id,
-              },
-            })
-          }
-        })
-      }
-
-      // Get the challenge bounding so we know which part of the map to display.
-      // Right now API double-nests bounding, but that will likely change.
-      bounding = _get(this.props, 'browsedChallenge.bounding.bounding') ||
-                 _get(this.props, 'browsedChallenge.bounding')
-
-
-      // If the challenge doesn't have a bounding polygon, build one from the
-      // markers instead. This is extra work and requires waiting for the clustered
-      // task data to arrive, so not ideal.
-      if (!bounding && markers.length > 0) {
-        bounding = bboxPolygon(
-          bbox(featureCollection(
-            _map(markers, marker => point([marker.position[1], marker.position[0]]))
-          ))
-        )
-      }
-    }
-
     return (
-      <div key={_get(this.props, 'browsedChallenge.id') || 'locator'}
+      <div key='locator'
            className={classNames('full-screen-map', this.props.className)}>
         <LayerToggle {...this.props} />
         <EnhancedMap center={latLng(0, 45)} zoom={3} minZoom={2} maxZoom={18}
                      setInitialBounds={false}
-                     initialBounds = {(this.props.browsedChallenge && this.currentBounds) ||
-                                      _get(this.props, 'mapBounds.locator.bounds')}
+                     initialBounds = {_get(this.props, 'mapBounds.locator.bounds')}
                      zoomControl={false} animate={true}
-                     features={bounding}
-                     justFitFeatures={markers.length > 0}
                      onBoundsChange={this.updateBounds}>
           <ZoomControl position='topright' />
           <VisibleTileLayer defaultLayer={this.props.layerSourceName} />
-          {markers.length > 0 &&
-           <MarkerClusterGroup markers={markers} onMarkerClick={this.markerClicked} />
-          }
         </EnhancedMap>
-
-        {isLoadingData && <BusySpinner />}
       </div>
     )
   }
@@ -193,12 +111,8 @@ LocatorMap.propTypes = {
    * on updated mapBounds values.
    */
   mapBounds: PropTypes.object,
-  /** The current challenge being browsed, if any */
-  browsedChallenge: PropTypes.object,
   /** Invoked when the user moves the locator map */
   setLocatorMapBounds: PropTypes.func.isRequired,
-  /** Invoked when the user moves the map while browsing a challenge */
-  setChallengeMapBounds: PropTypes.func.isRequired,
   /** Name of default layer to display */
   layerSourceName: PropTypes.string,
   /** The currently enabled challenge filter, if any */

--- a/src/components/LocatorMap/LocatorMap.test.js
+++ b/src/components/LocatorMap/LocatorMap.test.js
@@ -16,7 +16,6 @@ beforeEach(() => {
     },
     layerSourceName: "foo",
     setLocatorMapBounds: jest.fn(),
-    setChallengeMapBounds: jest.fn(),
     updateBoundedChallenges: jest.fn(),
   }
 })
@@ -65,30 +64,6 @@ test("rerenders if the default layer name changes", () => {
   expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
 })
 
-test("rerenders if the challenge being browsed changes", () => {
-  const wrapper = shallow(
-    <LocatorMap {...basicProps} />
-  )
-
-  const newProps = _cloneDeep(basicProps)
-  newProps.browsedChallenge = {id: 456}
-
-  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
-})
-
-test("rerenders if the challenge's clustered tasks have loaded", () => {
-  basicProps.loadingClusteredTasks = false
-
-  const wrapper = shallow(
-    <LocatorMap {...basicProps} />
-  )
-
-  const newProps = _cloneDeep(basicProps)
-  newProps.loadingClusteredTasks = true
-
-  expect(wrapper.instance().shouldComponentUpdate(newProps)).toBe(true)
-})
-
 test("moving the map signals that the locator map bounds should be updated", () => {
   const bounds = [0, 0, 0, 0]
   const zoom = 3
@@ -99,23 +74,6 @@ test("moving the map signals that the locator map bounds should be updated", () 
 
   wrapper.instance().updateBounds(bounds, zoom, false)
   expect(basicProps.setLocatorMapBounds).toBeCalledWith(bounds, zoom, false)
-  expect(basicProps.setChallengeMapBounds).not.toBeCalled()
-})
-
-test("moving the map when browsing a challenge updates the challenge bounds", () => {
-  basicProps.browsedChallenge = {id: 123}
-  const bounds = [0, 0, 0, 0]
-  const zoom = 3
-
-  const wrapper = shallow(
-    <LocatorMap {...basicProps} />
-  )
-
-  wrapper.instance().updateBounds(bounds, zoom, false)
-  expect(
-    basicProps.setChallengeMapBounds
-  ).toBeCalledWith(basicProps.browsedChallenge.id, bounds, zoom)
-  expect(basicProps.setLocatorMapBounds).not.toBeCalled()
 })
 
 test("moving the map signals that the challenges should be updated if filtering on map bounds", () => {
@@ -141,30 +99,4 @@ test("moving the map doesn't signal challenges updates if not filtering on map b
 
   wrapper.instance().updateBounds(bounds, zoom, false)
   expect(basicProps.updateBoundedChallenges).not.toBeCalled()
-})
-
-test("a busy indicator is displayed if clustered tasks are loading", () => {
-  basicProps.browsedChallenge = {id: 123}
-  basicProps.loadingClusteredTasks = true
-
-  const wrapper = shallow(
-    <LocatorMap {...basicProps} />
-  )
-
-  expect(wrapper.find('BusySpinner').exists()).toBe(true)
-
-  expect(wrapper).toMatchSnapshot()
-})
-
-test("the busy indicator is removed once tasks are done loading", () => {
-  basicProps.browsedChallenge = {id: 123}
-  basicProps.loadingClusteredTasks = false
-
-  const wrapper = shallow(
-    <LocatorMap {...basicProps} />
-  )
-
-  expect(wrapper.find('BusySpinner').exists()).toBe(false)
-
-  expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
+++ b/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
@@ -1,428 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`a busy indicator is displayed if clustered tasks are loading 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <LocatorMap
-    browsedChallenge={
-        Object {
-            "id": 123,
-          }
-    }
-    layerSourceName="foo"
-    loadingClusteredTasks={true}
-    mapBounds={
-        Object {
-            "locator": Object {
-              "bounds": Object {
-                "_northEast": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-                "_southWest": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-              },
-            },
-          }
-    }
-    setChallengeMapBounds={[Function]}
-    setLocatorMapBounds={[Function]}
-    updateBoundedChallenges={[Function]}
-/>,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": "123",
-    "nodeType": "host",
-    "props": Object {
-      "children": Array [
-        <Connect(Component)
-          browsedChallenge={
-                    Object {
-                              "id": 123,
-                            }
-          }
-          layerSourceName="foo"
-          loadingClusteredTasks={true}
-          mapBounds={
-                    Object {
-                              "locator": Object {
-                                "bounds": Object {
-                                  "_northEast": Object {
-                                    "lat": 0,
-                                    "lng": 0,
-                                  },
-                                  "_southWest": Object {
-                                    "lat": 0,
-                                    "lng": 0,
-                                  },
-                                },
-                              },
-                            }
-          }
-          setChallengeMapBounds={[Function]}
-          setLocatorMapBounds={[Function]}
-          updateBoundedChallenges={[Function]}
-/>,
-        <EnhancedMap
-          animate={true}
-          center={
-                    Object {
-                              "lat": 0,
-                              "lng": 45,
-                            }
-          }
-          features={undefined}
-          initialBounds={
-                    Object {
-                              "_northEast": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                              "_southWest": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                            }
-          }
-          justFitFeatures={false}
-          maxZoom={18}
-          minZoom={2}
-          onBoundsChange={[Function]}
-          setInitialBounds={false}
-          zoom={3}
-          zoomControl={false}
->
-          <ZoomControl
-                    position="topright"
-          />
-          <Connect(InjectIntl(SourcedTileLayer))
-                    defaultLayer="foo"
-          />
-</EnhancedMap>,
-        <BusySpinner />,
-      ],
-      "className": "full-screen-map",
-    },
-    "ref": null,
-    "rendered": Array [
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "browsedChallenge": Object {
-            "id": 123,
-          },
-          "layerSourceName": "foo",
-          "loadingClusteredTasks": true,
-          "mapBounds": Object {
-            "locator": Object {
-              "bounds": Object {
-                "_northEast": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-                "_southWest": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-              },
-            },
-          },
-          "setChallengeMapBounds": [Function],
-          "setLocatorMapBounds": [Function],
-          "updateBoundedChallenges": [Function],
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "animate": true,
-          "center": Object {
-            "lat": 0,
-            "lng": 45,
-          },
-          "children": Array [
-            <ZoomControl
-              position="topright"
-/>,
-            <Connect(InjectIntl(SourcedTileLayer))
-              defaultLayer="foo"
-/>,
-            false,
-          ],
-          "features": undefined,
-          "initialBounds": Object {
-            "_northEast": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-            "_southWest": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-          },
-          "justFitFeatures": false,
-          "maxZoom": 18,
-          "minZoom": 2,
-          "onBoundsChange": [Function],
-          "setInitialBounds": false,
-          "zoom": 3,
-          "zoomControl": false,
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "position": "topright",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "defaultLayer": "foo",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          false,
-        ],
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {},
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-    ],
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": "123",
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          <Connect(Component)
-            browsedChallenge={
-                        Object {
-                                    "id": 123,
-                                  }
-            }
-            layerSourceName="foo"
-            loadingClusteredTasks={true}
-            mapBounds={
-                        Object {
-                                    "locator": Object {
-                                      "bounds": Object {
-                                        "_northEast": Object {
-                                          "lat": 0,
-                                          "lng": 0,
-                                        },
-                                        "_southWest": Object {
-                                          "lat": 0,
-                                          "lng": 0,
-                                        },
-                                      },
-                                    },
-                                  }
-            }
-            setChallengeMapBounds={[Function]}
-            setLocatorMapBounds={[Function]}
-            updateBoundedChallenges={[Function]}
-/>,
-          <EnhancedMap
-            animate={true}
-            center={
-                        Object {
-                                    "lat": 0,
-                                    "lng": 45,
-                                  }
-            }
-            features={undefined}
-            initialBounds={
-                        Object {
-                                    "_northEast": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                    "_southWest": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                  }
-            }
-            justFitFeatures={false}
-            maxZoom={18}
-            minZoom={2}
-            onBoundsChange={[Function]}
-            setInitialBounds={false}
-            zoom={3}
-            zoomControl={false}
->
-            <ZoomControl
-                        position="topright"
-            />
-            <Connect(InjectIntl(SourcedTileLayer))
-                        defaultLayer="foo"
-            />
-</EnhancedMap>,
-          <BusySpinner />,
-        ],
-        "className": "full-screen-map",
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "browsedChallenge": Object {
-              "id": 123,
-            },
-            "layerSourceName": "foo",
-            "loadingClusteredTasks": true,
-            "mapBounds": Object {
-              "locator": Object {
-                "bounds": Object {
-                  "_northEast": Object {
-                    "lat": 0,
-                    "lng": 0,
-                  },
-                  "_southWest": Object {
-                    "lat": 0,
-                    "lng": 0,
-                  },
-                },
-              },
-            },
-            "setChallengeMapBounds": [Function],
-            "setLocatorMapBounds": [Function],
-            "updateBoundedChallenges": [Function],
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "animate": true,
-            "center": Object {
-              "lat": 0,
-              "lng": 45,
-            },
-            "children": Array [
-              <ZoomControl
-                position="topright"
-/>,
-              <Connect(InjectIntl(SourcedTileLayer))
-                defaultLayer="foo"
-/>,
-              false,
-            ],
-            "features": undefined,
-            "initialBounds": Object {
-              "_northEast": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-              "_southWest": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-            },
-            "justFitFeatures": false,
-            "maxZoom": 18,
-            "minZoom": 2,
-            "onBoundsChange": [Function],
-            "setInitialBounds": false,
-            "zoom": 3,
-            "zoomControl": false,
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "position": "topright",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "defaultLayer": "foo",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            false,
-          ],
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {},
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-      ],
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
 exports[`it renders a full screen map 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -445,7 +22,6 @@ ShallowWrapper {
             },
           }
     }
-    setChallengeMapBounds={[Function]}
     setLocatorMapBounds={[Function]}
     updateBoundedChallenges={[Function]}
 />,
@@ -480,7 +56,6 @@ ShallowWrapper {
                               },
                             }
           }
-          setChallengeMapBounds={[Function]}
           setLocatorMapBounds={[Function]}
           updateBoundedChallenges={[Function]}
 />,
@@ -492,7 +67,6 @@ ShallowWrapper {
                               "lng": 45,
                             }
           }
-          features={null}
           initialBounds={
                     Object {
                               "_northEast": Object {
@@ -520,7 +94,6 @@ ShallowWrapper {
                     defaultLayer="foo"
           />
 </EnhancedMap>,
-        false,
       ],
       "className": "full-screen-map",
     },
@@ -546,7 +119,6 @@ ShallowWrapper {
               },
             },
           },
-          "setChallengeMapBounds": [Function],
           "setLocatorMapBounds": [Function],
           "updateBoundedChallenges": [Function],
         },
@@ -571,9 +143,7 @@ ShallowWrapper {
             <Connect(InjectIntl(SourcedTileLayer))
               defaultLayer="foo"
 />,
-            false,
           ],
-          "features": null,
           "initialBounds": Object {
             "_northEast": Object {
               "lat": 0,
@@ -616,11 +186,9 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          false,
         ],
         "type": [Function],
       },
-      false,
     ],
     "type": "div",
   },
@@ -649,7 +217,6 @@ ShallowWrapper {
                                     },
                                   }
             }
-            setChallengeMapBounds={[Function]}
             setLocatorMapBounds={[Function]}
             updateBoundedChallenges={[Function]}
 />,
@@ -661,7 +228,6 @@ ShallowWrapper {
                                     "lng": 45,
                                   }
             }
-            features={null}
             initialBounds={
                         Object {
                                     "_northEast": Object {
@@ -689,7 +255,6 @@ ShallowWrapper {
                         defaultLayer="foo"
             />
 </EnhancedMap>,
-          false,
         ],
         "className": "full-screen-map",
       },
@@ -715,7 +280,6 @@ ShallowWrapper {
                 },
               },
             },
-            "setChallengeMapBounds": [Function],
             "setLocatorMapBounds": [Function],
             "updateBoundedChallenges": [Function],
           },
@@ -740,9 +304,7 @@ ShallowWrapper {
               <Connect(InjectIntl(SourcedTileLayer))
                 defaultLayer="foo"
 />,
-              false,
             ],
-            "features": null,
             "initialBounds": Object {
               "_northEast": Object {
                 "lat": 0,
@@ -785,418 +347,9 @@ ShallowWrapper {
               "rendered": null,
               "type": [Function],
             },
-            false,
           ],
           "type": [Function],
         },
-        false,
-      ],
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
-exports[`the busy indicator is removed once tasks are done loading 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <LocatorMap
-    browsedChallenge={
-        Object {
-            "id": 123,
-          }
-    }
-    layerSourceName="foo"
-    loadingClusteredTasks={false}
-    mapBounds={
-        Object {
-            "locator": Object {
-              "bounds": Object {
-                "_northEast": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-                "_southWest": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-              },
-            },
-          }
-    }
-    setChallengeMapBounds={[Function]}
-    setLocatorMapBounds={[Function]}
-    updateBoundedChallenges={[Function]}
-/>,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": "123",
-    "nodeType": "host",
-    "props": Object {
-      "children": Array [
-        <Connect(Component)
-          browsedChallenge={
-                    Object {
-                              "id": 123,
-                            }
-          }
-          layerSourceName="foo"
-          loadingClusteredTasks={false}
-          mapBounds={
-                    Object {
-                              "locator": Object {
-                                "bounds": Object {
-                                  "_northEast": Object {
-                                    "lat": 0,
-                                    "lng": 0,
-                                  },
-                                  "_southWest": Object {
-                                    "lat": 0,
-                                    "lng": 0,
-                                  },
-                                },
-                              },
-                            }
-          }
-          setChallengeMapBounds={[Function]}
-          setLocatorMapBounds={[Function]}
-          updateBoundedChallenges={[Function]}
-/>,
-        <EnhancedMap
-          animate={true}
-          center={
-                    Object {
-                              "lat": 0,
-                              "lng": 45,
-                            }
-          }
-          features={undefined}
-          initialBounds={
-                    Object {
-                              "_northEast": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                              "_southWest": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                            }
-          }
-          justFitFeatures={false}
-          maxZoom={18}
-          minZoom={2}
-          onBoundsChange={[Function]}
-          setInitialBounds={false}
-          zoom={3}
-          zoomControl={false}
->
-          <ZoomControl
-                    position="topright"
-          />
-          <Connect(InjectIntl(SourcedTileLayer))
-                    defaultLayer="foo"
-          />
-</EnhancedMap>,
-        false,
-      ],
-      "className": "full-screen-map",
-    },
-    "ref": null,
-    "rendered": Array [
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "browsedChallenge": Object {
-            "id": 123,
-          },
-          "layerSourceName": "foo",
-          "loadingClusteredTasks": false,
-          "mapBounds": Object {
-            "locator": Object {
-              "bounds": Object {
-                "_northEast": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-                "_southWest": Object {
-                  "lat": 0,
-                  "lng": 0,
-                },
-              },
-            },
-          },
-          "setChallengeMapBounds": [Function],
-          "setLocatorMapBounds": [Function],
-          "updateBoundedChallenges": [Function],
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "animate": true,
-          "center": Object {
-            "lat": 0,
-            "lng": 45,
-          },
-          "children": Array [
-            <ZoomControl
-              position="topright"
-/>,
-            <Connect(InjectIntl(SourcedTileLayer))
-              defaultLayer="foo"
-/>,
-            false,
-          ],
-          "features": undefined,
-          "initialBounds": Object {
-            "_northEast": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-            "_southWest": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-          },
-          "justFitFeatures": false,
-          "maxZoom": 18,
-          "minZoom": 2,
-          "onBoundsChange": [Function],
-          "setInitialBounds": false,
-          "zoom": 3,
-          "zoomControl": false,
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "position": "topright",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "defaultLayer": "foo",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          false,
-        ],
-        "type": [Function],
-      },
-      false,
-    ],
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": "123",
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          <Connect(Component)
-            browsedChallenge={
-                        Object {
-                                    "id": 123,
-                                  }
-            }
-            layerSourceName="foo"
-            loadingClusteredTasks={false}
-            mapBounds={
-                        Object {
-                                    "locator": Object {
-                                      "bounds": Object {
-                                        "_northEast": Object {
-                                          "lat": 0,
-                                          "lng": 0,
-                                        },
-                                        "_southWest": Object {
-                                          "lat": 0,
-                                          "lng": 0,
-                                        },
-                                      },
-                                    },
-                                  }
-            }
-            setChallengeMapBounds={[Function]}
-            setLocatorMapBounds={[Function]}
-            updateBoundedChallenges={[Function]}
-/>,
-          <EnhancedMap
-            animate={true}
-            center={
-                        Object {
-                                    "lat": 0,
-                                    "lng": 45,
-                                  }
-            }
-            features={undefined}
-            initialBounds={
-                        Object {
-                                    "_northEast": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                    "_southWest": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                  }
-            }
-            justFitFeatures={false}
-            maxZoom={18}
-            minZoom={2}
-            onBoundsChange={[Function]}
-            setInitialBounds={false}
-            zoom={3}
-            zoomControl={false}
->
-            <ZoomControl
-                        position="topright"
-            />
-            <Connect(InjectIntl(SourcedTileLayer))
-                        defaultLayer="foo"
-            />
-</EnhancedMap>,
-          false,
-        ],
-        "className": "full-screen-map",
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "browsedChallenge": Object {
-              "id": 123,
-            },
-            "layerSourceName": "foo",
-            "loadingClusteredTasks": false,
-            "mapBounds": Object {
-              "locator": Object {
-                "bounds": Object {
-                  "_northEast": Object {
-                    "lat": 0,
-                    "lng": 0,
-                  },
-                  "_southWest": Object {
-                    "lat": 0,
-                    "lng": 0,
-                  },
-                },
-              },
-            },
-            "setChallengeMapBounds": [Function],
-            "setLocatorMapBounds": [Function],
-            "updateBoundedChallenges": [Function],
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "animate": true,
-            "center": Object {
-              "lat": 0,
-              "lng": 45,
-            },
-            "children": Array [
-              <ZoomControl
-                position="topright"
-/>,
-              <Connect(InjectIntl(SourcedTileLayer))
-                defaultLayer="foo"
-/>,
-              false,
-            ],
-            "features": undefined,
-            "initialBounds": Object {
-              "_northEast": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-              "_southWest": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-            },
-            "justFitFeatures": false,
-            "maxZoom": 18,
-            "minZoom": 2,
-            "onBoundsChange": [Function],
-            "setInitialBounds": false,
-            "zoom": 3,
-            "zoomControl": false,
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "position": "topright",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "defaultLayer": "foo",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            false,
-          ],
-          "type": [Function],
-        },
-        false,
       ],
       "type": "div",
     },

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -41,9 +41,10 @@ export default class Navbar extends Component {
               </span>
             </Link>
 
-            <Link to='/' className="navbar-item">
-              <span className={classNames('item-text',
-                                          {'is-active': this.props.location.pathname === '/'})}>
+            <Link to='/browse/challenges' className="navbar-item">
+              <span className={
+                classNames('item-text',
+                           {'is-active': /\/browse\/challenges/.test(this.props.location.pathname)})}>
                 <FormattedMessage {...messages.results} />
               </span>
             </Link>

--- a/src/components/Navbar/__snapshots__/Navbar.test.js.snap
+++ b/src/components/Navbar/__snapshots__/Navbar.test.js.snap
@@ -89,7 +89,7 @@ ShallowWrapper {
                     <Link
                               className="navbar-item"
                               replace={false}
-                              to="/"
+                              to="/browse/challenges"
                     >
                               <span
                                         className="item-text"
@@ -306,7 +306,7 @@ ShallowWrapper {
               <Link
                             className="navbar-item"
                             replace={false}
-                            to="/"
+                            to="/browse/challenges"
               >
                             <span
                                           className="item-text"
@@ -365,7 +365,7 @@ ShallowWrapper {
                 <Link
                   className="navbar-item"
                   replace={false}
-                  to="/"
+                  to="/browse/challenges"
 >
                   <span
                                     className="item-text"
@@ -448,7 +448,7 @@ ShallowWrapper {
 </span>,
                   "className": "navbar-item",
                   "replace": false,
-                  "to": "/",
+                  "to": "/browse/challenges",
                 },
                 "ref": null,
                 "rendered": Object {
@@ -597,7 +597,7 @@ ShallowWrapper {
                         <Link
                                     className="navbar-item"
                                     replace={false}
-                                    to="/"
+                                    to="/browse/challenges"
                         >
                                     <span
                                                 className="item-text"
@@ -814,7 +814,7 @@ ShallowWrapper {
                 <Link
                                 className="navbar-item"
                                 replace={false}
-                                to="/"
+                                to="/browse/challenges"
                 >
                                 <span
                                                 className="item-text"
@@ -873,7 +873,7 @@ ShallowWrapper {
                   <Link
                     className="navbar-item"
                     replace={false}
-                    to="/"
+                    to="/browse/challenges"
 >
                     <span
                                         className="item-text"
@@ -956,7 +956,7 @@ ShallowWrapper {
 </span>,
                     "className": "navbar-item",
                     "replace": false,
-                    "to": "/",
+                    "to": "/browse/challenges",
                   },
                   "ref": null,
                   "rendered": Object {
@@ -1139,7 +1139,7 @@ ShallowWrapper {
                     <Link
                               className="navbar-item"
                               replace={false}
-                              to="/"
+                              to="/browse/challenges"
                     >
                               <span
                                         className="item-text"
@@ -1371,7 +1371,7 @@ ShallowWrapper {
               <Link
                             className="navbar-item"
                             replace={false}
-                            to="/"
+                            to="/browse/challenges"
               >
                             <span
                                           className="item-text"
@@ -1445,7 +1445,7 @@ ShallowWrapper {
                 <Link
                   className="navbar-item"
                   replace={false}
-                  to="/"
+                  to="/browse/challenges"
 >
                   <span
                                     className="item-text"
@@ -1542,7 +1542,7 @@ ShallowWrapper {
 </span>,
                   "className": "navbar-item",
                   "replace": false,
-                  "to": "/",
+                  "to": "/browse/challenges",
                 },
                 "ref": null,
                 "rendered": Object {
@@ -1739,7 +1739,7 @@ ShallowWrapper {
                         <Link
                                     className="navbar-item"
                                     replace={false}
-                                    to="/"
+                                    to="/browse/challenges"
                         >
                                     <span
                                                 className="item-text"
@@ -1971,7 +1971,7 @@ ShallowWrapper {
                 <Link
                                 className="navbar-item"
                                 replace={false}
-                                to="/"
+                                to="/browse/challenges"
                 >
                                 <span
                                                 className="item-text"
@@ -2045,7 +2045,7 @@ ShallowWrapper {
                   <Link
                     className="navbar-item"
                     replace={false}
-                    to="/"
+                    to="/browse/challenges"
 >
                     <span
                                         className="item-text"
@@ -2142,7 +2142,7 @@ ShallowWrapper {
 </span>,
                     "className": "navbar-item",
                     "replace": false,
-                    "to": "/",
+                    "to": "/browse/challenges",
                   },
                   "ref": null,
                   "rendered": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskDetails.js
@@ -6,6 +6,7 @@ import _isNumber from 'lodash/isNumber'
 import _isEmpty from 'lodash/isEmpty'
 import classNames from 'classnames'
 import { FormattedMessage, injectIntl } from 'react-intl'
+import { Link } from 'react-router-dom'
 import Delayed from 'react-delayed'
 import Sidebar from '../../Sidebar/Sidebar'
 import Popout from '../../Bulma/Popout'
@@ -74,6 +75,11 @@ export class ActiveTaskDetails extends Component {
       !canBeMinimized ? null :
       <button className="toggle-minimization" onClick={this.toggleIsMinimized} />
 
+    const challengeNameLink =
+      <Link to={`/browse/challenges/${_get(this.props.task, 'parent.id', '')}`}>
+        {_startCase(_get(this.props.task, 'parent.name'))}
+      </Link>
+
     const taskInstructions = !_isEmpty(this.props.task.instruction) ?
                              this.props.task.instruction :
                              _get(this.props.task, 'parent.instruction')
@@ -94,9 +100,7 @@ export class ActiveTaskDetails extends Component {
                              className='active-task-details__info-popout'
                              control={infoPopoutButton}>
           <div className="popout-content__header active-task-details--bordered">
-            <h3 className="info-popout--name">
-              {_startCase(_get(this.props.task, 'parent.name'))}
-            </h3>
+            <h3 className="info-popout--name">{challengeNameLink}</h3>
 
             <div className="info-popout--project-name">
               {_get(this.props.task, 'parent.parent.displayName')}
@@ -150,9 +154,7 @@ export class ActiveTaskDetails extends Component {
               <FormattedMessage {...messages.challengeHeading} />
             </div>
 
-            <h2 className="active-task-details--name">
-              {_startCase(_get(this.props.task, 'parent.name'))}
-            </h2>
+            <h2 className="active-task-details--name">{challengeNameLink}</h2>
 
             <div className="active-task-details--project-name">
               {_get(this.props.task, 'parent.parent.displayName')}

--- a/src/components/TaskPane/ChallengeShareControls/ChallengeShareControls.js
+++ b/src/components/TaskPane/ChallengeShareControls/ChallengeShareControls.js
@@ -20,7 +20,7 @@ export default class ChallengeShareControls extends Component {
     const TwitterIcon = generateShareIcon('twitter')
     const EmailIcon = generateShareIcon('email')
 
-    const shareUrl = `${process.env.REACT_APP_URL}/challenge/${this.props.challenge.id}`
+    const shareUrl = `${process.env.REACT_APP_URL}/browse/challenges/${this.props.challenge.id}`
     const title = process.env.REACT_APP_TITLE
     const hashtag = 'maproulette'
 

--- a/src/components/TaskPane/ChallengeShareControls/__snapshots__/ChallengeShareControls.test.js.snap
+++ b/src/components/TaskPane/ChallengeShareControls/__snapshots__/ChallengeShareControls.test.js.snap
@@ -55,7 +55,7 @@ ShallowWrapper {
 >
           <CreatedButton
                     quote="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
                     windowHeight={400}
                     windowWidth={550}
           >
@@ -81,7 +81,7 @@ ShallowWrapper {
                                       ]
                     }
                     title="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
                     windowHeight={400}
                     windowWidth={550}
           >
@@ -101,11 +101,11 @@ ShallowWrapper {
           className="share-control"
 >
           <CreatedButton
-                    body="http://localhost:3000/challenge/123"
+                    body="http://localhost:3000/browse/challenges/123"
                     onClick={[Function]}
                     openWindow={false}
                     subject="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
           >
                     <span
                               className="share-icon"
@@ -131,7 +131,7 @@ ShallowWrapper {
         "props": Object {
           "children": <CreatedButton
             quote="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
             windowHeight={400}
             windowWidth={550}
 >
@@ -165,7 +165,7 @@ ShallowWrapper {
               />
 </span>,
             "quote": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
             "windowHeight": 400,
             "windowWidth": 550,
           },
@@ -216,7 +216,7 @@ ShallowWrapper {
                                   ]
             }
             title="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
             windowHeight={400}
             windowWidth={550}
 >
@@ -253,7 +253,7 @@ ShallowWrapper {
               "maproulette",
             ],
             "title": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
             "windowHeight": 400,
             "windowWidth": 550,
           },
@@ -298,11 +298,11 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": <CreatedButton
-            body="http://localhost:3000/challenge/123"
+            body="http://localhost:3000/browse/challenges/123"
             onClick={[Function]}
             openWindow={false}
             subject="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
 >
             <span
                         className="share-icon"
@@ -323,7 +323,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "body": "http://localhost:3000/challenge/123",
+            "body": "http://localhost:3000/browse/challenges/123",
             "children": <span
               className="share-icon"
 >
@@ -337,7 +337,7 @@ ShallowWrapper {
             "onClick": [Function],
             "openWindow": false,
             "subject": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
           },
           "ref": null,
           "rendered": Object {
@@ -389,7 +389,7 @@ ShallowWrapper {
 >
             <CreatedButton
                         quote="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
                         windowHeight={400}
                         windowWidth={550}
             >
@@ -415,7 +415,7 @@ ShallowWrapper {
                                               ]
                         }
                         title="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
                         windowHeight={400}
                         windowWidth={550}
             >
@@ -435,11 +435,11 @@ ShallowWrapper {
             className="share-control"
 >
             <CreatedButton
-                        body="http://localhost:3000/challenge/123"
+                        body="http://localhost:3000/browse/challenges/123"
                         onClick={[Function]}
                         openWindow={false}
                         subject="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
             >
                         <span
                                     className="share-icon"
@@ -465,7 +465,7 @@ ShallowWrapper {
           "props": Object {
             "children": <CreatedButton
               quote="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
               windowHeight={400}
               windowWidth={550}
 >
@@ -499,7 +499,7 @@ ShallowWrapper {
                 />
 </span>,
               "quote": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
               "windowHeight": 400,
               "windowWidth": 550,
             },
@@ -550,7 +550,7 @@ ShallowWrapper {
                                         ]
               }
               title="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
               windowHeight={400}
               windowWidth={550}
 >
@@ -587,7 +587,7 @@ ShallowWrapper {
                 "maproulette",
               ],
               "title": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
               "windowHeight": 400,
               "windowWidth": 550,
             },
@@ -632,11 +632,11 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <CreatedButton
-              body="http://localhost:3000/challenge/123"
+              body="http://localhost:3000/browse/challenges/123"
               onClick={[Function]}
               openWindow={false}
               subject="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
 >
               <span
                             className="share-icon"
@@ -657,7 +657,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
-              "body": "http://localhost:3000/challenge/123",
+              "body": "http://localhost:3000/browse/challenges/123",
               "children": <span
                 className="share-icon"
 >
@@ -671,7 +671,7 @@ ShallowWrapper {
               "onClick": [Function],
               "openWindow": false,
               "subject": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
             },
             "ref": null,
             "rendered": Object {
@@ -752,7 +752,7 @@ ShallowWrapper {
 >
           <CreatedButton
                     quote="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
                     windowHeight={400}
                     windowWidth={550}
           >
@@ -778,7 +778,7 @@ ShallowWrapper {
                                       ]
                     }
                     title="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
                     windowHeight={400}
                     windowWidth={550}
           >
@@ -798,11 +798,11 @@ ShallowWrapper {
           className="share-control"
 >
           <CreatedButton
-                    body="http://localhost:3000/challenge/123"
+                    body="http://localhost:3000/browse/challenges/123"
                     onClick={[Function]}
                     openWindow={false}
                     subject="MR3 alpha preview"
-                    url="http://localhost:3000/challenge/123"
+                    url="http://localhost:3000/browse/challenges/123"
           >
                     <span
                               className="share-icon"
@@ -828,7 +828,7 @@ ShallowWrapper {
         "props": Object {
           "children": <CreatedButton
             quote="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
             windowHeight={400}
             windowWidth={550}
 >
@@ -862,7 +862,7 @@ ShallowWrapper {
               />
 </span>,
             "quote": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
             "windowHeight": 400,
             "windowWidth": 550,
           },
@@ -913,7 +913,7 @@ ShallowWrapper {
                                   ]
             }
             title="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
             windowHeight={400}
             windowWidth={550}
 >
@@ -950,7 +950,7 @@ ShallowWrapper {
               "maproulette",
             ],
             "title": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
             "windowHeight": 400,
             "windowWidth": 550,
           },
@@ -995,11 +995,11 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": <CreatedButton
-            body="http://localhost:3000/challenge/123"
+            body="http://localhost:3000/browse/challenges/123"
             onClick={[Function]}
             openWindow={false}
             subject="MR3 alpha preview"
-            url="http://localhost:3000/challenge/123"
+            url="http://localhost:3000/browse/challenges/123"
 >
             <span
                         className="share-icon"
@@ -1020,7 +1020,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "body": "http://localhost:3000/challenge/123",
+            "body": "http://localhost:3000/browse/challenges/123",
             "children": <span
               className="share-icon"
 >
@@ -1034,7 +1034,7 @@ ShallowWrapper {
             "onClick": [Function],
             "openWindow": false,
             "subject": "MR3 alpha preview",
-            "url": "http://localhost:3000/challenge/123",
+            "url": "http://localhost:3000/browse/challenges/123",
           },
           "ref": null,
           "rendered": Object {
@@ -1086,7 +1086,7 @@ ShallowWrapper {
 >
             <CreatedButton
                         quote="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
                         windowHeight={400}
                         windowWidth={550}
             >
@@ -1112,7 +1112,7 @@ ShallowWrapper {
                                               ]
                         }
                         title="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
                         windowHeight={400}
                         windowWidth={550}
             >
@@ -1132,11 +1132,11 @@ ShallowWrapper {
             className="share-control"
 >
             <CreatedButton
-                        body="http://localhost:3000/challenge/123"
+                        body="http://localhost:3000/browse/challenges/123"
                         onClick={[Function]}
                         openWindow={false}
                         subject="MR3 alpha preview"
-                        url="http://localhost:3000/challenge/123"
+                        url="http://localhost:3000/browse/challenges/123"
             >
                         <span
                                     className="share-icon"
@@ -1162,7 +1162,7 @@ ShallowWrapper {
           "props": Object {
             "children": <CreatedButton
               quote="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
               windowHeight={400}
               windowWidth={550}
 >
@@ -1196,7 +1196,7 @@ ShallowWrapper {
                 />
 </span>,
               "quote": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
               "windowHeight": 400,
               "windowWidth": 550,
             },
@@ -1247,7 +1247,7 @@ ShallowWrapper {
                                         ]
               }
               title="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
               windowHeight={400}
               windowWidth={550}
 >
@@ -1284,7 +1284,7 @@ ShallowWrapper {
                 "maproulette",
               ],
               "title": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
               "windowHeight": 400,
               "windowWidth": 550,
             },
@@ -1329,11 +1329,11 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <CreatedButton
-              body="http://localhost:3000/challenge/123"
+              body="http://localhost:3000/browse/challenges/123"
               onClick={[Function]}
               openWindow={false}
               subject="MR3 alpha preview"
-              url="http://localhost:3000/challenge/123"
+              url="http://localhost:3000/browse/challenges/123"
 >
               <span
                             className="share-icon"
@@ -1354,7 +1354,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
-              "body": "http://localhost:3000/challenge/123",
+              "body": "http://localhost:3000/browse/challenges/123",
               "children": <span
                 className="share-icon"
 >
@@ -1368,7 +1368,7 @@ ShallowWrapper {
               "onClick": [Function],
               "openWindow": false,
               "subject": "MR3 alpha preview",
-              "url": "http://localhost:3000/challenge/123",
+              "url": "http://localhost:3000/browse/challenges/123",
             },
             "ref": null,
             "rendered": Object {

--- a/src/components/UserProfile/SavedChallenges/SavedChallenges.js
+++ b/src/components/UserProfile/SavedChallenges/SavedChallenges.js
@@ -14,7 +14,7 @@ export default class SavedChallenges extends Component {
       _map(_get(this.props, 'user.savedChallenges', []), challenge =>
         <li key={challenge.id} className="columns saved-challenges__challenge">
           <div className="column">
-            <Link to={`/challenge/${challenge.id}`}>
+            <Link to={`/browse/challenges/${challenge.id}`}>
               {challenge.name}
             </Link>
           </div>

--- a/src/components/UserProfile/SavedChallenges/__snapshots__/SavedChallenges.test.js.snap
+++ b/src/components/UserProfile/SavedChallenges/__snapshots__/SavedChallenges.test.js.snap
@@ -231,7 +231,7 @@ ShallowWrapper {
                     >
                               <Link
                                         replace={false}
-                                        to="/challenge/321"
+                                        to="/browse/challenges/321"
                               >
                                         First Challenge
                               </Link>
@@ -260,7 +260,7 @@ ShallowWrapper {
                     >
                               <Link
                                         replace={false}
-                                        to="/challenge/654"
+                                        to="/browse/challenges/654"
                               >
                                         Second Challenge
                               </Link>
@@ -289,7 +289,7 @@ ShallowWrapper {
                     >
                               <Link
                                         replace={false}
-                                        to="/challenge/987"
+                                        to="/browse/challenges/987"
                               >
                                         Third Challenge
                               </Link>
@@ -358,7 +358,7 @@ ShallowWrapper {
               >
                             <Link
                                           replace={false}
-                                          to="/challenge/321"
+                                          to="/browse/challenges/321"
                             >
                                           First Challenge
                             </Link>
@@ -387,7 +387,7 @@ ShallowWrapper {
               >
                             <Link
                                           replace={false}
-                                          to="/challenge/654"
+                                          to="/browse/challenges/654"
                             >
                                           Second Challenge
                             </Link>
@@ -416,7 +416,7 @@ ShallowWrapper {
               >
                             <Link
                                           replace={false}
-                                          to="/challenge/987"
+                                          to="/browse/challenges/987"
                             >
                                           Third Challenge
                             </Link>
@@ -452,7 +452,7 @@ ShallowWrapper {
 >
                   <Link
                                     replace={false}
-                                    to="/challenge/321"
+                                    to="/browse/challenges/321"
                   >
                                     First Challenge
                   </Link>
@@ -484,7 +484,7 @@ ShallowWrapper {
                 "props": Object {
                   "children": <Link
                     replace={false}
-                    to="/challenge/321"
+                    to="/browse/challenges/321"
 >
                     First Challenge
 </Link>,
@@ -498,7 +498,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": "First Challenge",
                     "replace": false,
-                    "to": "/challenge/321",
+                    "to": "/browse/challenges/321",
                   },
                   "ref": null,
                   "rendered": "First Challenge",
@@ -571,7 +571,7 @@ ShallowWrapper {
 >
                   <Link
                                     replace={false}
-                                    to="/challenge/654"
+                                    to="/browse/challenges/654"
                   >
                                     Second Challenge
                   </Link>
@@ -603,7 +603,7 @@ ShallowWrapper {
                 "props": Object {
                   "children": <Link
                     replace={false}
-                    to="/challenge/654"
+                    to="/browse/challenges/654"
 >
                     Second Challenge
 </Link>,
@@ -617,7 +617,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": "Second Challenge",
                     "replace": false,
-                    "to": "/challenge/654",
+                    "to": "/browse/challenges/654",
                   },
                   "ref": null,
                   "rendered": "Second Challenge",
@@ -690,7 +690,7 @@ ShallowWrapper {
 >
                   <Link
                                     replace={false}
-                                    to="/challenge/987"
+                                    to="/browse/challenges/987"
                   >
                                     Third Challenge
                   </Link>
@@ -722,7 +722,7 @@ ShallowWrapper {
                 "props": Object {
                   "children": <Link
                     replace={false}
-                    to="/challenge/987"
+                    to="/browse/challenges/987"
 >
                     Third Challenge
 </Link>,
@@ -736,7 +736,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": "Third Challenge",
                     "replace": false,
-                    "to": "/challenge/987",
+                    "to": "/browse/challenges/987",
                   },
                   "ref": null,
                   "rendered": "Third Challenge",
@@ -829,7 +829,7 @@ ShallowWrapper {
                         >
                                     <Link
                                                 replace={false}
-                                                to="/challenge/321"
+                                                to="/browse/challenges/321"
                                     >
                                                 First Challenge
                                     </Link>
@@ -858,7 +858,7 @@ ShallowWrapper {
                         >
                                     <Link
                                                 replace={false}
-                                                to="/challenge/654"
+                                                to="/browse/challenges/654"
                                     >
                                                 Second Challenge
                                     </Link>
@@ -887,7 +887,7 @@ ShallowWrapper {
                         >
                                     <Link
                                                 replace={false}
-                                                to="/challenge/987"
+                                                to="/browse/challenges/987"
                                     >
                                                 Third Challenge
                                     </Link>
@@ -956,7 +956,7 @@ ShallowWrapper {
                 >
                                 <Link
                                                 replace={false}
-                                                to="/challenge/321"
+                                                to="/browse/challenges/321"
                                 >
                                                 First Challenge
                                 </Link>
@@ -985,7 +985,7 @@ ShallowWrapper {
                 >
                                 <Link
                                                 replace={false}
-                                                to="/challenge/654"
+                                                to="/browse/challenges/654"
                                 >
                                                 Second Challenge
                                 </Link>
@@ -1014,7 +1014,7 @@ ShallowWrapper {
                 >
                                 <Link
                                                 replace={false}
-                                                to="/challenge/987"
+                                                to="/browse/challenges/987"
                                 >
                                                 Third Challenge
                                 </Link>
@@ -1050,7 +1050,7 @@ ShallowWrapper {
 >
                     <Link
                                         replace={false}
-                                        to="/challenge/321"
+                                        to="/browse/challenges/321"
                     >
                                         First Challenge
                     </Link>
@@ -1082,7 +1082,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <Link
                       replace={false}
-                      to="/challenge/321"
+                      to="/browse/challenges/321"
 >
                       First Challenge
 </Link>,
@@ -1096,7 +1096,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": "First Challenge",
                       "replace": false,
-                      "to": "/challenge/321",
+                      "to": "/browse/challenges/321",
                     },
                     "ref": null,
                     "rendered": "First Challenge",
@@ -1169,7 +1169,7 @@ ShallowWrapper {
 >
                     <Link
                                         replace={false}
-                                        to="/challenge/654"
+                                        to="/browse/challenges/654"
                     >
                                         Second Challenge
                     </Link>
@@ -1201,7 +1201,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <Link
                       replace={false}
-                      to="/challenge/654"
+                      to="/browse/challenges/654"
 >
                       Second Challenge
 </Link>,
@@ -1215,7 +1215,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": "Second Challenge",
                       "replace": false,
-                      "to": "/challenge/654",
+                      "to": "/browse/challenges/654",
                     },
                     "ref": null,
                     "rendered": "Second Challenge",
@@ -1288,7 +1288,7 @@ ShallowWrapper {
 >
                     <Link
                                         replace={false}
-                                        to="/challenge/987"
+                                        to="/browse/challenges/987"
                     >
                                         Third Challenge
                     </Link>
@@ -1320,7 +1320,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <Link
                       replace={false}
-                      to="/challenge/987"
+                      to="/browse/challenges/987"
 >
                       Third Challenge
 </Link>,
@@ -1334,7 +1334,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": "Third Challenge",
                       "replace": false,
-                      "to": "/challenge/987",
+                      "to": "/browse/challenges/987",
                     },
                     "ref": null,
                     "rendered": "Third Challenge",

--- a/src/services/Status/Status.js
+++ b/src/services/Status/Status.js
@@ -3,8 +3,8 @@ import _get from 'lodash/get'
 import _pull from 'lodash/pull'
 
 /**
- * Manage application status so that it can be reflected in
- * various components as appropriate.
+ * Manage application status so that it can be reflected in various components
+ * as appropriate.
  */
 
 // status names

--- a/src/services/Task/ClusteredTask.js
+++ b/src/services/Task/ClusteredTask.js
@@ -1,0 +1,102 @@
+import { defaultRoutes as api } from '../Server/Server'
+import Endpoint from '../Server/Endpoint'
+import RequestStatus from '../Server/RequestStatus'
+import { taskSchema } from './Task'
+import { buildError, addError } from '../Error/Error'
+import _get from 'lodash/get'
+import _each from 'lodash/each'
+import _values from 'lodash/values'
+import _isArray from 'lodash/isArray'
+import _uniqueId from 'lodash/uniqueId'
+
+// redux actions
+const RECEIVE_CLUSTERED_TASKS = 'RECEIVE_CLUSTERED_TASKS'
+const CLEAR_CLUSTERED_TASKS = 'CLEAR_CLUSTERED_TASKS'
+
+// redux action creators
+
+/**
+ * Add or replace the clustered tasks in the redux store
+ */
+export const receiveClusteredTasks = function(challengeId,
+                                              tasks,
+                                              status=RequestStatus.success,
+                                              fetchId) {
+  return {
+    type: RECEIVE_CLUSTERED_TASKS,
+    status,
+    challengeId,
+    tasks,
+    fetchId,
+    receivedAt: Date.now(),
+  }
+}
+
+/**
+ * Clear the clustered tasks from the redux store
+ */
+export const clearClusteredTasks = function() {
+  return {
+    type: CLEAR_CLUSTERED_TASKS,
+    receivedAt: Date.now()
+  }
+}
+
+
+// async action creators
+
+/**
+ * Retrieve clustered task data belonging to the given challenge
+ */
+export const fetchClusteredTasks = function(challengeId) {
+  return function(dispatch) {
+    const fetchId = _uniqueId()
+    dispatch(receiveClusteredTasks(challengeId, [], RequestStatus.inProgress, fetchId))
+
+    return new Endpoint(
+      api.challenge.clusteredTasks,
+      {schema: [ taskSchema() ], variables: {id: challengeId}}
+    ).execute().then(normalizedResults => {
+      // Add parent field
+      const tasks = _values(_get(normalizedResults, 'entities.tasks', {}))
+      _each(tasks, task => task.parent = challengeId)
+
+      dispatch(receiveClusteredTasks(challengeId, tasks, RequestStatus.success, fetchId))
+      return tasks
+    }).catch((error) => {
+      dispatch(receiveClusteredTasks(challengeId, [], RequestStatus.error, fetchId))
+      dispatch(addError(buildError(
+        "ClusteredTask.fetchFailure", "Unable to fetch task clusters"
+      )))
+
+      console.log(error.response || error)
+    })
+  }
+}
+
+// redux reducers
+export const currentClusteredTasks = function(state={}, action) {
+  if (action.type === RECEIVE_CLUSTERED_TASKS) {
+    // Only update the state if this represents either a later fetch
+    // of data or an update to the current data in the store.
+    const currentFetch = parseInt(_get(state, 'fetchId', 0), 10)
+
+    if (parseInt(action.fetchId, 10) >= currentFetch) {
+      return {
+        challengeId: action.challengeId,
+        loading: action.status === RequestStatus.inProgress,
+        tasks: _isArray(action.tasks) ? action.tasks : [],
+        fetchId: action.fetchId,
+      }
+    }
+    else {
+      return state
+    }
+  }
+  else if (action.type === CLEAR_CLUSTERED_TASKS) {
+    return {}
+  }
+  else {
+    return state
+  }
+}

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -10,11 +10,9 @@ import { commentSchema, receiveComments } from '../Comment/Comment'
 import { buildError, buildServerError, addError } from '../Error/Error'
 import { logoutUser } from '../User/User'
 import _get from 'lodash/get'
-import _each from 'lodash/each'
 import _pick from 'lodash/pick'
 import _cloneDeep from 'lodash/cloneDeep'
 import _keys from 'lodash/keys'
-import _values from 'lodash/values'
 import _map from 'lodash/map'
 import _isEmpty from 'lodash/isEmpty'
 import _isUndefined from 'lodash/isUndefined'
@@ -241,35 +239,6 @@ export const fetchChallengeTasks = function(challengeId, limit=50) {
     ).execute().then(normalizedResults => {
       dispatch(receiveTasks(normalizedResults.entities))
       return normalizedResults
-    })
-  }
-}
-
-
-/**
- * Retrieve clustered task data belonging to the given challenge
- *
- * > Note: because we could be retrieving data on literally tens of thousands
- * > of tasks in some cases, we don't store the tasks in the redux store like
- * > we do with nearly all other data retrievals. They're simply returned.
- */
-export const fetchClusteredTasks = function(challengeId) {
-  return function(dispatch) {
-    return new Endpoint(
-      api.challenge.clusteredTasks,
-      {schema: [ taskSchema() ], variables: {id: challengeId}}
-    ).execute().then(normalizedResults => {
-      // Add parent field
-      const tasks = _values(_get(normalizedResults, 'entities.tasks', {}))
-      _each(tasks, task => task.parent = challengeId)
-
-      return tasks
-    }).catch((error) => {
-      dispatch(addError(buildError(
-        "Task.fetchFailure", "Unable to fetch task clusters"
-      )))
-
-      console.log(error.response || error)
     })
   }
 }


### PR DESCRIPTION
* Browsing a challenge now receives its own route, making the browser
  back button behave as one might expect after starting a challenge.

* When working on a task, the challenge name is now linked to bring the
  user back to browsing the challenge.

* Social share links now make use of the browse route so that users will
  be offered more context rather than going straight into a random
  challenge task.

* Links to saved challenges on the user profile page now take the user
  to the browse route instead of into a random challenge task.