### PR TITLE
Support async deleted challenges. Closes #108

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
+++ b/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import _map from 'lodash/map'
 import _get from 'lodash/get'
+import _compact from 'lodash/compact'
 import { Link } from 'react-router-dom'
 import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
 import messages from './Messages'
@@ -18,7 +19,11 @@ import './ChallengeList.css'
  */
 export default class ChallengeList extends Component {
   render() {
-    const challengeItems = _map(this.props.challenges, challenge => {
+    const challengeItems = _compact(_map(this.props.challenges, challenge => {
+      if (challenge.deleted) {
+        return null
+      }
+
       const projectId = _get(challenge, 'parent.id', challenge.parent)
 
       return (
@@ -38,7 +43,7 @@ export default class ChallengeList extends Component {
           </div>
         </div>
       )
-    })
+    }))
 
     return (
       <div className='admin__manage__managed-item-list challenge-list'>

--- a/src/components/HOCs/WithChallenges/WithChallenges.js
+++ b/src/components/HOCs/WithChallenges/WithChallenges.js
@@ -33,6 +33,7 @@ export const mapStateToProps = (state, ownProps) => {
                             challenge.actions.available === 0 : false
 
       return challenge.enabled &&
+             !challenge.deleted &&
              !tasksComplete &&
              isUsableChallengeStatus(challenge.status)
     })

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -520,6 +520,12 @@ const reduceChallengesFurther = function(mergedState, oldState, challengeEntitie
   // The generic reduction will merge arrays and objects, and some fields
   // we want to simply overwrite with the latest data.
   challengeEntities.forEach(entity => {
+    // Until we implement undelete, ignore deleted challenges.
+    if (entity.deleted) {
+      delete mergedState[entity.id]
+      return
+    }
+
     if (_isArray(entity.tags)) {
       mergedState[entity.id].tags = entity.tags
     }


### PR DESCRIPTION
The server now instantly marks challenges as deleted, and then cleans
them up asynchronously, rather than deleting them synchronously as it
did before. These deleted challenges are now ignored in the front-end
while pending deletion.