### PR TITLE
Add Challenge Editor Review Setting

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -729,7 +729,7 @@ will not be able to make sense of it.
   reviewSettingDescription: {
     id: "Admin.EditChallenge.form.reviewSetting.description",
     defaultMessage: 
-    "This will pre-check the users request review box when submitting a task."
+    "This will pre-check the users request review box when submitting a task.",
   },
 
   reviewSettingNotRequired: {
@@ -739,8 +739,7 @@ will not be able to make sense of it.
 
   reviewSettingRequested: {
     id: "Challenge.reviewSetting.requested",
-    defaultMessage: 
-    "Yes"
+    defaultMessage: "Yes",
   },
 
   showLongformTooltip: {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -721,6 +721,28 @@ will not be able to make sense of it.
       "a park or a lake.",
   },
 
+  reviewSettingLabel: {
+    id: "Admin.EditChallenge.form.reviewSetting.label",
+    defaultMessage: "Request Review By Default",
+  },
+
+  reviewSettingDescription: {
+    id: "Admin.EditChallenge.form.reviewSetting.description",
+    defaultMessage: 
+    "This will pre-check the users request review box when submitting a task."
+  },
+
+  reviewSettingNotRequired: {
+    id: "Challenge.reviewSetting.notRequired",
+    defaultMessage: "No",
+  },
+
+  reviewSettingRequested: {
+    id: "Challenge.reviewSetting.requested",
+    defaultMessage: 
+    "Yes"
+  },
+
   showLongformTooltip: {
     id: "Admin.EditChallenge.controls.showLongform.tooltip",
     defaultMessage: "Show all fields",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/EditorSchema.js
@@ -1,9 +1,11 @@
 import _map from 'lodash/map'
+import _values from 'lodash/values'
 import _fromPairs from 'lodash/fromPairs'
 import _startCase from 'lodash/startCase'
 import _isUndefined from 'lodash/isUndefined'
 import _intersection from 'lodash/intersection'
 import idPresets from '../../../../../../preset_categories.json'
+import { ChallengeReviewSetting } from '../../../../../../services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting'
 import messages from '../Messages'
 
 const STEP_ID = "Editor"
@@ -33,6 +35,16 @@ export const jsSchema = (intl) => {
   const schemaFields = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     properties: {
+      reviewSetting: {
+        title: intl.formatMessage(messages.reviewSettingLabel),
+        type: "number",
+        enum: _values(ChallengeReviewSetting),
+        enumNames: [
+          intl.formatMessage(messages.reviewSettingRequested),
+          intl.formatMessage(messages.reviewSettingNotRequired),
+        ],
+        default: ChallengeReviewSetting.notRequired,
+      },
       presets: {
         title: intl.formatMessage(messages.presetsLabel),
         type: "boolean",
@@ -100,8 +112,14 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
   }))
 
   const uiSchemaFields = Object.assign({}, {
-    presets: {
+    reviewSetting: {
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.editorStepHeader) : undefined,
+      "ui:help": intl.formatMessage(messages.reviewSettingDescription),
+      "ui:collapsed": isGroupCollapsed,
+      "ui:toggleCollapsed": toggleGroupCollapsed,
+      "ui:widget": "radio",
+    },
+    presets: {
       "ui:collapsed": isGroupCollapsed,
       "ui:toggleCollapsed": toggleGroupCollapsed,
       "ui:widget": "radio",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -56,6 +56,7 @@ export class ActiveTaskControls extends Component {
     tags: null,
     revisionLoadBy: TaskReviewLoadMethod.all,
     doneLoadByFromHistory: false,
+    needsReview: this.props.challenge.reviewSetting === 1 ? true : undefined
   }
 
   setComment = comment => this.setState({comment})

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1010,6 +1010,7 @@ export const saveChallenge = function (
           "limitReviewTags",
           "taskStyles",
           "requiresLocal",
+          "reviewSetting",
         ]
       );
 

--- a/src/services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting.js
+++ b/src/services/Challenge/ChallengeReviewSetting/ChallengeReviewSetting.js
@@ -1,0 +1,8 @@
+// These constants are defined on the server
+export const REVIEW_SETTING_NOT_REQUIRED = 0
+export const REVIEW_SETTING_REQUESTED = 1
+
+export const ChallengeReviewSetting = Object.freeze({
+  requested: REVIEW_SETTING_REQUESTED,
+  notRequired: REVIEW_SETTING_NOT_REQUIRED,
+})


### PR DESCRIPTION
Adds additional setting to edit-challenge workflow that allows challenge managers to request review by default from users on all tasks within the challenge being edited.
This feature has an integer based configuration to allow for additional review settings in the future if requested.

Resolves: https://github.com/maproulette/maproulette3/issues/1964