### PR TITLE
Added Node Dependency Information

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,8 @@ This is the repository that holds the front-end code. The back-end and API are d
 * [jq](https://stedolan.github.io/jq/)
 * [curl](https://curl.haxx.se/)
 
+Note: When installing Node LTS,  ensure that the version of node installed is <= 17.0.1 & conversely, the version of npm is <= 8.19.3. Otherwise, with higher versions of node, yarn would not be able to recognize Node and run the frontend portion of the codebase.
+
 ### Initial Setup
 
 1. Create a `.env.development.local` file and then look through `.env` at the


### PR DESCRIPTION
When setting up the frontend of this project, in order to use yarn, the node version should be less than 17.0.0 or else yarn would crash when trying to run. 