### PR TITLE
Always allow commenting on tasks. Closes #113.

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -128,7 +128,11 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
      * Move to the next task without setting any completion status,
      * useful for when a user visits a task that is already complete.
      */
-    nextTask: (challengeId, taskId, taskLoadBy) =>
+    nextTask: (challengeId, taskId, taskLoadBy, comment) => {
+      if (_isString(comment) && comment.length > 0) {
+        dispatch(addTaskComment(taskId, comment))
+      }
+
       dispatch(
         loadRandomTaskFromChallenge(
           challengeId,
@@ -136,7 +140,8 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         )
       ).then(newTask =>
         visitNewTask(challengeId, taskId, newTask, ownProps.history)
-      ),
+      )
+    },
   }
 }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -53,6 +53,10 @@ export class ActiveTaskControls extends Component {
                             taskStatus, this.state.comment, this.props.taskLoadBy)
   }
 
+  next = (challengeId, taskId) => {
+    this.props.nextTask(challengeId, taskId, this.props.taskLoadBy, this.state.comment)
+  }
+
   render() {
     // If the user is not logged in, show a sign-in button instead of controls.
     if (!_get(this.props, 'user.isLoggedIn')) {
@@ -84,8 +88,6 @@ export class ActiveTaskControls extends Component {
       const allowedProgressions =
         allowedStatusProgressions(this.props.task.status)
 
-      const canProgress = allowedProgressions.size > 0
-
       const hasExistingStatus = _isNumber(this.props.task.status) &&
                                 this.props.task.status !== TaskStatus.created
 
@@ -95,22 +97,22 @@ export class ActiveTaskControls extends Component {
           <TaskTrackControls className="active-task-controls__track-task"
                              {..._omit(this.props, 'className')} />
 
-          {canProgress &&
-           <TaskCommentInput className="active-task-controls__task-comment"
-                             value={this.state.comment}
-                             commentChanged={this.setComment}
-                             {..._omit(this.props, 'className')} />
-          }
+          <TaskCommentInput className="active-task-controls__task-comment"
+                            value={this.state.comment}
+                            commentChanged={this.setComment}
+                            {..._omit(this.props, 'className')} />
 
           {!isEditingTask &&
            <TaskCompletionStep1 allowedProgressions={allowedProgressions}
                                 pickEditor={this.pickEditor}
                                 complete={this.complete}
-                                {...this.props} />
+                                nextTask={this.next}
+                                {..._omit(this.props, 'nextTask')} />
           }
 
           {!isEditingTask && hasExistingStatus &&
-           <TaskNextControl {...this.props} />
+           <TaskNextControl nextTask={this.next}
+                            {..._omit(this.props, 'nextTask')} />
           }
 
           {isEditingTask &&

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.scss
@@ -5,6 +5,9 @@
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
+    margin-top: 10px;
+    margin-bottom: 10px;
+
 
     button.button.large-and-wide {
       margin-bottom: 10px;
@@ -32,7 +35,6 @@
 
   &__task-comment {
     width: 100%;
-    margin-bottom: 20px;
 
     input {
       width: 100%;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.test.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.test.js
@@ -86,12 +86,24 @@ test("shows track/untrack controls", () => {
   expect(wrapper).toMatchSnapshot()
 })
 
-test("shows a completion comment field if status is appropriate", () => {
+test("shows a completion comment field", () => {
   const wrapper = shallow(
     <ActiveTaskControls {...basicProps} />
   )
 
   expect(wrapper.find('TaskCommentInput').exists()).toBe(true)
+})
+
+test("shows a comment field even for tasks that cannot progress further", () => {
+  basicProps.task.status = TaskStatus.fixed
+
+  const wrapper = shallow(
+    <ActiveTaskControls {...basicProps} />
+  )
+
+  expect(wrapper.find('TaskCommentInput').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
 })
 
 test("the comment field contains the current comment", () => {
@@ -103,18 +115,6 @@ test("the comment field contains the current comment", () => {
   wrapper.update()
 
   expect(wrapper.find('TaskCommentInput[value="Foo"]').exists()).toBe(true)
-})
-
-test("does not show comment field if task cannot progress to new status", () => {
-  basicProps.task.status = TaskStatus.fixed
-
-  const wrapper = shallow(
-    <ActiveTaskControls {...basicProps} />
-  )
-
-  expect(wrapper.find('TaskCommentInput').exists()).toBe(false)
-
-  expect(wrapper).toMatchSnapshot()
 })
 
 test("shows completion controls if the user has begun editing the task", () => {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCommentInput/TaskCommentInput.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCommentInput/TaskCommentInput.scss
@@ -2,7 +2,6 @@
 
 .task-completion-comment {
   width: 100%;
-  margin-bottom: 10px;
 
   input {
     width: 100%;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.scss
@@ -1,8 +1,8 @@
 @import '../../../../../variables.scss';
 
 .active-task-details .next-control {
-  margin-top: 15px;
-  margin-bottom: 0px;
+  margin-top: 5px;
+  margin-bottom: 10px;
 
   svg {
     height: 18px;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTrackControls/TaskTrackControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTrackControls/TaskTrackControls.js
@@ -64,6 +64,7 @@ export default class TaskTrackControls extends Component {
       control = (
         <div className="field" onClick={this.toggleSaved}>
           <input type="checkbox" className="switch is-thin"
+                 onChange={() => {}}
                  checked={this.taskIsTracked()} />
           <label>
             <FormattedMessage {...messages.trackLabel } />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTrackControls/__snapshots__/TaskTrackControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTrackControls/__snapshots__/TaskTrackControls.test.js.snap
@@ -52,6 +52,7 @@ ShallowWrapper {
         <input
                 checked={true}
                 className="switch is-thin"
+                onChange={[Function]}
                 type="checkbox"
         />
         <label>
@@ -74,6 +75,7 @@ ShallowWrapper {
           <input
             checked={true}
             className="switch is-thin"
+            onChange={[Function]}
             type="checkbox"
 />,
           <label>
@@ -96,6 +98,7 @@ ShallowWrapper {
           "props": Object {
             "checked": true,
             "className": "switch is-thin",
+            "onChange": [Function],
             "type": "checkbox",
           },
           "ref": null,
@@ -147,6 +150,7 @@ ShallowWrapper {
           <input
                     checked={true}
                     className="switch is-thin"
+                    onChange={[Function]}
                     type="checkbox"
           />
           <label>
@@ -169,6 +173,7 @@ ShallowWrapper {
             <input
               checked={true}
               className="switch is-thin"
+              onChange={[Function]}
               type="checkbox"
 />,
             <label>
@@ -191,6 +196,7 @@ ShallowWrapper {
             "props": Object {
               "checked": true,
               "className": "switch is-thin",
+              "onChange": [Function],
               "type": "checkbox",
             },
             "ref": null,
@@ -288,6 +294,7 @@ ShallowWrapper {
         <input
                 checked={false}
                 className="switch is-thin"
+                onChange={[Function]}
                 type="checkbox"
         />
         <label>
@@ -310,6 +317,7 @@ ShallowWrapper {
           <input
             checked={false}
             className="switch is-thin"
+            onChange={[Function]}
             type="checkbox"
 />,
           <label>
@@ -332,6 +340,7 @@ ShallowWrapper {
           "props": Object {
             "checked": false,
             "className": "switch is-thin",
+            "onChange": [Function],
             "type": "checkbox",
           },
           "ref": null,
@@ -383,6 +392,7 @@ ShallowWrapper {
           <input
                     checked={false}
                     className="switch is-thin"
+                    onChange={[Function]}
                     type="checkbox"
           />
           <label>
@@ -405,6 +415,7 @@ ShallowWrapper {
             <input
               checked={false}
               className="switch is-thin"
+              onChange={[Function]}
               type="checkbox"
 />,
             <label>
@@ -427,6 +438,7 @@ ShallowWrapper {
             "props": Object {
               "checked": false,
               "className": "switch is-thin",
+              "onChange": [Function],
               "type": "checkbox",
             },
             "ref": null,

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
@@ -2340,7 +2340,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`does not show comment field if task cannot progress to new status 1`] = `
+exports[`shows a comment field even for tasks that cannot progress further 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
@@ -2602,7 +2602,131 @@ ShallowWrapper {
                             }
           }
 />,
-        false,
+        <TaskCommentInput
+          activateKeyboardShortcutGroup={[Function]}
+          challengeId={321}
+          className="active-task-controls__task-comment"
+          closeEditor={[Function]}
+          commentChanged={[Function]}
+          completeTask={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          editTask={[Function]}
+          editor={Object {}}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          nextTask={[Function]}
+          saveTask={[Function]}
+          setTaskBeingCompleted={[Function]}
+          setTaskLoadBy={[Function]}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 1,
+                            }
+          }
+          taskLoadBy="random"
+          unsaveTask={[Function]}
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+          value=""
+/>,
         <TaskCompletionStep1
           activateKeyboardShortcutGroup={[Function]}
           allowedProgressions={Set {}}
@@ -3100,7 +3224,129 @@ ShallowWrapper {
         "rendered": null,
         "type": [Function],
       },
-      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcutGroup": [Function],
+          "challengeId": 321,
+          "className": "active-task-controls__task-comment",
+          "closeEditor": [Function],
+          "commentChanged": [Function],
+          "completeTask": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "editTask": [Function],
+          "editor": Object {},
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "nextTask": [Function],
+          "saveTask": [Function],
+          "setTaskBeingCompleted": [Function],
+          "setTaskLoadBy": [Function],
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 1,
+          },
+          "taskLoadBy": "random",
+          "unsaveTask": [Function],
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+          "value": "",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
       Object {
         "instance": null,
         "key": undefined,
@@ -3599,7 +3845,131 @@ ShallowWrapper {
                                   }
             }
 />,
-          false,
+          <TaskCommentInput
+            activateKeyboardShortcutGroup={[Function]}
+            challengeId={321}
+            className="active-task-controls__task-comment"
+            closeEditor={[Function]}
+            commentChanged={[Function]}
+            completeTask={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            editTask={[Function]}
+            editor={Object {}}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            nextTask={[Function]}
+            saveTask={[Function]}
+            setTaskBeingCompleted={[Function]}
+            setTaskLoadBy={[Function]}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 1,
+                                  }
+            }
+            taskLoadBy="random"
+            unsaveTask={[Function]}
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+            value=""
+/>,
           <TaskCompletionStep1
             activateKeyboardShortcutGroup={[Function]}
             allowedProgressions={Set {}}
@@ -4097,7 +4467,129 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcutGroup": [Function],
+            "challengeId": 321,
+            "className": "active-task-controls__task-comment",
+            "closeEditor": [Function],
+            "commentChanged": [Function],
+            "completeTask": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "editTask": [Function],
+            "editor": Object {},
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "nextTask": [Function],
+            "saveTask": [Function],
+            "setTaskBeingCompleted": [Function],
+            "setTaskLoadBy": [Function],
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 1,
+            },
+            "taskLoadBy": "random",
+            "unsaveTask": [Function],
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+            "value": "",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
         Object {
           "instance": null,
           "key": undefined,

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -98,13 +98,18 @@ export const completeTask = function(taskId, challengeId, taskStatus) {
 }
 
 /**
- * Add a comment to the given task, using the given status.
+ * Add a comment to the given task, associating the given task status if
+ * provided.
  */
 export const addTaskComment = function(taskId, comment, taskStatus) {
   return function(dispatch) {
+    const params = {comment}
+    if (_isNumber(taskStatus)) {
+      params.actionId = taskStatus
+    }
+
     return new Endpoint(
-      api.task.addComment,
-      {variables: {id: taskId}, params: {comment, actionId: taskStatus}}
+      api.task.addComment, {variables: {id: taskId}, params}
     ).execute().then(() => {
       fetchTaskComments(taskId)(dispatch)
       fetchTask(taskId)(dispatch) // Refresh task data


### PR DESCRIPTION
A comment field is now offered to users regardless of the task status,
whereas before it was only offered if the task was able to progress to a
new status.