### PR TITLE
Fetch tasks if challenge status usable. Fixes #127

### DIFF
--- a/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -9,6 +9,15 @@ import _omit from 'lodash/omit'
 import { TaskStatus }
        from '../../../../services/Task/TaskStatus/TaskStatus'
 
+/**
+ * WithFilteredClusteredTasks applies local filters to the given clustered
+ * tasks, along with a `toggleIncludedTaskStatus` function for toggling filtering
+ * on and off for a given status. The filter settings for each task status are
+ * passed down in the `includeTaskStatuses` props. By default, all statuses are
+ * enabled (so tasks in any status will pass through).
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
 export default function WithFilteredClusteredTasks(WrappedComponent,
                                                    tasksProp='clusteredTasks',
                                                    outputProp) {
@@ -17,6 +26,9 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       includeStatuses: _fromPairs(_map(TaskStatus, status => [status, true])),
     }
 
+    /**
+     * Toggle filtering on or off for the given task status
+     */
     toggleIncludedStatus = status => {
       this.setState({includeStatuses: Object.assign(
         {},
@@ -43,8 +55,8 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       }
 
       return <WrappedComponent {...{[outputProp]: filteredTasks}}
-                               includeStatuses={this.state.includeStatuses}
-                               toggleIncludedStatus={this.toggleIncludedStatus}
+                               includeTaskStatuses={this.state.includeStatuses}
+                               toggleIncludedTaskStatus={this.toggleIncludedStatus}
                                {..._omit(this.props, outputProp)} />
     }
   }

--- a/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
@@ -4,6 +4,7 @@ import { FormattedMessage,
 import { Link } from 'react-router-dom'
 import _get from 'lodash/get'
 import { ChallengeStatus,
+         isUsableChallengeStatus,
          messagesByStatus }
        from  '../../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import ChallengeActivityTimeline
@@ -50,7 +51,7 @@ export class ChallengeOverview extends Component {
             </div>
           </div>
 
-          {status !== ChallengeStatus.failed &&
+          {isUsableChallengeStatus(status) &&
            <div className="view-challenge">
              <Link to={`/challenge/${this.props.challenge.id}`}>
                <FormattedMessage {...messages.startChallengeLabel} />

--- a/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
@@ -14,14 +14,27 @@ import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
 import messages from './Messages'
 import './TaskAnalysisTable.css'
 
+// Setup child components with necessary HOCs
 const ViewTaskSubComponent = WithLoadedTask(ViewTask)
 
+/**
+ * TaskAnalysisTable renders a table of tasks using react-table.  Rendering is
+ * performed from summary info, like that given by clusteredTasks, but an
+ * individual task can be expanded to see additional details provided by
+ * the ViewTask component.
+ *
+ * @see See ViewTask
+ * @see See [react-table](https://react-table.js.org)
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
 export class TaskAnalysisTable extends Component {
   render() {
     const taskBaseRoute = 
       `/admin/project/${this.props.challenge.parent.id}` +
       `/challenge/${this.props.challenge.id}/task`
 
+    // Setup tasks table. See react-table docs for details.
     const data = _get(this.props, 'taskInfo.tasks', [])
     const columns = [{
       id: 'id',
@@ -55,6 +68,8 @@ export class TaskAnalysisTable extends Component {
         </div>
     }]
 
+    // Setup wrapper that displays total tasks available, percentage
+    // currrently included in the table, etc.
     const taskCountWrapper = [{
       id: 'taskCount',
       Header: () => {
@@ -98,6 +113,10 @@ TaskAnalysisTable.propTypes = {
     loading: PropTypes.bool,
     tasks: PropTypes.array,
   }),
+  /** Challenge the tasks belong to */
+  challenge: PropTypes.object,
+  /** Total tasks available (we may receive a subset) */
+  totalTaskCount: PropTypes.number,
 }
 
 export default injectIntl(TaskAnalysisTable)

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
@@ -21,8 +21,8 @@ import messages from './Messages'
 import './ViewChallenge.css'
 
 /**
- * ViewChallenge displays various challenge details and metrics of interest
- * to challenge owners, along with a list of the challenge tasks.
+ * ViewChallenge displays various challenge details and metrics of interest to
+ * challenge owners, along with the challenge tasks.
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
@@ -107,9 +107,14 @@ export class ViewChallenge extends Component {
 }
 
 ViewChallenge.propTypes = {
+  /** The parent project of the challenge */
   project: PropTypes.object,
+  /** The current challenge to view */
   challenge: PropTypes.object,
-  loadingTasks: PropTypes.bool.isRequired,
+  /** Set to true if challenge data is still loading */
+  loadingChallenge: PropTypes.bool.isRequired,
+  /** Invoked to signal the user wishes to delete the challenge */
+  deleteChallenge: PropTypes.func.isRequired,
 }
 
 export default WithCurrentChallenge(

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { FormattedMessage,
          FormattedRelative } from 'react-intl'
@@ -20,9 +21,16 @@ import TaskAnalysisTable from '../TaskAnalysisTable/TaskAnalysisTable'
 import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
 import messages from './Messages'
 
+// Setup child components with necessary HOCs
 const BoundedTaskTable =
   WithBoundedTasks(TaskAnalysisTable, 'filteredClusteredTasks', 'taskInfo')
 
+/**
+ * ViewChallengeTasks displays challenge tasks as both a map and a table,
+ * along with filtering controls for showing subsets of tasks.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
 export default class ViewChallengeTasks extends Component {
   state = {
     mapBounds: null,
@@ -47,7 +55,7 @@ export default class ViewChallengeTasks extends Component {
 
             <button className={classNames("button is-primary is-outlined has-svg-icon refresh-control",
                                           {"is-loading": this.props.loadingChallenge})}
-                    onClick={this.props.refreshStatus}>
+                    onClick={this.props.refreshChallengeStatus}>
               <SvgSymbol viewBox='0 0 20 20' sym="refresh-icon" />
               <FormattedMessage {...messages.refreshStatusLabel} />
             </button>
@@ -80,10 +88,10 @@ export default class ViewChallengeTasks extends Component {
     const statusFilters = _map(TaskStatus, status => (
       <div key={status} className="status-filter is-narrow">
         <div className={classNames("field", keysByStatus[status])}
-             onClick={() => this.props.toggleIncludedStatus(status)}>
+             onClick={() => this.props.toggleIncludedTaskStatus(status)}>
           <input className="is-checkradio is-circle has-background-color is-success"
                  type="checkbox"
-                 checked={this.props.includeStatuses[status]}
+                 checked={this.props.includeTaskStatuses[status]}
                  onChange={() => null} />
           <label>
             <FormattedMessage {...messagesByStatus[status]} />
@@ -93,7 +101,7 @@ export default class ViewChallengeTasks extends Component {
     ))
 
     const filterOptions = {
-      includeStatuses: this.props.includeStatuses,
+      includeStatuses: this.props.includeTaskStatuses,
       withinBounds: this.state.mapBounds,
     }
 
@@ -120,4 +128,27 @@ export default class ViewChallengeTasks extends Component {
       </div>
     )
   }
+}
+
+ViewChallengeTasks.propTypes = {
+  /** The tasks to display */
+  filteredClusteredTasks: PropTypes.shape({
+    challengeId: PropTypes.number,
+    loading: PropTypes.bool,
+    tasks: PropTypes.array,
+  }),
+  /** Challenge the tasks belong to */
+  challenge: PropTypes.object,
+  /** Set to true if challenge data is loading */
+  loadingChallenge: PropTypes.bool,
+  /** Invoked to refresh the status of the challenge */
+  refreshChallengeStatus: PropTypes.func.isRequired,
+  /** Object enumerating whether each task status filter is on or off. */
+  includeTaskStatuses: PropTypes.object,
+  /** Invoked to toggle filtering of a task status on or off */
+  toggleIncludedTaskStatus: PropTypes.func.isRequired,
+}
+
+ViewChallengeTasks.defaultProps = {
+  loadingChallenge: false,
 }

--- a/src/components/AdminPane/MetricsOverview/CompletionMetrics.js
+++ b/src/components/AdminPane/MetricsOverview/CompletionMetrics.js
@@ -1,16 +1,18 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { TaskStatus }
+import { injectIntl } from 'react-intl'
+import { TaskStatus,
+         statusLabels }
        from '../../../services/Task/TaskStatus/TaskStatus'
 import LabeledProgressBar from '../../Bulma/LabeledProgressBar'
 import _map from 'lodash/map'
 import _values from 'lodash/values'
 import _sum from 'lodash/sum'
-import _startCase from 'lodash/startCase'
 import _pick from 'lodash/pick'
 import _keys from 'lodash/keys'
+import messages from './Messages'
 
-export default class CompletionMetrics extends Component {
+export class CompletionMetrics extends Component {
   render() {
     const allStatusMetrics =
       _pick(this.props.taskMetrics, _keys(TaskStatus))
@@ -19,23 +21,28 @@ export default class CompletionMetrics extends Component {
       _pick(this.props.taskMetrics,
             ['fixed', 'falsePositive', 'alreadyFixed', 'skipped', 'tooHard'])
 
+    const localizedStatusLabels = statusLabels(this.props.intl)
     const totalEvaluated = _sum(_values(evaluatedStatusMetrics))
 
     let statusProgressBars = null
     if (!this.props.onlyCompleted) {
       statusProgressBars = _map(allStatusMetrics,
-        (value, label) =>
+        (value, statusName) =>
           <LabeledProgressBar className='completion-progress'
-                              key={label} label={_startCase(label)}
-                              value={value} max={this.props.taskMetrics.total} />
+                              key={statusName}
+                              label={localizedStatusLabels[statusName]}
+                              value={value}
+                              max={this.props.taskMetrics.total} />
       )
     }
 
     return (
       <div className="completion-stats">
         <LabeledProgressBar className='completion-progress'
-                            key="total-completed" label="Evaluated"
-                            value={totalEvaluated} max={this.props.taskMetrics.total} />
+                            key="total-completed"
+                            label={this.props.intl.formatMessage(messages.evaluatedLabel)}
+                            value={totalEvaluated}
+                            max={this.props.taskMetrics.total} />
         {!this.props.onlyCompleted && <div>{statusProgressBars}</div>}
       </div>
     )
@@ -45,3 +52,5 @@ export default class CompletionMetrics extends Component {
 CompletionMetrics.propTypes = {
   taskMetrics: PropTypes.object.isRequired,
 }
+
+export default injectIntl(CompletionMetrics)

--- a/src/components/AdminPane/MetricsOverview/Messages.js
+++ b/src/components/AdminPane/MetricsOverview/Messages.js
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with MetricsOverview
+ */
+export default defineMessages({
+  evaluatedLabel: {
+    id: "Metrics.tasks.evaluatedByUser.label",
+    defaultMessage: "Evaluated by User",
+  },
+})

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -44,6 +44,25 @@ export const challengeDenormalizationSchema = function() {
   })
 }
 
+// utility functions
+
+/**
+ * Retrieves the resulting challenge entity object from the given
+ * normalizedChallengeResults, or null if there is no result.
+ *
+ * > Note that if the results contain multiple challenges, only the
+ * > first challenge entity is returned.
+ */
+export const challengeResultEntity = function(normalizedChallengeResults) {
+  const challengeId = _isArray(normalizedChallengeResults.result) ?
+                      normalizedChallengeResults.result[0] :
+                      normalizedChallengeResults.result
+
+  return _isNumber(challengeId) ?
+         normalizedChallengeResults.entities.challenges[challengeId] :
+         null
+}
+
 // redux actions -- see Server/ChallengeActions
 
 // redux action creators
@@ -495,11 +514,11 @@ export const deleteChallenge = function(challengeId) {
  * > parent project of the first result is retrieved.
  */
 const fetchParentProject = function(dispatch, normalizedChallengeResults) {
-  const challengeId = _isArray(normalizedChallengeResults.result) ?
-                      normalizedChallengeResults.result[0] :
-                      normalizedChallengeResults.result
-  const projectId = normalizedChallengeResults.entities.challenges[challengeId].parent
-  return dispatch(fetchProject(projectId))
+  const challenge = challengeResultEntity(normalizedChallengeResults)
+
+  if (challenge) {
+    return dispatch(fetchProject(challenge.parent))
+  }
 }
 
 /**


### PR DESCRIPTION
When a challenge owner views a challenge, do not attempt to fetch the
challenge tasks if the tasks are still building or if they failed to
build.