### PR TITLE
improve frontend caching for user and leaderboard

### DIFF
--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -24,6 +24,7 @@ export const USER_TYPE_REVIEWER = "reviewer"
 // one hour
 const CACHE_TIME = 60 * 60 * 1000;
 const GLOBAL_LEADERBOARD_CACHE = "globalLeaderboard";
+const USER_LEADERBOARD_CACHE = "userLeaderboard";
 
 const leaderboardCache = setupCustomCache(CACHE_TIME);
 
@@ -44,7 +45,7 @@ export const fetchLeaderboard = async (numberMonths=null, onlyEnabled=true,
   initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
                               forUsers, forCountries, startDate, endDate)
 
-  const cachedLeaderboard = leaderboardCache.get(params, GLOBAL_LEADERBOARD_CACHE);
+  const cachedLeaderboard = leaderboardCache.get({}, params, GLOBAL_LEADERBOARD_CACHE);
 
   if (cachedLeaderboard) {
     return cachedLeaderboard;
@@ -53,7 +54,7 @@ export const fetchLeaderboard = async (numberMonths=null, onlyEnabled=true,
   const results = await new Endpoint(api.users.leaderboard, {params}).execute()
 
   if (results) {
-    leaderboardCache.set(params, results, GLOBAL_LEADERBOARD_CACHE)
+    leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
   }
 
   return results
@@ -72,10 +73,25 @@ export const fetchLeaderboardForUser = async (userId, bracket=0, numberMonths=1,
     bracket,
     onlyEnabled
   }
+
+  const variables = {
+    id: userId
+  }
+
   initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
                               null, forCountries, startDate, endDate)
 
-  const results = await new Endpoint(api.users.userLeaderboard, {variables: {id: userId}, params}).execute()
+  const cachedLeaderboard = leaderboardCache.get(variables, params, USER_LEADERBOARD_CACHE);
+
+  if (cachedLeaderboard) {
+    return cachedLeaderboard;
+  }
+
+  const results = await new Endpoint(api.users.userLeaderboard, {variables, params}).execute()
+
+  if (results) {
+    leaderboardCache.set(variables, params, results, USER_LEADERBOARD_CACHE)
+  }
 
   return results;
 }

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -18,8 +18,8 @@ import AppErrors from "../Error/AppErrors";
 import { findUser, ensureUserLoggedIn, fetchUser } from "../User/User";
 import { setupCustomCache } from "../../utils/setupCustomCache";
 
-// 30 minute cache
-const CACHE_TIME = 30 * 60 * 1000;
+// 5 minute cache
+const CACHE_TIME = 5 * 60 * 1000;
 const PROJECT_ACTIVITY_CACHE = "projectActivity";
 const FEATURED_PROJECTS_CACHE = 'featuredProjects';
 const projectCache = setupCustomCache(CACHE_TIME);
@@ -129,7 +129,7 @@ export const fetchFeaturedProjects = function (
   return function (dispatch) {
     const pageToFetch = _isFinite(page) ? page : 0;
     const params = { onlyEnabled, limit, page: pageToFetch }
-    const cachedFeaturedProjects = projectCache.get(params, FEATURED_PROJECTS_CACHE);
+    const cachedFeaturedProjects = projectCache.get({}, params, FEATURED_PROJECTS_CACHE);
 
     if (cachedFeaturedProjects) {
       return new Promise((resolve) => {
@@ -144,7 +144,7 @@ export const fetchFeaturedProjects = function (
     })
       .execute()
       .then((normalizedResults) => {
-        projectCache.set(params, normalizedResults, FEATURED_PROJECTS_CACHE)
+        projectCache.set({}, params, normalizedResults, FEATURED_PROJECTS_CACHE)
         dispatch(receiveProjects(normalizedResults.entities));
         return normalizedResults;
       })
@@ -339,7 +339,7 @@ export const fetchProjectActivity = function (projectId, startDate, endDate) {
       params.end = startOfDay(endDate).toISOString();
     }
 
-    const cachedProjectActivity = projectCache.get(params, PROJECT_ACTIVITY_CACHE);
+    const cachedProjectActivity = projectCache.get({}, params, PROJECT_ACTIVITY_CACHE);
 
     if (cachedProjectActivity) {
       return dispatch(receiveProjects(cachedProjectActivity));
@@ -356,7 +356,7 @@ export const fetchProjectActivity = function (projectId, startDate, endDate) {
           },
         };
 
-        projectCache.set(params, normalizedResults, PROJECT_ACTIVITY_CACHE)
+        projectCache.set({}, params, normalizedResults, PROJECT_ACTIVITY_CACHE)
 
         return dispatch(receiveProjects(normalizedResults.entities));
       })

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -30,7 +30,15 @@ import { taskSchema,
          receiveTasks } from '../Task/Task'
 import { addError } from '../Error/Error'
 import AppErrors from '../Error/AppErrors'
+import { setupCustomCache } from '../../utils/setupCustomCache'
 import CommentType from '../Comment/CommentType'
+
+// 60 minutes
+const CACHE_TIME = 60 * 60 * 1000;
+const USER_ACTIVITY_CACHE = "userActivity";
+const USER_TOP_CHALLENGES = "userTopChallenges";
+const USER_METRICS_CACHE = "userMetrics";
+const userCache = setupCustomCache(CACHE_TIME);
 
 // constants defined on the server
 export const GUEST_USER_ID = -998 // i.e., not logged in
@@ -376,10 +384,21 @@ export const fetchTopChallenges = function(userId, startDate, limit=5) {
       limit,
     }
 
+    const variables = { userId }
+
+    const cachedTopChallenges = userCache.get(variables, params, USER_TOP_CHALLENGES);
+
+    if (cachedTopChallenges) {
+      dispatch(receiveChallenges(cachedTopChallenges.challenges))
+      dispatch(receiveUsers(cachedTopChallenges.user))
+
+      return cachedTopChallenges.challenges
+    }
+
     return new Endpoint(
       api.user.topChallenges, {
         schema: [ challengeSchema() ],
-        variables: {userId},
+        variables,
         params,
       }
     ).execute().then(normalizedChallenges => {
@@ -399,6 +418,8 @@ export const fetchTopChallenges = function(userId, startDate, limit=5) {
       _each(challenges, challenge => {
         delete challenge.activity
       })
+
+      userCache.set(variables, params, { challenges: normalizedChallenges.entities, user }, USER_TOP_CHALLENGES)
 
       dispatch(receiveChallenges(normalizedChallenges.entities))
       dispatch(receiveUsers(simulatedEntities(user)))
@@ -502,11 +523,20 @@ export const deleteNotifications = function(userId, notificationIds) {
  */
 export const fetchUserActivity = function(userId) {
   return function(dispatch) {
+
+    const cachedUserActivity = userCache.get({}, {}, USER_ACTIVITY_CACHE);
+
+    if (cachedUserActivity) {
+      return dispatch(receiveUsers(simulatedEntities(cachedUserActivity)));
+    }
+
     return new Endpoint(
       api.user.activity
     ).execute().then(activity => {
       const user = {id: userId}
       user.activity = activity
+
+      userCache.set({}, {}, user, USER_ACTIVITY_CACHE)
 
       dispatch(receiveUsers(simulatedEntities(user)))
       return activity
@@ -517,18 +547,33 @@ export const fetchUserActivity = function(userId) {
 /**
  * Fetch the user's recent metrics.
  */
-export const fetchUserMetrics = function(userId,
+export const fetchUserMetrics = async (userId,
                                          monthDuration = -1,
                                          reviewDuration = -1,
                                          reviewerDuration = -1,
                                          start = null, end = null,
                                          reviewStart = null, reviewEnd = null,
-                                         reviewerStart = null, reviewerEnd = null) {
-  return new Endpoint(api.user.metrics, {
-    variables: {userId},
-    params: {monthDuration, reviewDuration, reviewerDuration,
-             start, end, reviewStart, reviewEnd, reviewerStart, reviewerEnd}
+                                         reviewerStart = null, reviewerEnd = null) => {
+
+  const params = { monthDuration, reviewDuration, reviewerDuration,
+    start, end, reviewStart, reviewEnd, reviewerStart, reviewerEnd }
+
+  const variables = { userId }
+
+  const cachedUserMetrics = userCache.get(variables, params, USER_METRICS_CACHE);
+
+  if (cachedUserMetrics) {
+    return cachedUserMetrics;
+  }
+  
+  const userMetrics = await new Endpoint(api.user.metrics, {
+    variables,
+    params
   }).execute()
+
+  userCache.set(variables, params, userMetrics, USER_METRICS_CACHE)
+
+  return userMetrics
 }
 
 /**

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -571,7 +571,9 @@ export const fetchUserMetrics = async (userId,
     params
   }).execute()
 
-  userCache.set(variables, params, userMetrics, USER_METRICS_CACHE)
+  if (userMetrics.tasks) {
+    userCache.set(variables, params, userMetrics, USER_METRICS_CACHE)
+  }
 
   return userMetrics
 }

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -571,7 +571,7 @@ export const fetchUserMetrics = async (userId,
     params
   }).execute()
 
-  if (userMetrics.tasks) {
+  if (userMetrics?.tasks) {
     userCache.set(variables, params, userMetrics, USER_METRICS_CACHE)
   }
 

--- a/src/utils/setupCustomCache.js
+++ b/src/utils/setupCustomCache.js
@@ -1,7 +1,7 @@
 export const setupCustomCache = (cacheTime) => {
   return {
-    get: (params, type) => {
-      const cachedData = localStorage.getItem(`${type}::${JSON.stringify(params)}`);
+    get: (variables, params, type) => {
+      const cachedData = localStorage.getItem(`${type}::${JSON.stringify(variables)}::${JSON.stringify(params)}`);
 
       if (cachedData) {
         const parsed = JSON.parse(cachedData);
@@ -14,13 +14,13 @@ export const setupCustomCache = (cacheTime) => {
       return false;
     },
 
-    set: (params, data, type) => {
+    set: (variables, params, data, type) => {
       const obj = JSON.stringify({
         date: Date.now(),
         data
       })
 
-      localStorage.setItem(`${type}::${JSON.stringify(params)}`, obj)
+      localStorage.setItem(`${type}::${JSON.stringify(variables)}::${JSON.stringify(params)}`, obj)
     }
   }
 }


### PR DESCRIPTION
This will restore some of the pre-existing caching methods for user and leaderboard services.  We're also adding variable capture to endpoints that require user ids