### PR TITLE
move notificationIds to json in notification services

### DIFF
--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -184,7 +184,7 @@ const apiRoutes = (factory) => {
       ),
       notifications: factory.get("/user/:userId/notifications"),
       markNotificationsRead: factory.put("/user/:userId/notifications"),
-      deleteNotifications: factory.delete("/user/:userId/notifications"),
+      deleteNotifications: factory.put("/user/:userId/notifications/delete"),
     },
     teams: {
       find: factory.get("/teams/find"),

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -430,7 +430,7 @@ export const markNotificationsRead = function(userId, notificationIds) {
   return function(dispatch) {
     return new Endpoint(api.user.markNotificationsRead, {
       variables: {userId},
-      params: {notificationIds: notificationIds.join(',')},
+      json: { notificationIds },
     }).execute().then(() => {
       return fetchUserNotifications(userId)(dispatch)
     })
@@ -444,7 +444,7 @@ export const deleteNotifications = function(userId, notificationIds) {
   return function(dispatch) {
     return new Endpoint(api.user.deleteNotifications, {
       variables: {userId},
-      params: {notificationIds: notificationIds.join(',')},
+      json: { notificationIds },
     }).execute().then(() => {
       return fetchUserNotifications(userId)(dispatch)
     })


### PR DESCRIPTION
If a user has many notifications and tries to delete them all at once, the URL paramter `notificationIds` can surpass the length that is allowed.

Moving notificaitonIds in both the `delete` and `markRead` services to the json payload of the requests.

Resolves https://github.com/maproulette/maproulette3/issues/1569

Requires https://github.com/maproulette/maproulette-backend/pull/997