### PR TITLE
Added Request Review Challenge Setting

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -721,6 +721,17 @@ will not be able to make sense of it.
       "a park or a lake.",
   },
 
+  reviewSettingsLabel: {
+    id: "Admin.EditChallenge.form.reviewSettings.label",
+    defaultMessage: "Request Review By Default",
+  },
+
+  reviewSettingsDescription: {
+    id: "Admin.EditChallenge.form.reviewSettings.description",
+    defaultMessage: 
+    "This will pre-check the users request review box when submitting a task."
+  },
+
   showLongformTooltip: {
     id: "Admin.EditChallenge.controls.showLongform.tooltip",
     defaultMessage: "Show all fields",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -721,16 +721,28 @@ will not be able to make sense of it.
       "a park or a lake.",
   },
 
-  reviewSettingsLabel: {
-    id: "Admin.EditChallenge.form.reviewSettings.label",
-    defaultMessage: "Request Review By Default",
+  reviewSettingLabel: {
+    id: "Admin.EditChallenge.form.reviewSetting.label",
+    defaultMessage: "Request Review Settings",
   },
 
-  reviewSettingsDescription: {
-    id: "Admin.EditChallenge.form.reviewSettings.description",
+  reviewSettingDescription: {
+    id: "Admin.EditChallenge.form.reviewSetting.description",
     defaultMessage: 
     "This will pre-check the users request review box when submitting a task."
   },
+
+  reviewSettingNotRequired: {
+    id: "Challenge.reviewSetting.notRequired",
+    defaultMessage: "No Review Requirements",
+  },
+
+  reviewSettingRequested: {
+    id: "Challenge.reviewSetting.requested",
+    defaultMessage: 
+    "Request Review By Default."
+  },
+
 
   showLongformTooltip: {
     id: "Admin.EditChallenge.controls.showLongform.tooltip",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
@@ -1,9 +1,11 @@
 import _map from 'lodash/map'
+import _values from 'lodash/values'
 import _fromPairs from 'lodash/fromPairs'
 import _startCase from 'lodash/startCase'
 import _isUndefined from 'lodash/isUndefined'
 import _intersection from 'lodash/intersection'
 import idPresets from '../../../../../../preset_categories.json'
+import { ChallengeReviewSetting } from '../../../../../../services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting'
 import messages from '../Messages'
 
 const STEP_ID = "Editor"
@@ -33,14 +35,15 @@ export const jsSchema = (intl) => {
   const schemaFields = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     properties: {
-      reviewSettings: {
-        title: intl.formatMessage(messages.reviewSettingsLabel),
-        type: "boolean",
-        default: false,
+      reviewSetting: {
+        title: intl.formatMessage(messages.reviewSettingLabel),
+        type: "number",
+        enum: _values(ChallengeReviewSetting),
         enumNames: [
-          intl.formatMessage(messages.yesLabel),
-          intl.formatMessage(messages.noLabel),
+          intl.formatMessage(messages.reviewSettingNotRequired),
+          intl.formatMessage(messages.reviewSettingRequested),
         ],
+        default: ChallengeReviewSetting.notRequired,
       },
       presets: {
         title: intl.formatMessage(messages.presetsLabel),
@@ -109,12 +112,12 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
   }))
 
   const uiSchemaFields = Object.assign({}, {
-    reviewSettings: {
+    reviewSetting: {
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.editorStepHeader) : undefined,
-      "ui:help": intl.formatMessage(messages.reviewSettingsDescription),
+      "ui:help": intl.formatMessage(messages.reviewSettingDescription),
       "ui:collapsed": isGroupCollapsed,
       "ui:toggleCollapsed": toggleGroupCollapsed,
-      "ui:widget": "radio",
+      "ui:field": "columnRadio",
     },
     presets: {
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.editorStepHeader) : undefined,

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
@@ -33,6 +33,15 @@ export const jsSchema = (intl) => {
   const schemaFields = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     properties: {
+      reviewSettings: {
+        title: intl.formatMessage(messages.reviewSettingsLabel),
+        type: "boolean",
+        default: false,
+        enumNames: [
+          intl.formatMessage(messages.yesLabel),
+          intl.formatMessage(messages.noLabel),
+        ],
+      },
       presets: {
         title: intl.formatMessage(messages.presetsLabel),
         type: "boolean",
@@ -100,6 +109,13 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
   }))
 
   const uiSchemaFields = Object.assign({}, {
+    reviewSettings: {
+      "ui:groupHeader": options.longForm ? intl.formatMessage(messages.editorStepHeader) : undefined,
+      "ui:help": intl.formatMessage(messages.reviewSettingsDescription),
+      "ui:collapsed": isGroupCollapsed,
+      "ui:toggleCollapsed": toggleGroupCollapsed,
+      "ui:widget": "radio",
+    },
     presets: {
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.editorStepHeader) : undefined,
       "ui:collapsed": isGroupCollapsed,

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -277,7 +277,7 @@ export class TaskConfirmationModal extends Component {
                         <input
                           type="checkbox"
                           className="mr-mr-2"
-                          checked={this.props.challenge.reviewSettings == true ? this.props.challenge.reviewSettings : this.props.reviewSettings}
+                          checked={this.props.needsReview}
                           onClick={this.props.toggleNeedsReview}
                           onChange={_noop}
                         />

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -277,7 +277,7 @@ export class TaskConfirmationModal extends Component {
                         <input
                           type="checkbox"
                           className="mr-mr-2"
-                          checked={this.props.needsReview}
+                          checked={this.props.challenge.reviewSettings == true ? this.props.challenge.reviewSettings : this.props.reviewSettings}
                           onClick={this.props.toggleNeedsReview}
                           onChange={_noop}
                         />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -56,6 +56,7 @@ export class ActiveTaskControls extends Component {
     tags: null,
     revisionLoadBy: TaskReviewLoadMethod.all,
     doneLoadByFromHistory: false,
+    needsReview: this.props.challenge.reviewSetting === 1 ? true : undefined
   }
 
   setComment = comment => this.setState({comment})

--- a/src/lang/af.json
+++ b/src/lang/af.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/cs_CZ.json
+++ b/src/lang/cs_CZ.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Vzdálené umístění URL, ze kterého lze načíst GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Bevorzugte MR Tags",
   "Admin.EditChallenge.form.presets.description": "Beschränke die Auswahl von OSM Objekttypen beim Bearbeiten mit dem iD Editor, damit sich Bearbeiter auf das Kartieren von Dingen konzentrieren können, die für die Kampagne relevant sind. Sollen in der Kampagne zum Beispiel Gebäude kartiert werden, kann die Auswahl der Vorlagen in iD auf Gebäudetypen beschränkt werden, so dass Bearbeiter keine Möglichkeit haben, ein Gebiet als Park oder See zu kartieren.",
   "Admin.EditChallenge.form.presets.label": "iD Editor Presets einschränken",
+  "Admin.EditChallenge.form.reviewSettings.description": "Dadurch wird das Überprüfungsfeld des Benutzers vorab aktiviert, wenn eine Aufgabe gesendet wird.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Überprüfung standardmäßig anfordern",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Externe URL, von der die GeoJSON Datei geladen werden soll.",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Ich habe eine URL zu den GeoJSON-Daten",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.beispiel.com/geojson.json",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Etiquetas MR preferidas",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Ubicación remota de URL desde la cual recuperar el GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Tengo una URL para los datos de GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.ejemplo.com/geojson.json",

--- a/src/lang/fa_IR.json
+++ b/src/lang/fa_IR.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "محدود کردن تنظیمات از پیش تنظیم شده ویرایشگر iD",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "درخواست بررسی به صورت پیش فرض",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "من یک آدرس اینترنتی به داده‌های GeoJSON دارم",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Tags MR préférés",
   "Admin.EditChallenge.form.presets.description": "Limitez les types d'éléments OSM présentés par défaut aux cartographes dans iD lorsqu'ils travaillent sur vos tâches, afin qu'ils se concentrent sur la cartographie des éléments pertinents pour votre défi. Par exemple, si votre défi consiste à cartographier des bâtiments, vous pouvez activer uniquement les préréglages relatifs aux bâtiments. Les cartographes n'auront alors pas la possibilité de cartographier une zone comme, par exemple, un parc ou un lac.",
   "Admin.EditChallenge.form.presets.label": "Restreindre les préréglages d'iD",
+  "Admin.EditChallenge.form.reviewSettings.description": "Cela pré-cochera la case de révision de la demande des utilisateurs lors de la soumission d'une tâche.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Demander une révision par défaut",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Saisir l'URL permettant de récupérer le GeoJSON distant.",
   "Admin.EditChallenge.form.remoteGeoJson.label": "J'ai une URL vers les données au format GeoJSON.",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/it_IT.json
+++ b/src/lang/it_IT.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Etichette MR preferite",
   "Admin.EditChallenge.form.presets.description": "Limita i tipi di funzionalità OSM presentate ai mappatori con ID predefinito quando lavori ai tuoi compiti, aiutandoli a rimanere concentrati sulla mappatura di cose rilevanti per la tua sfida. Ad esempio, se la tua sfida riguarda la mappatura degli edifici, potresti abilitare solo i preset relativi agli edifici e quindi ai mappatori non verrebbe presentata l'opzione per mappare un'area come, ad esempio, un parco o un lago.",
   "Admin.EditChallenge.form.presets.label": "Limita i preimpostati dell'editor ID",
+  "Admin.EditChallenge.form.reviewSettings.description": "Questo pre-controllerà la casella di revisione della richiesta degli utenti quando inviano un'attività.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Richiedi revisione per impostazione predefinita",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Posizione dell'URL remoto da cui recuperare il GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Ho un URL per i dati GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "GeoJSONを参照するためのリモートURLの場所",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "선호하는 MR 태그",
   "Admin.EditChallenge.form.presets.description": "임무를 수행할 때 기본적으로 iD의 지도 제작자에게 제공되는 OSM 기능 유형을 제한하여 도전과 관련된 매핑에 집중할 수 있도록 합니다. 예를 들어, 건물 매핑 관련 도전이 있는 경우, 건물과 관련된 사전 설정만 활성화하면 지도 제작자에게 공원이나 호수와 같은 지역을 매핑하는 옵션이 표시되지 않습니다.",
   "Admin.EditChallenge.form.presets.label": "iD 편집기 사전 설정 제한",
+  "Admin.EditChallenge.form.reviewSettings.description": "이것은 작업을 제출할 때 사용자 요청 검토 상자를 미리 확인합니다.",
+  "Admin.EditChallenge.form.reviewSettings.label": "기본적으로 검토 요청",
   "Admin.EditChallenge.form.remoteGeoJson.description": "GeoJSON 파일을 가져올 URL을 입력해 주세요",
   "Admin.EditChallenge.form.remoteGeoJson.label": "GeoJSON 데이터에 대한 URL을 가지고 있어요",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Voorkeurtags MR",
   "Admin.EditChallenge.form.presets.description": "Beperk standaard de typen van objecten voor OSM die worden gepresenteerd aan de mappers in iD bij het werken aan uw taken, wat hen helpt om te focussen relevante dingen in kaart te brengen voor uw uitdaging. Als uw uitdaging bijvoorbeeld over het in kaart brengen van gebouwen gaat zou u alleen voorkeuzen gerelateerd aan gebouwen kunnen inschakelen en dan zouden aan mappers niet de opties worden getoond om een gebied, zoals bijvoorbeeld een park of een meer, in kaart te brengen.",
   "Admin.EditChallenge.form.presets.label": "Voorkeuzen bewerker iD beperken",
+  "Admin.EditChallenge.form.reviewSettings.description": "Dit vinkt vooraf het vakje Gebruikersverzoek om beoordeling aan bij het indienen van een taak.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Standaard beoordeling aanvragen",
   "Admin.EditChallenge.form.remoteGeoJson.description": "URL van de locatie op afstand waar de GeoJSON moet worden opgehaald",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Ik heb een URL voor de gegevens van GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferowane tagi MR",
   "Admin.EditChallenge.form.presets.description": "Ogranicz rodzaje funkcji OSM prezentowanych domyślnie edytorom w edytorze iD podczas pracy nad zadaniami, co pomoże im skupić się na mapowaniu rzeczy istotnych dla Twojego wyzwania. Na przykład, jeśli zadanie dotyczy mapowania budynków, możesz włączyć tylko ustawienia wstępne związane z budynkami, dzięki czemu edytorzy nie będą mieli możliwości mapowania obszaru na przykład jako parku lub jeziora.",
   "Admin.EditChallenge.form.presets.label": "Ogranicz ustawienia edytora iD",
+  "Admin.EditChallenge.form.reviewSettings.description": "Spowoduje to wstępne zaznaczenie pola przeglądu prośby użytkowników podczas przesyłania zadania.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Prośba o weryfikację domyślnie",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Zdalny adres URL, z którego ma zostać pobrany GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Mam adres URL do danych GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.przyklad.com/geojson.json",

--- a/src/lang/pt_BR.json
+++ b/src/lang/pt_BR.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Localização de URL remota a partir da qual recuperar o GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/ru_RU.json
+++ b/src/lang/ru_RU.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Удаленный URL загрузки GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "У меня есть URL-адрес данных GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/tr.json
+++ b/src/lang/tr.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Tercih edilen MR etiketleri",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "GeoJSON'un alınacağı uzak URL konumu",
   "Admin.EditChallenge.form.remoteGeoJson.label": "GeoJSON verileri için bir URL’m var",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/uk.json
+++ b/src/lang/uk.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Бажані MR теґи",
   "Admin.EditChallenge.form.presets.description": "Обмежте типи об’єктів OSM, які показуватимуться маперам в iD, коли вони працюватимуть над завданням, що допоможе їм сконцентрувати увагу на речах, які стосуються Виклику. Наприклад, якщо ваш Виклик має на меті мапінг будинків, ви можете задіяти набір елементів, які мають стосунок до будинків і мапери не бачитимуть, скажімо, парки чи озера.",
   "Admin.EditChallenge.form.presets.label": "Показувати елементи даних в iD",
+  "Admin.EditChallenge.form.reviewSettings.description": "Це попередньо встановить прапорець запиту користувачів на перевірку під час надсилання завдання.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Надіслати запит на перегляд за замовчуванням",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Посилання URL, звідки можна отримати дані у вигляді GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "Я бажаю скористатись URL для отримання GeoJSON даних ",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/vi.json
+++ b/src/lang/vi.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/lang/zh_TW.json
+++ b/src/lang/zh_TW.json
@@ -188,6 +188,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.reviewSettings.description": "This will pre-check the users request review box when submitting a task.",
+  "Admin.EditChallenge.form.reviewSettings.label": "Request Review By Default",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1010,7 +1010,7 @@ export const saveChallenge = function (
           "limitReviewTags",
           "taskStyles",
           "requiresLocal",
-          "reviewSettings",
+          "reviewSetting",
         ]
       );
 

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1010,6 +1010,7 @@ export const saveChallenge = function (
           "limitReviewTags",
           "taskStyles",
           "requiresLocal",
+          "reviewSettings",
         ]
       );
 

--- a/src/services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting.js
+++ b/src/services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting.js
@@ -1,0 +1,8 @@
+// These constants are defined on the server
+export const REVIEW_SETTING_NOT_REQUIRED = 0
+export const REVIEW_SETTING_REQUESTED = 1
+
+export const ChallengeReviewSetting = Object.freeze({
+  notRequired: REVIEW_SETTING_NOT_REQUIRED,
+  requested: REVIEW_SETTING_REQUESTED,
+})


### PR DESCRIPTION
Adds additional, boolean step to edit-challenge workflow that allows challenge managers to request review by default from users on all tasks within the challenge being edited. 

Resolves: https://github.com/maproulette/maproulette3/issues/1964