### PR TITLE
Add geographic indexing notice. Closes #234

### DIFF
--- a/.env
+++ b/.env
@@ -42,6 +42,9 @@ REACT_APP_BOUNDED_TASKS_MAX_DIMENSION=2.5
 # Default time, in hours, until a newly-created virtual challenge expires.
 REACT_APP_VIRTUAL_CHALLENGE_DURATION=36
 
+# Duration, in hours, between geographic indexing runs on the server.
+REACT_APP_GEOGRAPHIC_INDEXING_DELAY=2
+
 # iD editor base URL
 REACT_APP_ID_EDITOR_SERVER_URL='https://www.openstreetmap.org/edit'
 

--- a/src/components/AdminPane/Manage/ViewChallenge/GeographicIndexingNotice.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/GeographicIndexingNotice.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
+import differenceInHours from 'date-fns/difference_in_hours'
+import _get from 'lodash/get'
+import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
+import messages from './Messages'
+
+/**
+ * GeographicIndexingNotice display a notice to the challenge owner letting
+ * them know that it could take time before their new or modified challenge
+ * shows up as expected in location-specific browsing or searching.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export default class GeographicIndexingNotice extends Component {
+  render() {
+    const reindexingDelay =
+      _get(process.env, 'REACT_APP_GEOGRAPHIC_INDEXING_DELAY', 0)
+
+    if (differenceInHours(Date.now(), _get(this.props, 'challenge.modified', 0)) >
+        reindexingDelay) {
+      return null
+    }
+
+    return (
+      <div className="admin__manage__view-challenge__indexing-notice notification">
+        <SvgSymbol sym='hourglass-icon' className='icon' viewBox='0 0 20 20' />
+        <FormattedMessage {...messages.geographicIndexingNotice}
+                          values={{delay: reindexingDelay}} />
+      </div>
+    )
+  }
+}
+
+GeographicIndexingNotice.propTypes = {
+  challenge: PropTypes.object,
+}

--- a/src/components/AdminPane/Manage/ViewChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/Messages.js
@@ -73,4 +73,13 @@ export default defineMessages({
     id: "Admin.ManageTasks.header",
     defaultMessage: "Tasks",
   },
+
+  geographicIndexingNotice: {
+    id: "Admin.ManageTasks.geographicIndexingNotice",
+    defaultMessage: "Please note that it can take up to {delay} hours " +
+                    "to geographically index new or modified challenges. " +
+                    "Your challenge (and tasks) may not appear as " +
+                    "expected in location-specific browsing or " +
+                    "searches until indexing is complete."
+  },
 })

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.scss
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.scss
@@ -28,6 +28,20 @@
     }
   }
 
+  .admin__manage__view-challenge__indexing-notice {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    svg.icon {
+      min-width: 35px;
+      height: 75px;
+      width: auto;
+      margin-right: 25px;
+      fill: $grey;
+    }
+  }
+
   section {
     margin-bottom: 1em;
   }

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
@@ -24,6 +24,7 @@ import MapPane from '../../../EnhancedMap/MapPane/MapPane'
 import ChallengeTaskMap from '../ChallengeTaskMap/ChallengeTaskMap'
 import TaskAnalysisTable from '../TaskAnalysisTable/TaskAnalysisTable'
 import TaskBuildProgress from './TaskBuildProgress'
+import GeographicIndexingNotice from './GeographicIndexingNotice'
 import messages from './Messages'
 
 /**
@@ -110,6 +111,8 @@ export class ViewChallengeTasks extends Component {
 
     return (
       <div className='admin__manage-tasks'>
+        <GeographicIndexingNotice challenge={this.props.challenge} />
+
         <MapPane>
           <ChallengeTaskMap taskInfo={this.props.taskInfo}
                             setChallengeOwnerMapBounds={this.props.setChallengeOwnerMapBounds}

--- a/src/components/Sprites/Sprites.js
+++ b/src/components/Sprites/Sprites.js
@@ -8,6 +8,9 @@ export default function () {
   return (
     <div className="sprites">
       <svg xmlns="http://www.w3.org/2000/svg" hidden>
+        <symbol id="hourglass-icon" viewBox="0 0 20 20">
+          <path d="M3 18a7 7 0 0 1 4-6.33V8.33A7 7 0 0 1 3 2H1V0h18v2h-2a7 7 0 0 1-4 6.33v3.34A7 7 0 0 1 17 18h2v2H1v-2h2zM5 2a5 5 0 0 0 4 4.9V10h2V6.9A5 5 0 0 0 15 2H5z"/>
+        </symbol>
         <symbol id="leaderboard-footer-icon" viewBox="0 0 1680 666">
           <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
             <g transform="translate(0.000000, -811.000000)" fill="#00A592">

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -163,6 +163,7 @@
   "Admin.Challenge.tasksCreatedCount": "{count, number} tasks created",
   "Admin.Challenge.controls.refreshStatus.label": "Refresh Status",
   "Admin.ManageTasks.header": "Tasks",
+  "Admin.ManageTasks.geographicIndexingNotice": "Please note that it can take up to {delay} hours to geographically index new or modified challenges. Your challenge (and tasks) may not appear as expected in location-specific browsing or searches until indexing is complete.",
   "Metrics.tasks.evaluatedByUser.label": "Tasks Evaluated by Users",
   "Form.textUpload.prompt": "Drop GeoJSON file here or click to select file",
   "Form.textUpload.readonly": "Existing file will be used",


### PR DESCRIPTION
Challenge owners, after creating or modifying a challenge, are now
presented with a notice informing them that there may be a delay until
their challenge is geographically indexed and appears as expected in
location-specific browsing or searches. The notice disappears once the
challenge is no longer within the delay window.

The indexing delay (in hours) can be specified in the
`REACT_APP_GEOGRAPHIC_INDEXING_DELAY` .env file variable.