### PR TITLE
Avoid bouncing between two tasks. Fixes #220

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { injectIntl } from 'react-intl'
 import _get from 'lodash/get'
-import _isNumber from 'lodash/isNumber'
 import _omit from 'lodash/omit'
 import { allowedStatusProgressions,
-         TaskStatus } from '../../../../services/Task/TaskStatus/TaskStatus'
+         isFinalStatus }
+       from '../../../../services/Task/TaskStatus/TaskStatus'
 import TaskCommentInput from './TaskCommentInput/TaskCommentInput'
 import TaskTrackControls from './TaskTrackControls/TaskTrackControls'
 import TaskRandomnessControl
@@ -99,9 +99,6 @@ export class ActiveTaskControls extends Component {
       const allowedProgressions =
         allowedStatusProgressions(this.props.task.status)
 
-      const hasExistingStatus = _isNumber(this.props.task.status) &&
-                                this.props.task.status !== TaskStatus.created
-
       return (
         <div className={classNames('active-task-controls', this.props.className,
                                   {'is-minimized': this.props.isMinimized})}>
@@ -119,7 +116,7 @@ export class ActiveTaskControls extends Component {
                                 {..._omit(this.props, 'nextTask')} />
           }
 
-          {!isEditingTask && hasExistingStatus &&
+          {(!isEditingTask && isFinalStatus(this.props.task.status)) &&
            <TaskNextControl nextTask={this.next}
                             {..._omit(this.props, 'nextTask')} />
           }

--- a/src/services/Task/TaskStatus/TaskStatus.js
+++ b/src/services/Task/TaskStatus/TaskStatus.js
@@ -73,6 +73,18 @@ export const allowedStatusProgressions = function(status, includeSelf = false) {
 }
 
 /**
+ * Returns true if the given status represents a final progression.
+ * Technically this returns true for one status that can transition to a
+ * different status as a correction (falsePositive -> fixed), but for most
+ * purposes falsePositive should be treated as final.
+ */
+export const isFinalStatus = function(status) {
+  return status === TaskStatus.fixed ||
+         status === TaskStatus.alreadyFixed ||
+         status === TaskStatus.falsePositive
+}
+
+/**
  * Returns an object mapping status values to raw internationalized
  * messages suitable for use with FormattedMessage or formatMessage.
  */


### PR DESCRIPTION
The "Next Task" option is now only offered to end users for tasks in a
final state of progression. Users who, for example, view a
previously-Skipped task and wish to move to a new task will need to
complete it normally, including possibly Skipping it themselves.