### PR TITLE
map through and show all feature properties in widget

### DIFF
--- a/src/components/EnhancedMap/PropertyList/PropertyList.js
+++ b/src/components/EnhancedMap/PropertyList/PropertyList.js
@@ -67,7 +67,7 @@ const PropertyList = props => {
   }))
 
   return (
-    <div className="feature-properties mr-ml-2">
+    <div className="feature-properties mr-ml-4">
       {!props.hideHeader && header}
       <table className={classNames("property-list", {"mr-bg-transparent mr-text-white": darkMode, "table": !darkMode})}>
         <tbody>{rows}</tbody>

--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.js
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.js
@@ -23,14 +23,26 @@ export default class TaskPropertiesWidget extends Component {
   render() {
     const taskList = _get(this.props.taskBundle, 'tasks') || [this.props.task]
     const propertyLists = _map(taskList, (task) => {
-      const properties = AsMappableTask(task).osmFeatureProperties(this.props.osmElements)
+      const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(this.props.osmElements)
+
       return (
         <div key={task.id} className="mr-mb-6">
           <div className="mr-text-yellow">
             <FormattedMessage {...messages.taskLabel} values={{taskId: task.id}}/>
           </div>
-          <PropertyList featureProperties={properties} hideHeader
-                        lightMode={false} {...this.props} />
+          {
+            featurePropertiesList.map((feature, index) => {
+              return (
+                <div key={index}>
+                  <div className="mr-text-yellow mr-ml-2">
+                    {feature.properties?.id || feature.geometry?.type}
+                  </div>
+                  <PropertyList featureProperties={feature.properties} hideHeader
+                    lightMode={false} {...this.props} />
+                </div>
+              )
+            })
+          }
         </div>
       )
     })

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -101,6 +101,31 @@ export class AsMappableTask {
     return allProperties
   }
 
+    /**
+   * Generates an array of property objects containing all feature properties found in the
+   * task's geometries. Later properties will overwrite earlier properties with
+   * the same name.
+   */
+    allFeaturePropertiesArray(features) {
+      if (!this.hasGeometries()) {
+        return []
+      }
+  
+      if (!features) {
+        features = this.geometries.features
+      }
+  
+      let allProperties = []
+  
+      features.forEach(feature => {
+        if (feature && feature.properties) {
+          allProperties.push(feature);
+        }
+      })
+  
+      return allProperties
+    }
+
   /**
    * Similar to allFeatureProperties, but uses current OSM tags for the feature
    * properties. If OSM data isn't available, falls back to default behavior of
@@ -112,10 +137,10 @@ export class AsMappableTask {
     }
 
     if (!osmElements || osmElements.size === 0) {
-      return this.allFeatureProperties()
+      return this.allFeaturePropertiesArray()
     }
 
-    return this.allFeatureProperties(
+    return this.allFeaturePropertiesArray(
       this.featuresWithTags(this.geometries.features, osmElements, true, supportedSimplestyles)
     )
   }


### PR DESCRIPTION
the task properties widget does not show all features for tasks comprised of feature collections.  this implementation will map through all features in a feature collection of a single task and render all feature keys/values for each node.