### PR TITLE
Browse pending-delete challenge error. Fixes #332

### DIFF
--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -192,7 +192,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         return dispatch(
           fetchChallenge(challengeId)
         ).then(normalizedResults => {
-          if (!_isFinite(normalizedResults.result)) {
+          if (!_isFinite(normalizedResults.result) ||
+              _get(normalizedResults,
+                   `entities.challenges.${normalizedResults.result}.deleted`)) {
             dispatch(addError(AppErrors.challenge.doesNotExist))
             ownProps.history.push('/')
           }


### PR DESCRIPTION
Attempting to browse a challenge that is pending deletion, but not yet
fully deleted, now shows the same "Challenge does not exist" error that
is shown when attempting to browse a challenge that is fully deleted or
non-existent.