### PR TITLE
Preserve challenge-owner map. Closes #123

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
@@ -108,9 +108,9 @@ export class ChallengeTaskMap extends Component {
     }
 
     this.currentBounds = bounds
-    if (this.props.setChallengeMapBounds) {
-      this.props.setChallengeMapBounds(this.props.challenge.id,
-                                       bounds, zoom)
+    if (this.props.setChallengeOwnerMapBounds) {
+      this.props.setChallengeOwnerMapBounds(this.props.challenge.id,
+                                            bounds, zoom)
     }
   }
 
@@ -306,7 +306,7 @@ ChallengeTaskMap.propTypes = {
   /** Options for filtering displayed tasks */
   filterOptions: PropTypes.object,
   /** Invoked when the user moves or zooms the map */
-  setChallengeMapBounds: PropTypes.func,
+  setChallengeOwnerMapBounds: PropTypes.func,
   /** Optional default map layer to display */
   defaultLayer: PropTypes.object,
   /** Set to true to render monochromatic cluster icons */

--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.scss
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.scss
@@ -41,6 +41,21 @@
   .leaflet-container {
     height: 400px;
     width: auto;
+
+    .leaflet-popup-content-wrapper {
+      .leaflet-popup-content {
+        width: 200px;
+        padding: 10px;
+
+        .marker-popup-content {
+          text-align: center;
+
+          &__links {
+            margin-top: 10px;
+          }
+        }
+      }
+    }
   }
 
   .cluster-tasks-control {
@@ -53,14 +68,6 @@
     padding: 5px;
     border: 1px solid $grey-lighter;
     border-radius: $radius-medium;
-  }
-
-  .marker-popup-content {
-    text-align: center;
-
-    &__links {
-      margin-top: 10px;
-    }
   }
 
   .greyscale-cluster {

--- a/src/components/HOCs/WithMapBounds/WithMapBounds.js
+++ b/src/components/HOCs/WithMapBounds/WithMapBounds.js
@@ -5,7 +5,9 @@ import _isEmpty from 'lodash/isEmpty'
 import _uniqueId from 'lodash/uniqueId'
 import { setLocatorMapBounds,
          setChallengeMapBounds,
-         setTaskMapBounds }
+         setTaskMapBounds,
+         setChallengeOwnerMapBounds,
+       }
        from '../../../services/MapBounds/MapBounds'
 import { fetchChallengesWithinBoundingBox }
        from '../../../services/Challenge/Challenge'
@@ -43,6 +45,7 @@ const mapStateToProps = state => ({
     locator: convertBounds(_get(state, 'currentMapBounds.locator')),
     challenge: convertBounds(_get(state, 'currentMapBounds.challenge')),
     task: convertBounds(_get(state, 'currentMapBounds.task')),
+    challengeOwner: convertBounds(_get(state, 'currentMapBounds.challengeOwner')),
   }
 })
 
@@ -54,6 +57,10 @@ const mapDispatchToProps = dispatch => {
 
     setChallengeMapBounds: (challengeId, bounds, zoom) => {
       dispatch(setChallengeMapBounds(challengeId, bounds, zoom))
+    },
+
+    setChallengeOwnerMapBounds: (challengeId, bounds, zoom) => {
+      dispatch(setChallengeOwnerMapBounds(challengeId, bounds, zoom))
     },
 
     updateBoundedChallenges: bounds => {

--- a/src/services/MapBounds/MapBounds.js
+++ b/src/services/MapBounds/MapBounds.js
@@ -79,6 +79,7 @@ export const toLatLngBounds = function(arrayBounds) {
 const SET_LOCATOR_MAP_BOUNDS = 'SET_LOCATOR_MAP_BOUNDS'
 const SET_CHALLENGE_MAP_BOUNDS = 'SET_CHALLENGE_MAP_BOUNDS'
 const SET_TASK_MAP_BOUNDS = 'SET_TASK_MAP_BOUNDS'
+const SET_CHALLENGE_OWNER_MAP_BOUNDS = 'SET_CHALLENGE_OWNER_MAP_BOUNDS'
 
 // redux action creators
 
@@ -105,8 +106,8 @@ export const setLocatorMapBounds = function(bounds, fromUserAction=false) {
 }
 
 /**
- * Set the given bounds of the challenge (browsing) map in the redux store as
- * the current bounds.
+ * Update the redux store with the given bounds of the challenge (browsing)
+ * map.
  *
  * @param bounds - either a LatLngBounds instance or an array of
  *       [west, south, east, north]
@@ -114,6 +115,21 @@ export const setLocatorMapBounds = function(bounds, fromUserAction=false) {
 export const setChallengeMapBounds = function(challengeId, bounds, zoom) {
   return {
     type: SET_CHALLENGE_MAP_BOUNDS,
+    challengeId,
+    bounds: fromLatLngBounds(bounds),
+    zoom,
+  }
+}
+
+/**
+ * Update the redux store with the given bounds of a challenge-owner map.
+ *
+ * @param bounds - either a LatLngBounds instance or an array of
+ *       [west, south, east, north]
+ */
+export const setChallengeOwnerMapBounds = function(challengeId, bounds, zoom) {
+  return {
+    type: SET_CHALLENGE_OWNER_MAP_BOUNDS,
     challengeId,
     bounds: fromLatLngBounds(bounds),
     zoom,
@@ -152,44 +168,40 @@ const defaultState = {
 }
 
 export const currentMapBounds = function(state=defaultState, action) {
-  if (action.type === SET_LOCATOR_MAP_BOUNDS) {
-    return Object.assign(
-      {},
-      state,
-      {
+  switch(action.type) {
+    case SET_LOCATOR_MAP_BOUNDS:
+      return Object.assign({}, state, {
         locator: {
           bounds: action.bounds,
-          fromUserAction: action.fromUserAction
+          fromUserAction: action.fromUserAction,
         }
-      },
-    )
-  }
-  else if (action.type === SET_CHALLENGE_MAP_BOUNDS) {
-    return Object.assign(
-      {},
-      state,
-      {
+      })
+    case SET_CHALLENGE_MAP_BOUNDS:
+      return Object.assign({}, state, {
         challenge: {
           challengeId: action.challengeId,
           bounds: action.bounds,
           zoom: action.zoom,
         }
-      },
-    )
-  }
-  else if (action.type === SET_TASK_MAP_BOUNDS) {
-    return Object.assign(
-      {},
-      state,
-      {
+      })
+    case SET_TASK_MAP_BOUNDS:
+      return Object.assign({}, state, {
         task: {
           bounds: action.bounds,
           zoom: action.zoom,
-          fromUserAction: action.fromUserAction
+          fromUserAction: action.fromUserAction,
         }
-      },
-    )
+      })
+    case SET_CHALLENGE_OWNER_MAP_BOUNDS:
+      return Object.assign({}, state, {
+        challengeOwner: {
+          challengeId: action.challengeId,
+          bounds: action.bounds,
+          zoom: action.zoom,
+          updatedAt: Date.now(),
+        }
+      })
+    default:
+      return state
   }
-
-  return state
 }


### PR DESCRIPTION
The latest bounds and zoom of the challenge-owner map are now preserved
if the user navigates away and then returns to it.