### PR TITLE
make toggleVisible a function in LocationSearchBox

### DIFF
--- a/src/components/EnhancedMap/SearchControl/LocationSearchBox.js
+++ b/src/components/EnhancedMap/SearchControl/LocationSearchBox.js
@@ -77,7 +77,7 @@ export class LocationSearchBox extends Component {
             <Dropdown
               className="mr-flex"
               arrowClassName="mr-pr-5"
-              toggleVisible
+              toggleVisible={() => null}
               isVisible
               dropdownButton={() => null}
               dropdownContent={() =>


### PR DESCRIPTION
For some reason, toggleVisible param was a boolean passed to Dropdown in LocationSearchBox, which doesn't seem to have ever been a workable parameter.  Passing an empty function fixes the ominous error modal when inputting a location.