### PR TITLE
Added keyboard shortcut for completeTogetherbutton

### DIFF
--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -68,6 +68,7 @@ const ClusterMap = WithChallengeTaskClusters(
   true
 )
 
+const shortcutGroup = 'taskEditing'
 
 export default class TaskBundleWidget extends Component {
   bundleTasks = () => {
@@ -132,7 +133,26 @@ export default class TaskBundleWidget extends Component {
     )
   }
 
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.alreadyFixed)
+  }
+
+  handleKeyboardShortcuts = this.props.quickKeyHandler(
+    this.props.keyboardShortcutGroups.taskEditing.completeTogether.key,
+    () => this.completeTask()
+  )
+
   componentDidMount() {
+    this.props.activateKeyboardShortcut(
+      shortcutGroup,
+      _pick(this.props.keyboardShortcutGroups.taskEditing, 'alreadyFixed'),
+      this.handleKeyboardShortcuts)
+
     if (!this.props.taskBundle) {
       this.initializeClusterFilters()
       this.initializeWebsocketSubscription()
@@ -160,6 +180,8 @@ export default class TaskBundleWidget extends Component {
   }
 
   componentWillUnmount() {
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'alreadyFixed',
+                                          this.handleKeyboardShortcuts)
     const challengeId = _get(this.props.task, 'parent.id')
     if (_isFinite(challengeId)) {
       this.props.unsubscribeFromChallengeTaskMessages(challengeId)

--- a/src/services/KeyboardShortcuts/KeyMappings.js
+++ b/src/services/KeyboardShortcuts/KeyMappings.js
@@ -24,6 +24,7 @@ export default {
   taskEditing: {
     cancel: {key: 'Escape', label: messages.cancel, keyLabel: messages.escapeLabel},
     fitBounds: {key: '0', label: messages.fitBounds},
+    completeTogether: {key: 'c', label: messages.completeTogether}
   },
   layers: {
     layerOSMData: {key: 'o', label: messages.layerOSMData},

--- a/src/services/KeyboardShortcuts/Messages.js
+++ b/src/services/KeyboardShortcuts/Messages.js
@@ -59,6 +59,11 @@ export default defineMessages({
     defaultMessage: "Fit Map to Task Features",
   },
 
+  completeTogether: {
+    id: "KeyMapping.taskEditing.completeTogether",
+    defaultMessage: "Complete tasks together"
+  },
+
   escapeLabel: {
     id: "KeyMapping.taskEditing.escapeLabel",
     defaultMessage: "ESC",


### PR DESCRIPTION
Issue
Keyboard shortcut to make users select multiple tasks. Same functionality as the complete together button.

Approach / Solution
Created a new shortcut where users can bundle tasks together and complete them together with the 'c' key.

Resolves:
https://github.com/maproulette/maproulette3/issues/1793

Possible Requests
Currently the shortcut utilizes the 'c' key. If preferred I can change it to another key instead.