### PR TITLE
Progress tooltip - add % symbol

### DIFF
--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -21,6 +21,16 @@ import tailwindConfig from '../../tailwind.config.js'
 
 const colors = resolveConfig(tailwindConfig).theme.colors
 
+export const ProgressTooltip = (props) => {
+  return (
+    <div className="mr-bg-black mr-p-2 mr-flex mr-items-center mr-color-white">
+      <div className="mr-w-3 mr-h-3 mr-mr-2" style={{ backgroundColor: props.input.color }} />
+      <div>{props.input.label}</div>
+      <div className="mr-ml-1 mr-font-bold">{props.input.value}%</div>
+    </div>
+  )
+}
+
 const theme = (lightMode = false) => {
   return {
     axis: {
@@ -168,7 +178,7 @@ export class ChallengeProgress extends Component {
                       motionDamping={15}
                       axisLeft={{tickCount: 0, tickValues: []}}
                       axisBottom={{format: v => `${v}%`, tickCount: 5}}
-                      tooltipFormat={v => `${v}%`}
+                      tooltip={(input) => <ProgressTooltip input={input} />}
                       theme={theme(this.props.lightMode)}
         />
         {taskActions.total > 0 && taskActions.available === 0 &&

--- a/src/components/ChallengeProgress/ChallengeProgress.test.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.test.js
@@ -1,0 +1,13 @@
+import "@testing-library/jest-dom";
+import * as React from "react";
+import { ProgressTooltip } from "./ChallengeProgress";
+
+describe("ProgressTooltip", () => {
+  it("renders value with % sign", () => {
+    const { getByText } = global.withProvider(
+      <ProgressTooltip input={{ value: 86 }} />
+    );
+    const text = getByText("86%");
+    expect(text).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<img width="375" alt="Screen Shot 2022-11-19 at 4 02 55 PM" src="https://user-images.githubusercontent.com/79289630/202873839-9755704d-92f2-4d48-9987-fc4049a706c1.png">
 
The Challenge Completion widget tooltip was missing a % symbol due to an update to the library. Implementing a custom tooltip to resolve that should match the same styling and add the % symbol back.