### PR TITLE
robots.txt: Disallow indexing of /ws

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,7 +36,7 @@ Note that this will create the development build and not the 'production' build.
    REACT_APP_FEATURE_MOBILE_DEVICES='enabled'
    ```
 
-1. Build the image using `docker build -t maproulette-ui .`
+1. Build the image using `docker build --pull -t maproulette-ui .`
 1. Start a container from the image using `docker run -itd -p 127.0.0.1:3000:3000 --name maproulette-ui maproulette-ui`
 
 #### Developing with a local back-end server

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+# Tell all robots to not index the websocket endpoint /ws.
+# This is simply to not waste the resources on a bot.
+user-agent: *
+disallow: /ws


### PR DESCRIPTION
Create a robots.txt file and request all robot user-agents to not use endpoint /ws. We've seen a few bots access this: petalbot, ahrefsbot, yandexbot, bingpreview.