### PR TITLE
Properly url-encode change comment sent to editor.

### DIFF
--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -115,7 +115,8 @@ export const constructIdURI = function(task, mapBounds) {
 	}))
 
   const idUriComponent = "id=" + featureStrings.join(',')
-  const commentUriComponent = "comment=" + encodeURI(task.parent.checkinComment)
+  const commentUriComponent = "comment=" +
+                              encodeURIComponent(task.parent.checkinComment)
 
   return baseUriComponent +
          [idUriComponent, mapUriComponent, commentUriComponent].join('&')
@@ -132,7 +133,7 @@ export const constructJosmURI = function(asNewLayer = false, task, mapBounds) {
   const ne = mapBounds.bounds.getNorthEast()
   let uri = `http://127.0.0.1:8111/load_and_zoom?left=${sw.lng}&right=${ne.lng}` +
             `&top=${ne.lat}&bottom=${sw.lat}&new_layer=${asNewLayer ? 'true' : 'false'}` +
-            `&changeset_comment=${encodeURI(task.parent.checkinComment)}&select=`
+            `&changeset_comment=${encodeURIComponent(task.parent.checkinComment)}&select=`
 
   let selects = []
   if (task.geometries && task.geometries.features) {
@@ -190,14 +191,13 @@ export const featureOSMId = function(feature) {
     return null
   }
 
-  if (feature.properties.osmid) {
-    return feature.properties.osmid
+  const idValue = feature.properties.osmid || feature.properties['@id']
+  if (!idValue) {
+    return null
   }
-  else if (feature.properties['@id']) {
-    // The @id property will often contain a representation of the feature type
-    // prior to the numerical id, which we strip out as different editors may
-    // expect different representations.
-    const match = /[^\d]*(\d+)$/.exec(feature.properties['@id'])
-    return (match && match.length > 1) ? match[1] : null
-  }
+
+  // id properties may contain additional information, such as a representation
+  // of the feature type. We want to return just the the numerical OSM id.
+  const match = /(\d+)/.exec(idValue)
+  return (match && match.length > 1) ? match[1] : null
 }

--- a/src/services/Editor/Editor.test.js
+++ b/src/services/Editor/Editor.test.js
@@ -136,13 +136,11 @@ describe('constructJosmURI', () => {
   })
 
   test("uri includes a URI-encoded checkin comment from the task challenge", () => {
+    challenge.checkinComment = "###Non-Conforming"
     const uri = constructJosmURI(true, task, mapBounds)
 
-    expect(uri).toEqual(
-      expect.stringContaining(
-        `changeset_comment=${encodeURI(challenge.checkinComment)}`
-      )
-    )
+    expect(uri).toEqual(expect.stringContaining("Conforming"))
+    expect(uri).not.toEqual(expect.stringContaining("#"))
   })
 
   test("uri includes a node selection for Point features with an OSM id", () => {
@@ -322,16 +320,16 @@ describe('featureOSMId', () => {
     expect(featureOSMId(basicFeature)).toBeNull()
   })
 
-  test("returns the `osmid` property if it exists", () => {
-    basicFeature.properties.osmid = '123'
+  test("returns the numeical id from the `osmid` property if it exists", () => {
+    basicFeature.properties.osmid = '"123"'
 
     expect(featureOSMId(basicFeature)).toEqual('123')
   })
 
-  test("returns the id from the `@id` property if it exists", () => {
-    basicFeature.properties['@id'] = 'way/456'
+  test("returns the numerical id from the `@id` property if it exists", () => {
+    basicFeature.properties['@id'] = '"node/1042007773"'
 
-    expect(featureOSMId(basicFeature)).toEqual('456')
+    expect(featureOSMId(basicFeature)).toEqual('1042007773')
   })
 
   test("favors osmid over @id if both are present", () => {


### PR DESCRIPTION
Change comments were being url-encoded with encodeURI instead of
encodeURIComponent, leading to the possibility of incorrectly encoded
change comments. Among other problems, this could lead to URL truncation
that resulted in lack of feature selection in the editor.