### PR TITLE
Handle admin non-existent challenge. Fixes #333

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
@@ -65,6 +65,7 @@ const WithCurrentProject = function(WrappedComponent, options={}) {
       const projectId = this.currentProjectId(props)
       if (_isFinite(this.routedProjectId(props)) && projectId === null) {
         this.props.notManagerError()
+        props.history.push('/admin/projects')
         return
       }
 


### PR DESCRIPTION
If a direct link/URL is used to view a non-existent challenge in admin,
an error is now shown and the user is redirected back to the admin
projects page.