### PR TITLE
bugfix - cannot filter by percentage completion in browse/challenges

### DIFF
--- a/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
+++ b/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
@@ -17,7 +17,7 @@ import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE
 const FEATURED_POINTS = -1
 const SAVED_POINTS = -2
 
-export const sortChallenges = function(props, challengesProp='challenges', config) {
+export const sortChallenges = function(props, challengesProp='challenges') {
   const sortCriteria = _get(props, 'searchSort.sortBy')
   let sortedChallenges = props[challengesProp]
 
@@ -73,7 +73,7 @@ export default function(WrappedComponent,
                         config) {
   class WithSortedChallenges extends Component {
     render() {
-      const sortedChallenges = sortChallenges(this.props, challengesProp, config)
+      const sortedChallenges = sortChallenges(this.props, challengesProp)
 
       if (_isEmpty(outputProp)) {
         outputProp = challengesProp

--- a/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
+++ b/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
@@ -33,9 +33,7 @@ export const sortChallenges = function(props, challengesProp='challenges', confi
       c => c.created ? c.created : ''))
   }
   else if (sortCriteria === SORT_COMPLETION) {
-    if (!config.frontendSearch) {
-      sortedChallenges = sortedChallenges.filter(challenge => challenge.completionPercentage !== 100);
-    }
+    sortedChallenges = sortedChallenges.filter(challenge => challenge.completionPercentage !== 100);
     sortedChallenges = _reverse(_sortBy(sortedChallenges, 
       c => c.completionPercentage ? c.completionPercentage : ''))
   }


### PR DESCRIPTION
This fixes a regression from admin metrics. We can't filter by percentage completion in browse/challenges page because of the newly added conditional check in withSortedChallenge, remove the conditional check solves the issue.