### PR TITLE
Directly load project actions in admin.

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
@@ -9,7 +9,8 @@ import _omit from 'lodash/omit'
 import { fetchProject,
          fetchProjectActivity,
          saveProject } from '../../../../services/Project/Project'
-import { fetchProjectChallenges }
+import { fetchProjectChallenges,
+         fetchProjectChallengeActions }
        from '../../../../services/Challenge/Challenge'
 import AppErrors from '../../../../services/Error/AppErrors'
 import { addError } from '../../../../services/Error/Error'
@@ -86,7 +87,14 @@ const WithCurrentProject = function(WrappedComponent, options={}) {
         })
 
         if (options.includeChallenges) {
-          props.fetchProjectChallenges(projectId).then(() =>
+          const retrievals = []
+          retrievals.push(props.fetchProjectChallenges(projectId))
+
+          if (options.includeActivity) {
+            retrievals.push(props.fetchProjectChallengeActions(projectId))
+          }
+
+          Promise.all(retrievals).then(() =>
             this.setState({loadingChallenges: false})
           )
         }
@@ -144,6 +152,8 @@ const mapDispatchToProps = dispatch => ({
   saveProject: projectData => dispatch(saveProject(projectData)),
   fetchProjectChallenges: projectId =>
     dispatch(fetchProjectChallenges(projectId)),
+  fetchProjectChallengeActions: projectId =>
+    dispatch(fetchProjectChallengeActions(projectId)),
   notManagerError: () => dispatch(addError(AppErrors.project.notManager)),
 })
 

--- a/src/components/AdminPane/Manage/ProjectMetrics/ProjectMetrics.js
+++ b/src/components/AdminPane/Manage/ProjectMetrics/ProjectMetrics.js
@@ -51,7 +51,7 @@ export default class ProjectMetrics extends Component {
 
         <div className="project-metrics__stats">
           <ChallengeMetrics burndownHeight={400}
-                            burndownActivity={_get(this.props, 'project.activity', [])}
+                            activity={_get(this.props, 'project.activity', [])}
                             {...this.props} />
         </div>
       </div>

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
+import _get from 'lodash/get'
 import WithCurrentChallenge
        from '../../HOCs/WithCurrentChallenge/WithCurrentChallenge'
 import WithFilteredClusteredTasks
@@ -59,7 +60,7 @@ export class ViewChallenge extends Component {
                 </Link>
               </li>
               <li>
-                <Link to={`/admin/project/${this.props.challenge.parent.id}`}>
+                <Link to={`/admin/project/${_get(this.props, 'challenge.parent.id')}`}>
                   {this.props.challenge.parent.displayName ||
                   this.props.challenge.parent.name}
                 </Link>

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -239,6 +239,31 @@ export const fetchChallengeActions = function(challengeId = null) {
 }
 
 /**
+ * Fetch action metrics for all challenges in the given project.
+ */
+export const fetchProjectChallengeActions = function(projectId) {
+  return function(dispatch) {
+    return new Endpoint(
+      api.challenges.actions,
+      {schema: [ challengeSchema() ], params: {projectList: projectId}}
+    ).execute().then(normalizedResults => {
+      dispatch(receiveChallenges(normalizedResults.entities))
+    }).catch((error) => {
+      if (error.response && error.response.status === 401) {
+        // If we get an unauthorized, we assume the user is not logged
+        // in (or no longer logged in with the server). There's nothing to
+        // do for this request except ensure we know the user is logged out.
+        dispatch(logoutUser())
+      }
+      else {
+        dispatch(addError(AppErrors.challenge.fetchFailure))
+        console.log(error.response || error)
+      }
+    })
+  }
+}
+
+/**
  * Fetch activity timeline for the given challenge
  */
 export const fetchChallengeActivity = function(challengeId, startDate, endDate) {


### PR DESCRIPTION
When challenge owner visits admin area, directly load project
actions (for child challenges) in case that data hadn't already
been loaded on a per-challenge basis.