### PR TITLE
Add Upload Error Message GeoJSON

### DIFF
--- a/src/components/Custom/RJSFFormFieldAdapter/Messages.js
+++ b/src/components/Custom/RJSFFormFieldAdapter/Messages.js
@@ -28,4 +28,9 @@ export default defineMessages({
     id: 'Form.controls.markdownField.preview.label',
     defaultMessage: "Preview",
   },
+
+  uploadErrorText: {
+    id: 'Form.controls.markdownField.uploadErrorText.label',
+    defaultMessage: "Upload Failed!",
+  }
 })

--- a/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -335,10 +335,16 @@ export const DropzoneTextUpload = ({id, onChange, readonly, formContext, dropAre
       disablePreview
       onDrop={files => {
         formContext[id] = {file: files[0]}
-        onChange(files[0].name)
+        onChange(files[0])
       }}
     >
       {({acceptedFiles, getRootProps, getInputProps}) => {
+        const [uploadErrorText, setUploadErrorText] = useState('')
+
+        if(acceptedFiles[0] !== undefined && !acceptedFiles[0].name.endsWith('.geojson')){
+          acceptedFiles.pop() 
+          setUploadErrorText(<span className="mr-mr-4 mr-text-red-light mr-ml-1"><FormattedMessage {...messages.uploadErrorText} /></span>)
+        }
         const body = acceptedFiles.length > 0 ? <p>{acceptedFiles[0].name}</p> : (
           <span className="mr-flex mr-items-center">
             <SvgSymbol
@@ -346,6 +352,7 @@ export const DropzoneTextUpload = ({id, onChange, readonly, formContext, dropAre
               sym="upload-icon"
               className="mr-fill-current mr-w-3 mr-h-3 mr-mr-4"
             />
+            {uploadErrorText}
             <FormattedMessage {...messages.uploadFilePrompt} />
             <input {...getInputProps()} />
           </span>


### PR DESCRIPTION
Message added to "I want to upload a GeoJSON file" option Drop Zone in the challenge editor. This message is visible after submitting a file that doesn't end with ".geojson".

Resolves: https://github.com/maproulette/maproulette3/issues/1743