### PR TITLE
Add LRU cache to services.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "redux-thunk": "^2.2.0",
     "remark": "^7.0.1",
     "remark-react": "^4.0.0",
-    "route-matcher": "^0.1.0"
+    "route-matcher": "^0.1.0",
+    "stale-lru-cache": "^5.1.1"
   },
   "devDependencies": {
     "combine-react-intl-messages": "^1.0.6",

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import ChallengePane from './components/ChallengePane/ChallengePane'
 import TaskPane from './components/TaskPane/TaskPane'
 import AdminPane from './components/AdminPane/AdminPane'
 import { GUEST_USER_ID } from './services/User/User'
+import { resetCache } from './services/Server/RequestCache'
 import WithCurrentUser from './components/HOCs/WithCurrentUser/WithCurrentUser'
 import WithCurrentTask from './components/HOCs/WithCurrentTask/WithCurrentTask'
 import WithVirtualChallenge
@@ -65,19 +66,19 @@ export class App extends Component {
         <TopNav />
 
         <Switch>
-          <Route exact path='/' component={ChallengePane} />
-          <Route path='/browse/challenges/:challengeId?' component={ChallengePane} />
-          <Route path='/browse/virtual/:virtualChallengeId' component={VirtualChallengePane} />
-          <Route exact path='/challenge/:challengeId/task/:taskId' component={CurrentTaskPane} />
-          <Route exact path='/challenge/:challengeId' component={LoadRandomChallengeTask} />
-          <Route exact path='/virtual/:virtualChallengeId/task/:taskId'
+          <CachedRoute exact path='/' component={ChallengePane} />
+          <CachedRoute path='/browse/challenges/:challengeId?' component={ChallengePane} />
+          <CachedRoute path='/browse/virtual/:virtualChallengeId' component={VirtualChallengePane} />
+          <CachedRoute exact path='/challenge/:challengeId/task/:taskId' component={CurrentTaskPane} />
+          <CachedRoute exact path='/challenge/:challengeId' component={LoadRandomChallengeTask} />
+          <CachedRoute exact path='/virtual/:virtualChallengeId/task/:taskId'
                  component={CurrentVirtualChallengeTaskPane} />
-          <Route exact path='/virtual/:virtualChallengeId'
+          <CachedRoute exact path='/virtual/:virtualChallengeId'
                  component={LoadRandomVirtualChallengeTask} />
-          <Route exact path='/task/:taskId' component={CurrentTaskPane} />
-          <Route exact path='/about' component={AboutPane} />
-          <Route path='/user/profile' component={UserProfile} />
-          <Route path='/admin' component={AdminPane} />
+          <CachedRoute exact path='/task/:taskId' component={CurrentTaskPane} />
+          <CachedRoute exact path='/about' component={AboutPane} />
+          <CachedRoute path='/user/profile' component={UserProfile} />
+          <CachedRoute path='/admin' component={AdminPane} />
         </Switch>
 
         {firstTimeModal}
@@ -87,5 +88,16 @@ export class App extends Component {
     )
   }
 }
+
+/**
+ * Simple wrapper for Route that clears the request cache prior to rendering.
+ */
+export const CachedRoute=({component: Component, ...rest}) => (
+  <Route {...rest}
+         render={props => {
+           resetCache()
+           return <Component {...props} />
+         }} />
+)
 
 export default withRouter(App)

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -40,7 +40,7 @@ const apiRoutes = factory => {
       'single': factory.get('/challenge/:id'),
       'tasks': factory.get('/challenge/:id/tasks'),
       'clusteredTasks': factory.get('/challenge/clustered/:id'),
-      'randomTask': factory.get('/challenge/:id/tasks/randomTasks'),
+      'randomTask': factory.get('/challenge/:id/tasks/randomTasks', {noCache: true}),
       'previousSequentialTask': factory.get('/challenge/:challengeId/previousTask/:taskId'),
       'nextSequentialTask': factory.get('/challenge/:challengeId/nextTask/:taskId'),
       'actions': factory.get('/data/challenge/:id'),
@@ -56,11 +56,11 @@ const apiRoutes = factory => {
       'single': factory.get('/virtualchallenge/:id'),
       'create': factory.post('/virtualchallenge'),
       'edit': factory.put('/virtualchallenge/:id'),
-      'randomTask': factory.get('/virtualchallenge/:id/task'),
+      'randomTask': factory.get('/virtualchallenge/:id/task', {noCache: true}),
       'clusteredTasks': factory.get('/virtualchallenge/clustered/:id'),
     },
     'tasks': {
-      'random': factory.get('/tasks/random'),
+      'random': factory.get('/tasks/random', {noCache: true}),
       'withinBounds': factory.get('/tasks/box/:left/:bottom/:right/:top'),
     },
     'task': {

--- a/src/services/Server/Endpoint.js
+++ b/src/services/Server/Endpoint.js
@@ -17,7 +17,7 @@ export default class Endpoint {
    * {object} variables - any named variables required by the endpoint
    * {object} params - named params to be added as URL parameters
    * {object|array} schema - normalization schema to be used to normalize
-   *                resopnse data
+   *                response data
    * {object} json - JSON body to be sent with the request
    *
    * @param route - the desired route for this endpoint
@@ -49,7 +49,8 @@ export default class Endpoint {
         return deleteContent(this.url())
       default:
         return fetchContent(this.url(),
-                            this.normalizationSchema)
+                            this.normalizationSchema,
+                            {noCache: !!this.route.options.noCache})
     }
   }
 

--- a/src/services/Server/RequestCache.js
+++ b/src/services/Server/RequestCache.js
@@ -1,0 +1,16 @@
+import Cache from 'stale-lru-cache'
+
+/**
+ * The primary purpose of the cache is simply to reduce duplicate requests to
+ * the serverf that can naturally occur during a single user action from
+ * decoupled components that don't know anything about data other components
+ * might already have retrieved. So the maxAge of the cache is set very low.
+ */
+export const cache = new Cache({
+  maxSize: 100,
+  maxAge: 10, // seconds
+})
+
+export const resetCache = () => {
+  cache.reset()
+}

--- a/src/services/Server/Route.js
+++ b/src/services/Server/Route.js
@@ -17,11 +17,12 @@ import _isEmpty from 'lodash/isEmpty'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class Route {
-  constructor(baseURL, apiVersion, routePath, method='GET') {
+  constructor(baseURL, apiVersion, routePath, method='GET', options={}) {
     this.rawPath = routePath
     this.baseURL = baseURL
     this.route = routeMatcher(`/api/${apiVersion}${routePath}`)
     this.method = method
+    this.options = options
   }
 
   /**

--- a/src/services/Server/RouteFactory.js
+++ b/src/services/Server/RouteFactory.js
@@ -33,14 +33,14 @@ export default class RouteFactory {
    *
    * @returns {APIRoute} an APIRoute instance
    */
-  route = (path, method='GET') =>
-    new Route(this.baseURL, this.apiVersion, path, method)
+  route = (path, method='GET', options) =>
+    new Route(this.baseURL, this.apiVersion, path, method, options)
 
-  get = path => this.route(path, 'GET')
+  get = (path, options) => this.route(path, 'GET', options)
 
-  post = path => this.route(path, 'POST')
+  post = (path, options) => this.route(path, 'POST', options)
 
-  put = path => this.route(path, 'PUT')
+  put = (path, options) => this.route(path, 'PUT', options)
 
-  delete = path => this.route(path, 'DELETE')
+  delete = (path, options) => this.route(path, 'DELETE', options)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7728,6 +7728,12 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stale-lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/stale-lru-cache/-/stale-lru-cache-5.1.1.tgz#3282c3a7148c74e3c7858799130af9dd3407c845"
+  dependencies:
+    yallist "^2.0.0"
+
 standard-changelog@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/standard-changelog/-/standard-changelog-0.0.1.tgz#b367266fce05ca39ef2bbc09c0d24ddbd4191891"
@@ -8746,7 +8752,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.1.2:
+yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 


### PR DESCRIPTION
Add request-based LRU cache to services to prevent multiple identical
API requests from decoupled components that naturally end up requesting
the same data. This provides some minor optimization, but more
importantly will give components the freedom to request whatever data
they may need, as often as they wish, without worry. That should
ultimately lead to a reduction in bugs arising from missing data when
unusual execution paths are followed that may bypass components that
would otherwise load data assumed to be available by downstream
components.