### PR TITLE
Visibility switch in view challenge. Closes #183

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
+++ b/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
@@ -11,6 +11,7 @@ import { challengeDenormalizationSchema,
          fetchChallengeActivity,
          fetchChallengeActions,
          saveChallenge,
+         setIsEnabled,
          rebuildChallenge,
          removeChallenge,
          deleteChallenge } from '../../../../services/Challenge/Challenge'
@@ -131,6 +132,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(deleteChallenge(challengeId)).then(() =>
       ownProps.history.replace(`/admin/project/${projectId}`)
     )
+  },
+  updateEnabled: (challengeId, isEnabled) => {
+    dispatch(setIsEnabled(challengeId, isEnabled))
   },
 })
 

--- a/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
@@ -11,6 +11,7 @@ import { ChallengeStatus,
 import ChallengeProgress
        from '../../../ChallengeProgress/ChallengeProgress'
 import ChallengeKeywords from '../ChallengeKeywords/ChallengeKeywords'
+import VisibilitySwitch from '../VisibilitySwitch/VisibilitySwitch'
 import ChallengeActivityTimeline
        from '../../../ActivityTimeline/ChallengeActivityTimeline/ChallengeActivityTimeline'
 import WithComputedMetrics from '../../HOCs/WithComputedMetrics/WithComputedMetrics'
@@ -64,6 +65,16 @@ export class ChallengeOverview extends Component {
 
             <div className="column is-narrow status-value">
               <FormattedMessage {...messagesByStatus[status]} />
+            </div>
+          </div>
+
+          <div className="columns">
+            <div className="column is-one-quarter status-label">
+              <FormattedMessage {...messages.visibleLabel} />
+            </div>
+
+            <div className="column is-narrow status-value">
+              <VisibilitySwitch {...this.props} />
             </div>
           </div>
 

--- a/src/components/AdminPane/Manage/ManageChallenges/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/Messages.js
@@ -46,6 +46,11 @@ export default defineMessages({
     defaultMessage: "Status:",
   },
 
+  visibleLabel: {
+    id: "Admin.Challenge.fields.enabled.label",
+    defaultMessage: "Visible:",
+  },
+
   startChallengeLabel: {
     id: "Admin.Challenge.controls.startChallenge.label",
     defaultMessage: "Start Challenge",

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
@@ -47,7 +47,7 @@ export class ViewChallenge extends Component {
 
     const tabs = {
       [this.props.intl.formatMessage(messages.challengeOverviewTabLabel)]:
-        <ChallengeOverview challenge={this.props.challenge} />,
+        <ChallengeOverview {...this.props} />,
 
       [this.props.intl.formatMessage(messages.challengeCommentsTabLabel)]:
         <ChallengeComments challenge={this.props.challenge} />,

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.scss
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.scss
@@ -70,6 +70,7 @@
       }
 
       .challenge-keywords {
+        margin-top: 15px;
         margin-bottom: 20px;
       }
 

--- a/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.js
+++ b/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * VisibilitySwitch renders a simple switch, with optional label, that
+ * toggles the given challenge's enabled status true or false as the
+ * switch is activated or deactivated, respectively.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export default class VisibilitySwitch extends Component {
+  toggleVisible = () => {
+    this.props.updateEnabled(this.props.challenge.id,
+                             !this.props.challenge.enabled)
+  }
+
+  render() {
+    if (!this.props.challenge) {
+      return null
+    }
+
+    return (
+      <div className="field visibility-switch" onClick={this.toggleVisible}>
+        <input type="checkbox" className="switch is-rounded short-and-wide"
+                checked={this.props.challenge.enabled}
+                onChange={() => null} />
+        <label>{this.props.label}</label>
+      </div>
+    )
+  }
+}
+
+VisibilitySwitch.propTypes = {
+  challenge: PropTypes.object,
+  updateEnabled: PropTypes.func.isRequired,
+  label: PropTypes.node,
+}

--- a/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.test.js
+++ b/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import VisibilitySwitch from './VisibilitySwitch'
+
+let basicProps = null
+
+beforeEach(() => {
+  basicProps = {
+    challenge: {
+      id: 123,
+      enabled: false,
+    },
+    updateEnabled: jest.fn(),
+  }
+})
+
+test("shows visibility switch", () => {
+  const wrapper = shallow(
+    <VisibilitySwitch {...basicProps} />
+  )
+
+  expect(wrapper.find('.visibility-switch').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("switch state is off when challenge not enabled", () => {
+  const wrapper = shallow(
+    <VisibilitySwitch {...basicProps} />
+  )
+
+  expect(
+    wrapper.find('.visibility-switch input[checked=false]').exists()
+  ).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("switch state is on when challenge is enabled", () => {
+  basicProps.challenge.enabled = true
+
+  const wrapper = shallow(
+    <VisibilitySwitch {...basicProps} />
+  )
+
+  expect(
+    wrapper.find('.visibility-switch input[checked=true]').exists()
+  ).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("clicking the switch for disabled challenge signals enable", () => {
+  const wrapper = shallow(
+    <VisibilitySwitch {...basicProps} />
+  )
+
+  wrapper.find('.visibility-switch').simulate('click')
+
+  expect(basicProps.updateEnabled).toBeCalledWith(basicProps.challenge.id, true)
+})
+
+test("clicking the switch for enabled challenge signals disable", () => {
+  basicProps.challenge.enabled = true
+
+  const wrapper = shallow(
+    <VisibilitySwitch {...basicProps} />
+  )
+
+  wrapper.find('.visibility-switch').simulate('click')
+
+  expect(basicProps.updateEnabled).toBeCalledWith(basicProps.challenge.id, false)
+})

--- a/src/components/AdminPane/Manage/VisibilitySwitch/__snapshots__/VisibilitySwitch.test.js.snap
+++ b/src/components/AdminPane/Manage/VisibilitySwitch/__snapshots__/VisibilitySwitch.test.js.snap
@@ -1,0 +1,379 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`shows visibility switch 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <VisibilitySwitch
+    challenge={
+        Object {
+            "enabled": false,
+            "id": 123,
+          }
+    }
+    updateEnabled={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <input
+          checked={false}
+          className="switch is-rounded short-and-wide"
+          onChange={[Function]}
+          type="checkbox"
+/>,
+        <label />,
+      ],
+      "className": "field visibility-switch",
+      "onClick": [Function],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "checked": false,
+          "className": "switch is-rounded short-and-wide",
+          "onChange": [Function],
+          "type": "checkbox",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "input",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": undefined,
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "label",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <input
+            checked={false}
+            className="switch is-rounded short-and-wide"
+            onChange={[Function]}
+            type="checkbox"
+/>,
+          <label />,
+        ],
+        "className": "field visibility-switch",
+        "onClick": [Function],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "checked": false,
+            "className": "switch is-rounded short-and-wide",
+            "onChange": [Function],
+            "type": "checkbox",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "input",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": undefined,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "label",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`switch state is off when challenge not enabled 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <VisibilitySwitch
+    challenge={
+        Object {
+            "enabled": false,
+            "id": 123,
+          }
+    }
+    updateEnabled={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <input
+          checked={false}
+          className="switch is-rounded short-and-wide"
+          onChange={[Function]}
+          type="checkbox"
+/>,
+        <label />,
+      ],
+      "className": "field visibility-switch",
+      "onClick": [Function],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "checked": false,
+          "className": "switch is-rounded short-and-wide",
+          "onChange": [Function],
+          "type": "checkbox",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "input",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": undefined,
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "label",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <input
+            checked={false}
+            className="switch is-rounded short-and-wide"
+            onChange={[Function]}
+            type="checkbox"
+/>,
+          <label />,
+        ],
+        "className": "field visibility-switch",
+        "onClick": [Function],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "checked": false,
+            "className": "switch is-rounded short-and-wide",
+            "onChange": [Function],
+            "type": "checkbox",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "input",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": undefined,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "label",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`switch state is on when challenge is enabled 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <VisibilitySwitch
+    challenge={
+        Object {
+            "enabled": true,
+            "id": 123,
+          }
+    }
+    updateEnabled={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <input
+          checked={true}
+          className="switch is-rounded short-and-wide"
+          onChange={[Function]}
+          type="checkbox"
+/>,
+        <label />,
+      ],
+      "className": "field visibility-switch",
+      "onClick": [Function],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "checked": true,
+          "className": "switch is-rounded short-and-wide",
+          "onChange": [Function],
+          "type": "checkbox",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "input",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": undefined,
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "label",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <input
+            checked={true}
+            className="switch is-rounded short-and-wide"
+            onChange={[Function]}
+            type="checkbox"
+/>,
+          <label />,
+        ],
+        "className": "field visibility-switch",
+        "onClick": [Function],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "checked": true,
+            "className": "switch is-rounded short-and-wide",
+            "onChange": [Function],
+            "type": "checkbox",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "input",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": undefined,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "label",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -83,6 +83,7 @@
   "Admin.Challenge.fields.creationDate.label": "Created:",
   "Admin.Challenge.fields.lastModifiedDate.label": "Modified:",
   "Admin.Challenge.fields.status.label": "Status:",
+  "Admin.Challenge.fields.enabled.label": "Visible:",
   "Admin.Challenge.controls.startChallenge.label": "Start Challenge",
   "Admin.Challenge.activity.label": "Recent Activity",
   "Admin.EditProject.unavailable": "Project Unavailable",


### PR DESCRIPTION
A visibility switch that can be used to quickly enable/disable a
challenge is now offered to challenge owners in the sidebar when viewing
their challenge in the admin area.