### PR TITLE
Don't skip map rendering when no clustered tasks.

### DIFF
--- a/src/components/ChallengePane/ChallengePane.test.js
+++ b/src/components/ChallengePane/ChallengePane.test.js
@@ -3,9 +3,14 @@ import { ChallengePane } from './ChallengePane'
 import { ChallengeDifficulty }
        from '../../services/Challenge/ChallengeDifficulty/ChallengeDifficulty'
 
+let challenge = null
 let basicProps = null
 
 beforeEach(() => {
+  challenge = {
+    id: 123,
+  }
+
   basicProps = {
     user: {
       id: 11,
@@ -24,5 +29,29 @@ test("renders with props as expected", () => {
   )
 
   expect(wrapper.find('.challenge-pane').exists()).toBe(true)
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("when no browsed challenge, the locator map is rendered", () => {
+  const wrapper = shallow(
+    <ChallengePane {...basicProps} />
+  )
+
+  expect(
+    wrapper.find('Connect(Connect(InjectIntl(LocatorMap)))'
+  ).exists()).toBe(true)
+})
+
+test("when browsing a challenge, the challenge map is rendered", () => {
+  basicProps.browsedChallenge = challenge
+
+  const wrapper = shallow(
+    <ChallengePane {...basicProps} />
+  )
+
+  expect(
+    wrapper.find('WithTaskMarkers(Connect(Connect(ChallengeMap)))'
+  ).exists()).toBe(true)
+
   expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
+++ b/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
@@ -536,3 +536,661 @@ ShallowWrapper {
   },
 }
 `;
+
+exports[`when browsing a challenge, the challenge map is rendered 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ChallengePane
+    browsedChallenge={
+        Object {
+            "id": 123,
+          }
+    }
+    intl={
+        Object {
+            "formatMessage": [Function],
+          }
+    }
+    saveChallenge={[Function]}
+    startChallenge={[Function]}
+    unsaveChallenge={[Function]}
+    user={
+        Object {
+            "id": 11,
+            "savedChallenges": Array [],
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Connect(Connect(InjectIntl(ChallengeFilterSubnav)))
+          browsedChallenge={
+                    Object {
+                              "id": 123,
+                            }
+          }
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          saveChallenge={[Function]}
+          startChallenge={[Function]}
+          unsaveChallenge={[Function]}
+          user={
+                    Object {
+                              "id": 11,
+                              "savedChallenges": Array [],
+                            }
+          }
+/>,
+        <div
+          className="challenge-pane"
+>
+          <Sidebar
+                    className="inline full-screen-height with-shadow challenge-pane__results"
+                    isActive={true}
+          >
+                    <Connect(Connect(WithSortedChallenges))
+                              browsedChallenge={
+                                        Object {
+                                                  "id": 123,
+                                                }
+                              }
+                              intl={
+                                        Object {
+                                                  "formatMessage": [Function],
+                                                }
+                              }
+                              saveChallenge={[Function]}
+                              startChallenge={[Function]}
+                              unsaveChallenge={[Function]}
+                              user={
+                                        Object {
+                                                  "id": 11,
+                                                  "savedChallenges": Array [],
+                                                }
+                              }
+                    />
+          </Sidebar>
+          <Connect(MapPane)>
+                    <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                              browsedChallenge={
+                                        Object {
+                                                  "id": 123,
+                                                }
+                              }
+                              challenge={
+                                        Object {
+                                                  "id": 123,
+                                                }
+                              }
+                              intl={
+                                        Object {
+                                                  "formatMessage": [Function],
+                                                }
+                              }
+                              layerSourceId="Mapbox"
+                              onTaskClick={undefined}
+                              saveChallenge={[Function]}
+                              startChallenge={[Function]}
+                              unsaveChallenge={[Function]}
+                              user={
+                                        Object {
+                                                  "id": 11,
+                                                  "savedChallenges": Array [],
+                                                }
+                              }
+                    />
+          </Connect(MapPane)>
+</div>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "browsedChallenge": Object {
+            "id": 123,
+          },
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "saveChallenge": [Function],
+          "startChallenge": [Function],
+          "unsaveChallenge": [Function],
+          "user": Object {
+            "id": 11,
+            "savedChallenges": Array [],
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <Sidebar
+              className="inline full-screen-height with-shadow challenge-pane__results"
+              isActive={true}
+>
+              <Connect(Connect(WithSortedChallenges))
+                            browsedChallenge={
+                                          Object {
+                                                        "id": 123,
+                                                      }
+                            }
+                            intl={
+                                          Object {
+                                                        "formatMessage": [Function],
+                                                      }
+                            }
+                            saveChallenge={[Function]}
+                            startChallenge={[Function]}
+                            unsaveChallenge={[Function]}
+                            user={
+                                          Object {
+                                                        "id": 11,
+                                                        "savedChallenges": Array [],
+                                                      }
+                            }
+              />
+</Sidebar>,
+            <Connect(MapPane)>
+              <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                            browsedChallenge={
+                                          Object {
+                                                        "id": 123,
+                                                      }
+                            }
+                            challenge={
+                                          Object {
+                                                        "id": 123,
+                                                      }
+                            }
+                            intl={
+                                          Object {
+                                                        "formatMessage": [Function],
+                                                      }
+                            }
+                            layerSourceId="Mapbox"
+                            onTaskClick={undefined}
+                            saveChallenge={[Function]}
+                            startChallenge={[Function]}
+                            unsaveChallenge={[Function]}
+                            user={
+                                          Object {
+                                                        "id": 11,
+                                                        "savedChallenges": Array [],
+                                                      }
+                            }
+              />
+</Connect(MapPane)>,
+          ],
+          "className": "challenge-pane",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <Connect(Connect(WithSortedChallenges))
+                browsedChallenge={
+                                Object {
+                                                "id": 123,
+                                              }
+                }
+                intl={
+                                Object {
+                                                "formatMessage": [Function],
+                                              }
+                }
+                saveChallenge={[Function]}
+                startChallenge={[Function]}
+                unsaveChallenge={[Function]}
+                user={
+                                Object {
+                                                "id": 11,
+                                                "savedChallenges": Array [],
+                                              }
+                }
+/>,
+              "className": "inline full-screen-height with-shadow challenge-pane__results",
+              "isActive": true,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "browsedChallenge": Object {
+                  "id": 123,
+                },
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "saveChallenge": [Function],
+                "startChallenge": [Function],
+                "unsaveChallenge": [Function],
+                "user": Object {
+                  "id": 11,
+                  "savedChallenges": Array [],
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                browsedChallenge={
+                                Object {
+                                                "id": 123,
+                                              }
+                }
+                challenge={
+                                Object {
+                                                "id": 123,
+                                              }
+                }
+                intl={
+                                Object {
+                                                "formatMessage": [Function],
+                                              }
+                }
+                layerSourceId="Mapbox"
+                onTaskClick={undefined}
+                saveChallenge={[Function]}
+                startChallenge={[Function]}
+                unsaveChallenge={[Function]}
+                user={
+                                Object {
+                                                "id": 11,
+                                                "savedChallenges": Array [],
+                                              }
+                }
+/>,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "browsedChallenge": Object {
+                  "id": 123,
+                },
+                "challenge": Object {
+                  "id": 123,
+                },
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "layerSourceId": "Mapbox",
+                "onTaskClick": undefined,
+                "saveChallenge": [Function],
+                "startChallenge": [Function],
+                "unsaveChallenge": [Function],
+                "user": Object {
+                  "id": 11,
+                  "savedChallenges": Array [],
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": [Function],
+          },
+        ],
+        "type": "div",
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Connect(Connect(InjectIntl(ChallengeFilterSubnav)))
+            browsedChallenge={
+                        Object {
+                                    "id": 123,
+                                  }
+            }
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            saveChallenge={[Function]}
+            startChallenge={[Function]}
+            unsaveChallenge={[Function]}
+            user={
+                        Object {
+                                    "id": 11,
+                                    "savedChallenges": Array [],
+                                  }
+            }
+/>,
+          <div
+            className="challenge-pane"
+>
+            <Sidebar
+                        className="inline full-screen-height with-shadow challenge-pane__results"
+                        isActive={true}
+            >
+                        <Connect(Connect(WithSortedChallenges))
+                                    browsedChallenge={
+                                                Object {
+                                                            "id": 123,
+                                                          }
+                                    }
+                                    intl={
+                                                Object {
+                                                            "formatMessage": [Function],
+                                                          }
+                                    }
+                                    saveChallenge={[Function]}
+                                    startChallenge={[Function]}
+                                    unsaveChallenge={[Function]}
+                                    user={
+                                                Object {
+                                                            "id": 11,
+                                                            "savedChallenges": Array [],
+                                                          }
+                                    }
+                        />
+            </Sidebar>
+            <Connect(MapPane)>
+                        <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                                    browsedChallenge={
+                                                Object {
+                                                            "id": 123,
+                                                          }
+                                    }
+                                    challenge={
+                                                Object {
+                                                            "id": 123,
+                                                          }
+                                    }
+                                    intl={
+                                                Object {
+                                                            "formatMessage": [Function],
+                                                          }
+                                    }
+                                    layerSourceId="Mapbox"
+                                    onTaskClick={undefined}
+                                    saveChallenge={[Function]}
+                                    startChallenge={[Function]}
+                                    unsaveChallenge={[Function]}
+                                    user={
+                                                Object {
+                                                            "id": 11,
+                                                            "savedChallenges": Array [],
+                                                          }
+                                    }
+                        />
+            </Connect(MapPane)>
+</div>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "browsedChallenge": Object {
+              "id": 123,
+            },
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "saveChallenge": [Function],
+            "startChallenge": [Function],
+            "unsaveChallenge": [Function],
+            "user": Object {
+              "id": 11,
+              "savedChallenges": Array [],
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <Sidebar
+                className="inline full-screen-height with-shadow challenge-pane__results"
+                isActive={true}
+>
+                <Connect(Connect(WithSortedChallenges))
+                                browsedChallenge={
+                                                Object {
+                                                                "id": 123,
+                                                              }
+                                }
+                                intl={
+                                                Object {
+                                                                "formatMessage": [Function],
+                                                              }
+                                }
+                                saveChallenge={[Function]}
+                                startChallenge={[Function]}
+                                unsaveChallenge={[Function]}
+                                user={
+                                                Object {
+                                                                "id": 11,
+                                                                "savedChallenges": Array [],
+                                                              }
+                                }
+                />
+</Sidebar>,
+              <Connect(MapPane)>
+                <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                                browsedChallenge={
+                                                Object {
+                                                                "id": 123,
+                                                              }
+                                }
+                                challenge={
+                                                Object {
+                                                                "id": 123,
+                                                              }
+                                }
+                                intl={
+                                                Object {
+                                                                "formatMessage": [Function],
+                                                              }
+                                }
+                                layerSourceId="Mapbox"
+                                onTaskClick={undefined}
+                                saveChallenge={[Function]}
+                                startChallenge={[Function]}
+                                unsaveChallenge={[Function]}
+                                user={
+                                                Object {
+                                                                "id": 11,
+                                                                "savedChallenges": Array [],
+                                                              }
+                                }
+                />
+</Connect(MapPane)>,
+            ],
+            "className": "challenge-pane",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": <Connect(Connect(WithSortedChallenges))
+                  browsedChallenge={
+                                    Object {
+                                                      "id": 123,
+                                                    }
+                  }
+                  intl={
+                                    Object {
+                                                      "formatMessage": [Function],
+                                                    }
+                  }
+                  saveChallenge={[Function]}
+                  startChallenge={[Function]}
+                  unsaveChallenge={[Function]}
+                  user={
+                                    Object {
+                                                      "id": 11,
+                                                      "savedChallenges": Array [],
+                                                    }
+                  }
+/>,
+                "className": "inline full-screen-height with-shadow challenge-pane__results",
+                "isActive": true,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "browsedChallenge": Object {
+                    "id": 123,
+                  },
+                  "intl": Object {
+                    "formatMessage": [Function],
+                  },
+                  "saveChallenge": [Function],
+                  "startChallenge": [Function],
+                  "unsaveChallenge": [Function],
+                  "user": Object {
+                    "id": 11,
+                    "savedChallenges": Array [],
+                  },
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": <WithTaskMarkers(Connect(Connect(ChallengeMap)))
+                  browsedChallenge={
+                                    Object {
+                                                      "id": 123,
+                                                    }
+                  }
+                  challenge={
+                                    Object {
+                                                      "id": 123,
+                                                    }
+                  }
+                  intl={
+                                    Object {
+                                                      "formatMessage": [Function],
+                                                    }
+                  }
+                  layerSourceId="Mapbox"
+                  onTaskClick={undefined}
+                  saveChallenge={[Function]}
+                  startChallenge={[Function]}
+                  unsaveChallenge={[Function]}
+                  user={
+                                    Object {
+                                                      "id": 11,
+                                                      "savedChallenges": Array [],
+                                                    }
+                  }
+/>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "browsedChallenge": Object {
+                    "id": 123,
+                  },
+                  "challenge": Object {
+                    "id": 123,
+                  },
+                  "intl": Object {
+                    "formatMessage": [Function],
+                  },
+                  "layerSourceId": "Mapbox",
+                  "onTaskClick": undefined,
+                  "saveChallenge": [Function],
+                  "startChallenge": [Function],
+                  "unsaveChallenge": [Function],
+                  "user": Object {
+                    "id": 11,
+                    "savedChallenges": Array [],
+                  },
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+          ],
+          "type": "div",
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
+++ b/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import _get from 'lodash/get'
 import _isArray from 'lodash/isArray'
+import _isFinite from 'lodash/isFinite'
 import _isObject from 'lodash/isObject'
 import _each from 'lodash/each'
 import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
@@ -16,30 +17,29 @@ import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
  */
 export default function WithTaskMarkers(WrappedComponent,
                                         tasksProp='clusteredTasks') {
-  return class extends Component {
+  class _WithTaskMarkers extends Component {
     render() {
       const clusteredTasks = this.props[tasksProp]
       const markers = []
-      if (!_isObject(clusteredTasks)) {
-        return null
-      }
-
-      if (_isArray(clusteredTasks.tasks) && clusteredTasks.tasks.length > 0) {
-        _each(clusteredTasks.tasks, task => {
-          // Only create markers for created or skipped tasks
-          if (task.point && (task.status === TaskStatus.created ||
-                             task.status === TaskStatus.skipped)) {
-            markers.push({
-              position: [task.point.lat, task.point.lng],
-              options: {
-                challengeId: clusteredTasks.challengeId,
-                isVirtualChallenge: clusteredTasks.isVirtualChallenge,
-                challengeName: task.parentName,
-                taskId: task.id,
-              },
-            })
-          }
-        })
+      if (_isObject(clusteredTasks)) {
+        if (_isArray(clusteredTasks.tasks) && clusteredTasks.tasks.length > 0) {
+          _each(clusteredTasks.tasks, task => {
+            // Only create markers for created or skipped tasks
+            if (task.point && (task.status === TaskStatus.created ||
+                              task.status === TaskStatus.skipped)) {
+              markers.push({
+                position: [task.point.lat, task.point.lng],
+                options: {
+                  challengeId: _isFinite(clusteredTasks.challengeId) ?
+                               clusteredTasks.challengeId : task.challengeId || task.parentId,
+                  isVirtualChallenge: clusteredTasks.isVirtualChallenge,
+                  challengeName: task.parentName,
+                  taskId: task.id,
+                },
+              })
+            }
+          })
+        }
       }
 
       return <WrappedComponent taskMarkers={markers}
@@ -48,4 +48,10 @@ export default function WithTaskMarkers(WrappedComponent,
                                {...this.props} />
     }
   }
+
+  _WithTaskMarkers.displayName =
+    `WithTaskMarkers(${WrappedComponent.displayName ||
+                       WrappedComponent.name || 'Component'})`
+
+  return _WithTaskMarkers
 }

--- a/src/components/LocatorMap/LocatorMap.js
+++ b/src/components/LocatorMap/LocatorMap.js
@@ -119,9 +119,11 @@ export class LocatorMap extends Component {
 
         <div className="marker-popup-content__links">
           <div>
-            <a onClick={() => this.props.history.push(
-              `/challenge/${marker.options.challengeId}/task/${marker.options.taskId}`
-            )}>
+            <a onClick={() => {
+              this.props.onTaskClick(marker.options.challengeId,
+                                     marker.options.isVirtualChallenge,
+                                     marker.options.taskId)
+            }}>
               {this.props.intl.formatMessage(messages.startChallengeLabel)}
             </a>
           </div>


### PR DESCRIPTION
WithTaskMarkers no longer skips rendering of its wrapped component if
there is no clustered task data.