### PR TITLE
Restrict admin stats to open project. Fixes #339

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
@@ -130,15 +130,15 @@ const WithCurrentProject = function(WrappedComponent, options={}) {
         challenges = _filter(allChallenges, {parent: projectId})
       }
 
-      return <WrappedComponent project={project}
+      return <WrappedComponent {..._omit(this.props, ['entities',
+                                                      'notManagerError',
+                                                      'fetchProject',
+                                                      'fetchProjectChallenges'])}
+                               project={project}
                                challenges={challenges}
                                routedProjectId={this.routedProjectId(this.props)}
                                loadingProject={this.state.loadingProject}
-                               loadingChallenges={this.state.loadingChallenges}
-                               {..._omit(this.props, ['entities',
-                                                      'notManagerError',
-                                                      'fetchProject',
-                                                      'fetchProjectChallenges'])} />
+                               loadingChallenges={this.state.loadingChallenges} />
     }
   }
 }

--- a/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
+++ b/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
@@ -39,11 +39,11 @@ const WithManageableProjects = function(WrappedComponent, includeChallenges=fals
         )
       }
 
-      return <WrappedComponent projects={manageableProjects}
+      return <WrappedComponent {..._omit(this.props, ['entities',
+                                                      'fetchManageableProjects'])}
+                               projects={manageableProjects}
                                challenges={manageableChallenges}
-                               loadingProjects={this.state.loadingProjects}
-                               {..._omit(this.props, ['entities',
-                                                      'fetchManageableProjects'])} />
+                               loadingProjects={this.state.loadingProjects} />
     }
   }
 }

--- a/src/components/AdminPane/Manage/Manage.js
+++ b/src/components/AdminPane/Manage/Manage.js
@@ -5,7 +5,6 @@ import _get from 'lodash/get'
 import Sidebar from '../../Sidebar/Sidebar'
 import WithManageableProjects from '../HOCs/WithManageableProjects/WithManageableProjects'
 import WithCurrentProject from '../HOCs/WithCurrentProject/WithCurrentProject'
-import WithSearchResults from '../../HOCs/WithSearchResults/WithSearchResults'
 import ManageProjects from './ManageProjects/ManageProjects'
 import ProjectMetrics from './ProjectMetrics/ProjectMetrics'
 import messages from './Messages'
@@ -64,24 +63,10 @@ export class Manage extends Component {
   }
 }
 
-export default WithManageableProjects(
-  WithCurrentProject(
-    WithSearchResults(
-      WithSearchResults(
-        Manage,
-        'adminChallenges',
-        'challenges',
-        'filteredChallenges'
-      ),
-      'adminProjects',
-      'projects',
-      'filteredProjects'
-    ), {
-      includeChallenges: true,
-      includeActivity: true,
-      historicalMonths: 2,
+export default
+  WithManageableProjects(
+    WithCurrentProject(Manage, {
       defaultToOnlyProject: true,
       restrictToGivenProjects: true,
-    }
-  ), true
-)
+    })
+  )

--- a/src/components/AdminPane/Manage/ManageProjects/ManageProjects.js
+++ b/src/components/AdminPane/Manage/ManageProjects/ManageProjects.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import _omit from 'lodash/omit'
+import WithManageableProjects
+       from '../../HOCs/WithManageableProjects/WithManageableProjects'
+import WithSearchResults
+       from '../../../HOCs/WithSearchResults/WithSearchResults'
 import WithComboSearchExecution
        from '../../HOCs/WithComboSearchExecution/WithComboSearchExecution'
 import SearchBox from '../../../SearchBox/SearchBox'
@@ -93,4 +97,18 @@ ManageProjects.defaultProps = {
   loadingProjects: false,
 }
 
-export default injectIntl(ManageProjects)
+export default
+  WithManageableProjects(
+    WithSearchResults(
+      WithSearchResults(
+        injectIntl(ManageProjects),
+        'adminChallenges',
+        'challenges',
+        'filteredChallenges'
+      ),
+      'adminProjects',
+      'projects',
+      'filteredProjects'
+    ),
+    true
+  )

--- a/src/components/AdminPane/Manage/ProjectMetrics/ProjectMetrics.js
+++ b/src/components/AdminPane/Manage/ProjectMetrics/ProjectMetrics.js
@@ -4,11 +4,18 @@ import { FormattedMessage, FormattedNumber } from 'react-intl'
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import _sum from 'lodash/sum'
+import WithCurrentProject from '../../HOCs/WithCurrentProject/WithCurrentProject'
 import ChallengeMetrics from '../ChallengeMetrics/ChallengeMetrics'
 import messages from './Messages'
 import './ProjectMetrics.css'
 
-export default class ProjectMetrics extends Component {
+/**
+ * ProjectMetrics displays various high-level metrics about the given projects
+ * and challenges.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export class ProjectMetrics extends Component {
   render() {
     const projectCount = _get(this.props, 'projects.length', 0)
     const challengeCount = _get(this.props, 'challenges.length', 0)
@@ -65,3 +72,12 @@ ProjectMetrics.propTypes = {
   projects: PropTypes.array,
   challenges: PropTypes.array,
 }
+
+export default
+  WithCurrentProject(ProjectMetrics, {
+    includeChallenges: true,
+    includeActivity: true,
+    historicalMonths: 2,
+    defaultToOnlyProject: true,
+    restrictToGivenProjects: true,
+  })


### PR DESCRIPTION
When a project is selected in admin, ensure project-metrics component is
only passed challenges from that project and not all projects managed by
the user, thereby ensuring displayed stats are restricted to open
project.