### PR TITLE
Only fit features bounds once on task map.

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -42,7 +42,8 @@ export default class EnhancedMap extends Map {
   }
 
   updateFeatures = (newFeatures) => {
-    if (!_isEmpty(this.currentFeatures)) {
+    const hasExistingFeatures = !_isEmpty(this.currentFeatures)
+    if (hasExistingFeatures) {
       this.currentFeatures.remove()
     }
 
@@ -57,7 +58,11 @@ export default class EnhancedMap extends Map {
         this.currentFeatures.addTo(this.leafletElement)
       }
 
-      this.leafletElement.fitBounds(this.currentFeatures.getBounds().pad(0.5))
+      // If we're only supposed to fit the features once, don't do it
+      // if we already had features.
+      if (!this.props.fitFeaturesOnlyOnce || !hasExistingFeatures) {
+        this.leafletElement.fitBounds(this.currentFeatures.getBounds().pad(0.5))
+      }
     }
   }
 

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -72,6 +72,7 @@ export default class TaskMap extends Component {
                      center={this.props.centerPoint} zoom={zoom} zoomControl={false}
                      minZoom={minZoom} maxZoom={maxZoom}
                      features={_get(this.props.task, 'geometries.features')}
+                     fitFeaturesOnlyOnce
                      onBoundsChange={this.updateTaskBounds}
         >
           <ZoomControl position='topright' />

--- a/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
+++ b/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
@@ -69,6 +69,7 @@ ShallowWrapper {
                             }
           }
           features={null}
+          fitFeaturesOnlyOnce={true}
           justFitFeatures={false}
           maxZoom={0}
           minZoom={1}
@@ -173,6 +174,7 @@ ShallowWrapper {
 />,
           ],
           "features": null,
+          "fitFeaturesOnlyOnce": true,
           "justFitFeatures": false,
           "maxZoom": 0,
           "minZoom": 1,
@@ -264,6 +266,7 @@ ShallowWrapper {
                                   }
             }
             features={null}
+            fitFeaturesOnlyOnce={true}
             justFitFeatures={false}
             maxZoom={0}
             minZoom={1}
@@ -368,6 +371,7 @@ ShallowWrapper {
 />,
             ],
             "features": null,
+            "fitFeaturesOnlyOnce": true,
             "justFitFeatures": false,
             "maxZoom": 0,
             "minZoom": 1,

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -200,6 +200,7 @@
   "ActiveTask.controls.comments.tooltip": "View Comments",
   "ActiveTask.subheading.comments": "Comments",
   "ActiveTask.heading": "Challenge Information",
+  "Task.controls.contactOwner.label": "Contact Owner",
   "ActiveTask.subheading.instructions": "Instructions",
   "ActiveTask.subheading.location": "Location",
   "ActiveTask.subheading.social": "Share",


### PR DESCRIPTION
If things were slow to load, it was possible for the task map to re-fit
to the features after the user had begun interacting it, causing the map
to snap back to its original position. Task maps will now only fit
bounds to features once.