### PR TITLE
Show challenge leaderboards to owners. Closes #316

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeLeaderboard/ChallengeLeaderboard.js
+++ b/src/components/AdminPane/Manage/ChallengeLeaderboard/ChallengeLeaderboard.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react'
+import _omit from 'lodash/omit'
+import Leaderboard from '../../../Leaderboard/Leaderboard'
+
+export default class ChallengeLeaderboard extends Component {
+  render() {
+    return <Leaderboard leaderboardOptions={{onlyEnabled: false, filterChallenges: true}}
+                        challenges={[this.props.challenge]}
+                        topLeaderCount={0}
+                        suppressTopChallenges
+                        compactView
+                        {..._omit(this.props, 'challenges')} />
+  }
+}

--- a/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/ChallengeOverview.js
@@ -10,6 +10,8 @@ import { ChallengeStatus,
        from  '../../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import ChallengeProgress
        from '../../../ChallengeProgress/ChallengeProgress'
+import ChallengeLeaderboard
+       from '../ChallengeLeaderboard/ChallengeLeaderboard'
 import ChallengeKeywords from '../ChallengeKeywords/ChallengeKeywords'
 import VisibilitySwitch from '../VisibilitySwitch/VisibilitySwitch'
 import ChallengeActivityTimeline
@@ -92,6 +94,10 @@ export class ChallengeOverview extends Component {
           {hasTasks &&
            <ChallengeProgress challenge={this.props.challenge} />
           }
+        </section>
+
+        <section className="challenge-overview__leaderboard">
+          <ChallengeLeaderboard {...this.props} />
         </section>
 
         <section className="challenge-overview--activity">

--- a/src/components/Leaderboard/Leaderboard.scss
+++ b/src/components/Leaderboard/Leaderboard.scss
@@ -289,9 +289,6 @@
           display: flex;
           flex-direction: column;
           justify-content: center;
-          margin: 15px 15px 15px 0px;
-          padding-right: 15px;
-          border-right: 2px solid $grey-lightest-less;
         }
 
         &__name {
@@ -307,6 +304,9 @@
         &__top-challenges {
           justify-content: center;
           align-items: left;
+          border-left: 2px solid $grey-lightest-less;
+          margin: 15px;
+          padding-left: 15px;
 
           h3 {
             border-bottom: none;
@@ -349,5 +349,86 @@
     top: $navbar-height;
     background-color: $grey-lightest-more;
     z-index: 1;
+  }
+
+  &--compact-view {
+    min-height: 0;
+    background-color: transparent;
+    padding: 0;
+
+    .leaderboard__board {
+      min-width: inherit;
+      min-height: 0;
+      width: 100%;
+      padding: 0;
+      box-shadow: none;
+      background-color: transparent;
+
+      &__header {
+        padding: 0;
+        margin-bottom: 5px;
+        border: none;
+
+        h1 {
+          font-size: $size-5;
+          font-weight: $weight-normal;
+          margin-bottom: 5px;
+        }
+
+        &__dates-control {
+          .dropdown-trigger {
+            .button.is-outlined {
+              margin-left: 1em;
+              margin-right: 1em;
+            }
+          }
+        }
+
+        &__point-breakdown {
+          display: none;
+        }
+      }
+
+      &__remaining-leaders {
+        margin-top: 5px;
+        margin-bottom: 15px;
+      }
+
+      &__leader {
+        border: none;
+        margin-bottom: 0;
+        background-color: transparent;
+        margin-bottom: 15px;
+
+        &__rank {
+          min-width: 55px;
+          max-width: 55px;
+          text-align: left;
+        }
+
+        &__avatar {
+          min-width: 40px;
+          width: 40px;
+          height: 40px;
+          margin: 2px 20px;
+
+          img {
+            width: 60px;
+          }
+        }
+
+        &__name-and-score {
+          margin: 0;
+        }
+
+        &__name, &__score {
+          font-size: $size-6;
+        }
+      }
+    }
+
+    .leaderboard__footer-icon, .leaderboard__obstruct-footer-icon {
+      display: none;
+    }
   }
 }

--- a/src/components/Leaderboard/Messages.js
+++ b/src/components/Leaderboard/Messages.js
@@ -37,6 +37,11 @@ export default defineMessages({
   userTopChallenges: {
     id: "Leaderboard.user.topChallenges",
     defaultMessage: "Top Challenges",
-  }
+  },
+
+  noLeaders: {
+    id: "Leaderboard.users.none",
+    defaultMessage: "No users for time period",
+  },
 })
 

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -205,6 +205,7 @@
   "Leaderboard.scoringMethod.explanation": "##### Points are awarded per completed task as follows:\n\n| Status        | Points |\n| :------------ | -----: |\n| Fixed         | 5      |\n| Not an Issue  | 3      |\n| Already Fixed | 3      |\n| Too Hard      | 1      |\n| Skipped       | 0      |",
   "Leaderboard.user.points": "Points",
   "Leaderboard.user.topChallenges": "Top Challenges",
+  "Leaderboard.users.none": "No users for time period",
   "LocatorMap.controls.startChallenge.label": "Start Challenge",
   "MobileNotSupported.header": "Please Visit on your Computer",
   "MobileNotSupported.message": "Sorry, MapRoulette does not currently support mobile devices.",


### PR DESCRIPTION
Challenge owners now see a leaderboard specific to their challenge when
viewing their challenge in the admin area.

Note that this depends on server PR maproulette/maproulette2#409