### PR TITLE
Disable project name filter for single project

### DIFF
--- a/src/components/AdminPane/Manage/Manage.js
+++ b/src/components/AdminPane/Manage/Manage.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import _get from 'lodash/get'
 import _find from 'lodash/find'
-import _isNumber from 'lodash/isNumber'
 import Sidebar from '../../Sidebar/Sidebar'
 import WithManageableChallenges from '../HOCs/WithManageableChallenges/WithManageableChallenges'
 import WithSearchResults from '../../HOCs/WithSearchResults/WithSearchResults'
@@ -19,12 +18,13 @@ import './Manage.css'
  */
 export class Manage extends Component {
   render() {
-    const selectedProjectId = _get(this.props, 'match.params.projectId')
+    const selectedProjectId =
+      parseInt(_get(this.props, 'match.params.projectId'), 10)
 
     let selectedProject = null
-    if (_isNumber(selectedProjectId)) {
+    if (!isNaN(selectedProjectId)) {
       selectedProject =
-        _find(this.props.projects, {id: parseInt(selectedProjectId, 10)})
+        _find(this.props.projects, {id: selectedProjectId})
     }
     else if (_get(this.props, 'projects.length', 0) === 1) {
       selectedProject = this.props.projects[0]

--- a/src/components/AdminPane/Manage/ManageProjects/ProjectList.js
+++ b/src/components/AdminPane/Manage/ManageProjects/ProjectList.js
@@ -13,19 +13,13 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 const ProjectList = function(props) {
-  return _map(props.projects, project => (
-    <div className='item-entry' key={project.id}>
-      <div className={classNames('columns list-item project-list-item',
-                                 {'is-active': project.id === _get(props, 'selectedProject.id')})}>
-        <div className='column is-narrow item-visibility'
-             title={project.enabled ?
-                    props.intl.formatMessage(messages.enabledTooltip) :
-                    props.intl.formatMessage(messages.disabledTooltip)}>
-          <SvgSymbol className={classNames('icon', {enabled: project.enabled})}
-                     viewBox='0 0 20 20'
-                     sym={project.enabled ? 'visible-icon' : 'hidden-icon'} />
-        </div>
-
+  return _map(props.projects, project => {
+    // If there's more than one project, highlight the selected project
+    // and link its name to displaying that project's challenges. But if
+    // there's only one project in the list, just show its name.
+    let projectNameColumn = null
+    if (props.projects.length > 1) {
+      projectNameColumn = (
         <div className={classNames(
           'column item-link',
           {'is-active': project.id === _get(props, 'selectedProject.id')})}
@@ -34,16 +28,42 @@ const ProjectList = function(props) {
             {project.displayName || project.name}
           </Link>
         </div>
+      )
+    }
+    else {
+      projectNameColumn = (
+        <div className="column item-link is-active">
+          {project.displayName || project.name}
+        </div>
+      )
+    }
 
-        <div className='column is-narrow has-text-right controls view-control'>
-          <Link to={`/admin/project/${project.id}`}
-                title={props.intl.formatMessage(messages.viewProjectTooltip)}>
-            <FormattedMessage {...messages.viewProjectLabel} />
-          </Link>
+    return (
+      <div className='item-entry' key={project.id}>
+        <div className={classNames(
+                          'columns list-item project-list-item',
+                          {'is-active': project.id === _get(props, 'selectedProject.id')})}>
+          <div className='column is-narrow item-visibility'
+              title={project.enabled ?
+                      props.intl.formatMessage(messages.enabledTooltip) :
+                      props.intl.formatMessage(messages.disabledTooltip)}>
+            <SvgSymbol className={classNames('icon', {enabled: project.enabled})}
+                      viewBox='0 0 20 20'
+                      sym={project.enabled ? 'visible-icon' : 'hidden-icon'} />
+          </div>
+
+          {projectNameColumn}
+
+          <div className='column is-narrow has-text-right controls view-control'>
+            <Link to={`/admin/project/${project.id}`}
+                  title={props.intl.formatMessage(messages.viewProjectTooltip)}>
+              <FormattedMessage {...messages.viewProjectLabel} />
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
-  ))
+    )
+  })
 }
 
 export default ProjectList

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -322,12 +322,16 @@ const updateUser = function(userId, updateFunction) {
  * @private
  */
 const reduceUsersFurther = function(mergedState, oldState, userEntities) {
-  // The generic reduction will merge arrays, creating a union of values.
-  // We don't want that for savedChallenges: we want to replace the old array
-  // with the new one. One complication is that not all user entities will
+  // The generic reduction will merge arrays, creating a union of values. We
+  // don't want that for user groups or savedChallenges: we want to replace the
+  // old arrays with new ones.
+  //
+  // One complication with savedChallenges is that not all user entities will
   // contain saved challenge data, as that comes from a separate API request.
   // So we only replace the challenge data if the entity contains some.
   for (let entity of userEntities) {
+    mergedState[entity.id].groups = entity.groups
+
     if (_isArray(entity.savedChallenges)) {
       mergedState[entity.id].savedChallenges = entity.savedChallenges
     }


### PR DESCRIPTION
Don't show the project name as a filter link in the create-and-manage
area if the user only has access to a single project.