### PR TITLE
Web crawlers should not access /api/v2/data*

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
-# Tell all robots to not index the websocket endpoint /ws.
-# This is simply to not waste the resources on a bot.
 user-agent: *
+# Disallow websocket to simply to not waste the resources on a bot.
 disallow: /ws
+# Disallow everything under data
+disallow: /api/v2/data


### PR DESCRIPTION
This will help prevent bots from sending requests to endpoints like these:

- /api/v2/data/challenge/:challengeId
- /api/v2/data/challenge/:challengeId/propertyKeys
- /api/v2/data/challenge/summary
- /api/v2/data/project/summary
- /api/v2/data/user/leaderboard?projectIds=:id

