### PR TITLE
Show tasks for partially-loaded status. Fixes #264

### DIFF
--- a/src/services/Challenge/ChallengeStatus/ChallengeStatus.js
+++ b/src/services/Challenge/ChallengeStatus/ChallengeStatus.js
@@ -38,5 +38,7 @@ export const statusLayerLabels = intl => _fromPairs(
  * and presentable to users, false if not.
  */
 export const isUsableChallengeStatus = function(status) {
-  return status === CHALLENGE_STATUS_READY || status === CHALLENGE_STATUS_NONE
+  return status === CHALLENGE_STATUS_READY ||
+         status === CHALLENGE_STATUS_PARTIALLY_LOADED ||
+         status === CHALLENGE_STATUS_NONE
 }


### PR DESCRIPTION
When a challenge owner views a challenge in a partially loaded
status, the successfully built tasks will now be displayed.