### PR TITLE
Show link to task changeset alongside status.

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/Messages.js
+++ b/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/Messages.js
@@ -12,5 +12,10 @@ export default defineMessages({
   statusTooltip: {
     id: 'ActiveTask.controls.status.tooltip',
     defaultMessage: "Existing Status",
+  },
+
+  viewChangeset: {
+    id: 'ActiveTask.controls.viewChangset.label',
+    defaultMessage: "View Changeset",
   }
 })

--- a/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/TaskStatusIndicator.js
+++ b/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/TaskStatusIndicator.js
@@ -21,6 +21,9 @@ const DeactivatablePopout = WithDeactivateOnOutsideClick(Popout)
  * By default, the indicator only renders for statuses other than created. Set
  * the allStatuses prop to true to render regardless of status.
  *
+ * If an OSM changeset is associated with the task, then a link to view the
+ * changeset will also be displayed alongside the task status.
+ *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskStatusIndicator extends Component {
@@ -70,6 +73,14 @@ export default class TaskStatusIndicator extends Component {
           <div>
             <div className="task-status__label">
               <FormattedMessage {...messagesByStatus[this.props.task.status]} />
+
+              {this.props.task.changesetId > 0 &&
+               <a href={`https://www.openstreetmap.org/changeset/${this.props.task.changesetId}`}
+                 target="_blank"
+                 className="task-status__view-changeset-link">
+                 <FormattedMessage {...messages.viewChangeset} />
+               </a>
+              }
             </div>
           </div>
         </div>

--- a/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/TaskStatusIndicator.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/TaskStatusIndicator.scss
@@ -27,12 +27,19 @@
 
   .task-status__label {
     width: 100%;
+    display: flex;
+    justify-content: space-between;
     border: 2px solid rgba($blue, 0.33);
     border-radius: 0 0 $radius-medium $radius-medium;
     border-top: none;
     padding: 10px 15px;
     font-weight: $weight-semibold;
     color: $grey;
+  }
+
+  .task-status__view-changeset-link {
+    font-weight: $weight-normal;
+    font-size: $size-7;
   }
 
   &.icon-only {

--- a/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/__snapshots__/TaskStatusIndicator.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/TaskStatusIndicator/__snapshots__/TaskStatusIndicator.test.js.snap
@@ -152,27 +152,33 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <FormattedMessage
-              defaultMessage="Created"
-              id="Task.status.created"
-              values={Object {}}
+            "children": Array [
+              <FormattedMessage
+                defaultMessage="Created"
+                id="Task.status.created"
+                values={Object {}}
 />,
+              false,
+            ],
             "className": "task-status__label",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "defaultMessage": "Created",
-              "id": "Task.status.created",
-              "values": Object {},
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultMessage": "Created",
+                "id": "Task.status.created",
+                "values": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
             },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
+            false,
+          ],
           "type": "div",
         },
         "type": "div",
@@ -261,27 +267,33 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <FormattedMessage
-                defaultMessage="Created"
-                id="Task.status.created"
-                values={Object {}}
+              "children": Array [
+                <FormattedMessage
+                  defaultMessage="Created"
+                  id="Task.status.created"
+                  values={Object {}}
 />,
+                false,
+              ],
               "className": "task-status__label",
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "defaultMessage": "Created",
-                "id": "Task.status.created",
-                "values": Object {},
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "defaultMessage": "Created",
+                  "id": "Task.status.created",
+                  "values": Object {},
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
               },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
+              false,
+            ],
             "type": "div",
           },
           "type": "div",
@@ -762,27 +774,33 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <FormattedMessage
-              defaultMessage="Skipped"
-              id="Task.status.skipped"
-              values={Object {}}
+            "children": Array [
+              <FormattedMessage
+                defaultMessage="Skipped"
+                id="Task.status.skipped"
+                values={Object {}}
 />,
+              false,
+            ],
             "className": "task-status__label",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "defaultMessage": "Skipped",
-              "id": "Task.status.skipped",
-              "values": Object {},
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "defaultMessage": "Skipped",
+                "id": "Task.status.skipped",
+                "values": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
             },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
+            false,
+          ],
           "type": "div",
         },
         "type": "div",
@@ -871,27 +889,33 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <FormattedMessage
-                defaultMessage="Skipped"
-                id="Task.status.skipped"
-                values={Object {}}
+              "children": Array [
+                <FormattedMessage
+                  defaultMessage="Skipped"
+                  id="Task.status.skipped"
+                  values={Object {}}
 />,
+                false,
+              ],
               "className": "task-status__label",
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "defaultMessage": "Skipped",
-                "id": "Task.status.skipped",
-                "values": Object {},
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "defaultMessage": "Skipped",
+                  "id": "Task.status.skipped",
+                  "values": Object {},
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
               },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
+              false,
+            ],
             "type": "div",
           },
           "type": "div",


### PR DESCRIPTION
When viewing a task that has an OSM changeset associated with it, show a
link to that changeset alongside the existing task status.