### PR TITLE
Fix Challenge Completion Percentage Sort

### DIFF
--- a/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
+++ b/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
@@ -33,7 +33,7 @@ export const sortChallenges = function(props, challengesProp='challenges', confi
       c => c.created ? c.created : ''))
   }
   else if (sortCriteria === SORT_COMPLETION) {
-    if (!config.frontendSearch) {
+    if (!config?.frontendSearch) {
       sortedChallenges = sortedChallenges.filter(challenge => challenge.completionPercentage !== 100);
     }
     sortedChallenges = _reverse(_sortBy(sortedChallenges, 


### PR DESCRIPTION
The Completion Percentage sort runs into a type error due to a missing config variable.  Adding a conditional check which should resolve the page.