### PR TITLE
Support custom keyword categories from .env

### DIFF
--- a/.env
+++ b/.env
@@ -67,3 +67,19 @@ REACT_APP_MAPBOX_SATELLITE_STREETS_MAP_TILESERVER_URL='https://api.mapbox.com/st
 # > @see https://developer.matomo.org/guides/tracking-javascript-guide
 REACT_APP_MATOMO_URL=''
 REACT_APP_MATOMO_SITE_ID=''
+
+# Custom keyword categories configuration
+# Additional categories of one or more keywords can be added into the Work On
+# dropdown filter. Custom categories must be formatted as a valid JSON string.
+# The following example would add two categories (arts and coworking), the first
+# with two keywords and the second with a single keyword.
+# > Note that even single keywords must be structured as an array.
+#
+# ```
+# '{"arts": {"keywords": ["arts_centre"]}, "coworking": {"keywords": ["internet_cafe", "coworking_space"], "label": "Coworking Spaces"}}'
+# ```
+
+# The label, if given, will be displayed in the dropdown. If left out, the category name
+# will simply be start-cased and displayed instead.
+# > Internationalization of custom keyword category labels is not supported.
+REACT_APP_CUSTOM_KEYWORD_CATEGORIES=''

--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
@@ -6,8 +6,8 @@ import _isEmpty from 'lodash/isEmpty'
 import _first from 'lodash/first'
 import { injectIntl } from 'react-intl'
 import { CHALLENGE_CATEGORY_OTHER,
-         ChallengeCategoryKeywords,
          categoryMatchingKeywords,
+         combinedCategoryKeywords,
          keywordLabels }
        from '../../../services/Challenge/ChallengeKeywords/ChallengeKeywords'
 import NavDropdown from '../../Bulma/NavDropdown'
@@ -34,7 +34,7 @@ export class FilterByKeyword extends Component {
       this.props.removeChallengeFilters(['keywords'])
     }
     else {
-      this.props.setKeywordFilter(ChallengeCategoryKeywords[value])
+      this.props.setKeywordFilter(combinedCategoryKeywords[value])
     }
   }
 
@@ -47,10 +47,10 @@ export class FilterByKeyword extends Component {
   }
 
   render() {
-    const localizedKeywordLabels = keywordLabels(this.props.intl)
+    const localizedKeywordLabels = keywordLabels(this.props.intl, true)
 
-    const categories = _without(_keys(ChallengeCategoryKeywords), 'other')
-    const activeCategory = categoryMatchingKeywords(this.props.challengeFilter.keywords)
+    const categories = _without(_keys(combinedCategoryKeywords), 'other')
+    const activeCategory = categoryMatchingKeywords(this.props.challengeFilter.keywords, true)
     const selectOptions = categories.map(keyword => ({
       key: keyword,
       text: localizedKeywordLabels[keyword],


### PR DESCRIPTION
Additional categories of one or more keywords can be added into the
"Work On" dropdown filter via the REACT_APP_CUSTOM_KEYWORD_CATEGORIES
.env setting. Note that these only apply to the end-user challenge
filter and cannot be used when creating/editing challenges.