### PR TITLE
Start virtual by task with right route. Fixes #257

### DIFF
--- a/src/components/ChallengeMap/ChallengeMap.js
+++ b/src/components/ChallengeMap/ChallengeMap.js
@@ -86,11 +86,9 @@ export class ChallengeMap extends Component {
    */
   markerClicked = marker => {
     if (this.props.onTaskClick) {
-      this.props.onTaskClick(marker.options.challengeId, marker.options.taskId)
-    }
-    else {
-      this.props.history.push(
-        `/challenge/${marker.options.challengeId}/task/${marker.options.taskId}`)
+      this.props.onTaskClick(marker.options.challengeId,
+                             marker.options.isVirtualChallenge,
+                             marker.options.taskId)
     }
   }
 

--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -9,6 +9,7 @@ import LocatorMap from '../LocatorMap/LocatorMap'
 import ChallengeMap from '../ChallengeMap/ChallengeMap'
 import ChallengeResultList from './ChallengeResultList/ChallengeResultList'
 import WithChallenges from '../HOCs/WithChallenges/WithChallenges'
+import WithStartChallenge from '../HOCs/WithStartChallenge/WithStartChallenge'
 import WithFilteredChallenges
        from '../HOCs/WithFilteredChallenges/WithFilteredChallenges'
 import WithChallengeFilters
@@ -24,7 +25,7 @@ import './ChallengePane.css'
 
 // Setup child components with necessary HOCs
 const ChallengeResults = WithStatus(ChallengeResultList)
-const BrowseChallengeMap = WithTaskMarkers(ChallengeMap, 'clusteredTasks')
+const BrowseChallengeMap = WithTaskMarkers(ChallengeMap)
 let DiscoveryMap = null
 
 // If the map-bounded task browsing feature is enabled, set up the LocatorMap
@@ -71,6 +72,7 @@ export class ChallengePane extends Component {
           <MapPane>
             <Map layerSourceId={MAPBOX_STREETS}
                  challenge={this.props.browsedChallenge}
+                 onTaskClick={this.props.startChallengeWithTask}
                  {...this.props} />
           </MapPane>
         </div>
@@ -86,7 +88,9 @@ export default WithMapBounds(
         WithSearchResults(
           WithMapBoundedTasks(
             WithClusteredTasks(
-              WithBrowsedChallenge(ChallengePane)
+              WithStartChallenge(
+                WithBrowsedChallenge(ChallengePane)
+              )
             )
           ),
           'challenges',

--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -8,7 +8,6 @@ import _isFinite from 'lodash/isFinite'
 import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import WithCurrentUser from '../../HOCs/WithCurrentUser/WithCurrentUser'
-import WithStartChallenge from '../../HOCs/WithStartChallenge/WithStartChallenge'
 import WithSortedChallenges from '../../HOCs/WithSortedChallenges/WithSortedChallenges'
 import ChallengeResultItem from '../ChallengeResultItem/ChallengeResultItem'
 import SvgSymbol from '../../SvgSymbol/SvgSymbol'
@@ -129,10 +128,4 @@ ChallengeResultList.propTypes = {
   challenges: PropTypes.array.isRequired,
 }
 
-export default WithCurrentUser(
-  WithStartChallenge(
-    WithSortedChallenges(
-      ChallengeResultList,
-    ),
-  )
-)
+export default WithCurrentUser(WithSortedChallenges(ChallengeResultList))

--- a/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
+++ b/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
@@ -56,7 +56,7 @@ ShallowWrapper {
                     className="inline full-screen-height with-shadow challenge-pane__results"
                     isActive={true}
           >
-                    <Connect(Connect(Connect(WithSortedChallenges)))
+                    <Connect(Connect(WithSortedChallenges))
                               intl={
                                         Object {
                                                   "formatMessage": [Function],
@@ -82,6 +82,7 @@ ShallowWrapper {
                                                 }
                               }
                               layerSourceId="Mapbox"
+                              onTaskClick={undefined}
                               saveChallenge={[Function]}
                               startChallenge={[Function]}
                               unsaveChallenge={[Function]}
@@ -128,7 +129,7 @@ ShallowWrapper {
               className="inline full-screen-height with-shadow challenge-pane__results"
               isActive={true}
 >
-              <Connect(Connect(Connect(WithSortedChallenges)))
+              <Connect(Connect(WithSortedChallenges))
                             intl={
                                           Object {
                                                         "formatMessage": [Function],
@@ -154,6 +155,7 @@ ShallowWrapper {
                                                       }
                             }
                             layerSourceId="Mapbox"
+                            onTaskClick={undefined}
                             saveChallenge={[Function]}
                             startChallenge={[Function]}
                             unsaveChallenge={[Function]}
@@ -175,7 +177,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
-              "children": <Connect(Connect(Connect(WithSortedChallenges)))
+              "children": <Connect(Connect(WithSortedChallenges))
                 intl={
                                 Object {
                                                 "formatMessage": [Function],
@@ -230,6 +232,7 @@ ShallowWrapper {
                                               }
                 }
                 layerSourceId="Mapbox"
+                onTaskClick={undefined}
                 saveChallenge={[Function]}
                 startChallenge={[Function]}
                 unsaveChallenge={[Function]}
@@ -252,6 +255,7 @@ ShallowWrapper {
                   "formatMessage": [Function],
                 },
                 "layerSourceId": "Mapbox",
+                "onTaskClick": undefined,
                 "saveChallenge": [Function],
                 "startChallenge": [Function],
                 "unsaveChallenge": [Function],
@@ -302,7 +306,7 @@ ShallowWrapper {
                         className="inline full-screen-height with-shadow challenge-pane__results"
                         isActive={true}
             >
-                        <Connect(Connect(Connect(WithSortedChallenges)))
+                        <Connect(Connect(WithSortedChallenges))
                                     intl={
                                                 Object {
                                                             "formatMessage": [Function],
@@ -328,6 +332,7 @@ ShallowWrapper {
                                                           }
                                     }
                                     layerSourceId="Mapbox"
+                                    onTaskClick={undefined}
                                     saveChallenge={[Function]}
                                     startChallenge={[Function]}
                                     unsaveChallenge={[Function]}
@@ -374,7 +379,7 @@ ShallowWrapper {
                 className="inline full-screen-height with-shadow challenge-pane__results"
                 isActive={true}
 >
-                <Connect(Connect(Connect(WithSortedChallenges)))
+                <Connect(Connect(WithSortedChallenges))
                                 intl={
                                                 Object {
                                                                 "formatMessage": [Function],
@@ -400,6 +405,7 @@ ShallowWrapper {
                                                               }
                                 }
                                 layerSourceId="Mapbox"
+                                onTaskClick={undefined}
                                 saveChallenge={[Function]}
                                 startChallenge={[Function]}
                                 unsaveChallenge={[Function]}
@@ -421,7 +427,7 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "class",
               "props": Object {
-                "children": <Connect(Connect(Connect(WithSortedChallenges)))
+                "children": <Connect(Connect(WithSortedChallenges))
                   intl={
                                     Object {
                                                       "formatMessage": [Function],
@@ -476,6 +482,7 @@ ShallowWrapper {
                                                     }
                   }
                   layerSourceId="Mapbox"
+                  onTaskClick={undefined}
                   saveChallenge={[Function]}
                   startChallenge={[Function]}
                   unsaveChallenge={[Function]}
@@ -498,6 +505,7 @@ ShallowWrapper {
                     "formatMessage": [Function],
                   },
                   "layerSourceId": "Mapbox",
+                  "onTaskClick": undefined,
                   "saveChallenge": [Function],
                   "startChallenge": [Function],
                   "unsaveChallenge": [Function],

--- a/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
+++ b/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
@@ -108,6 +108,16 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
         })
       }
     }
+  },
+
+  /** Invoked when user wants to start a challenge with a specific task */
+  startChallengeWithTask: (challengeId, isVirtual, taskId) => {
+    if (isVirtual) {
+      ownProps.history.push(`/virtual/${challengeId}/task/${taskId}`)
+    }
+    else {
+      ownProps.history.push(`/challenge/${challengeId}/task/${taskId}`)
+    }
   }
 })
 

--- a/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
+++ b/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import _get from 'lodash/get'
 import _isArray from 'lodash/isArray'
+import _isObject from 'lodash/isObject'
 import _each from 'lodash/each'
 import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
 
@@ -14,21 +15,25 @@ import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default function WithTaskMarkers(WrappedComponent,
-                                        tasksProp='tasks') {
+                                        tasksProp='clusteredTasks') {
   return class extends Component {
     render() {
+      const clusteredTasks = this.props[tasksProp]
       const markers = []
-      const tasks = _get(this.props, `${tasksProp}.tasks`, tasksProp)
+      if (!_isObject(clusteredTasks)) {
+        return null
+      }
 
-      if (_isArray(tasks) && tasks.length > 0) {
-        _each(tasks, task => {
+      if (_isArray(clusteredTasks.tasks) && clusteredTasks.tasks.length > 0) {
+        _each(clusteredTasks.tasks, task => {
           // Only create markers for created or skipped tasks
           if (task.point && (task.status === TaskStatus.created ||
                              task.status === TaskStatus.skipped)) {
             markers.push({
               position: [task.point.lat, task.point.lng],
               options: {
-                challengeId: task.parentId,
+                challengeId: clusteredTasks.challengeId,
+                isVirtualChallenge: clusteredTasks.isVirtualChallenge,
                 challengeName: task.parentName,
                 taskId: task.id,
               },


### PR DESCRIPTION
When browsing a virtual challenge, clicking on a task marker on the map
to begin the challenge will now generate the proper route.