### PR TITLE
support osm types extraction from osm identifiers for editor URI

### DIFF
--- a/src/interactions/TaskFeature/AsIdentifiableFeature.js
+++ b/src/interactions/TaskFeature/AsIdentifiableFeature.js
@@ -129,6 +129,44 @@ export class AsIdentifiableFeature {
     const re = new RegExp(/^(node|way|relation|n|r|w)?\/?\d+$/)
     return !!re.exec(id)
   }
+
+  // check whether osm types are consistent if there are multiple Ids
+  checkValidTypeMultipleIds(type) {
+    const typeRe = /^(node|way|relation|n|r|w)/
+    for (let i = 0; i < featureIdFields.length; i++) {
+      const match = typeRe.exec(this.properties[featureIdFields[i]])
+      let currentType
+
+      if (match) {
+        switch (match[0]) {
+          case 'node':
+          case 'n':
+            currentType = 'node'
+            break
+          case 'way':
+          case 'w':
+            currentType = 'way'
+            break
+          case 'relation':
+          case 'r':
+            currentType = 'relation'
+            break
+          default:
+            currentType = null
+        }
+      } else {
+        currentType = null
+      }
+
+      if (!currentType) {
+        continue
+      } else if (currentType != type) {
+        return false
+      }
+    }
+
+    return true
+  }
 }
 
 export default feature => new AsIdentifiableFeature(feature)

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -419,14 +419,19 @@ export const osmObjectParams = function (
       objects = objects.concat(
         _compact(
           task.geometries.features.map((feature) => {
-            const osmId = AsIdentifiableFeature(feature).osmId();
-            const osmType = AsIdentifiableFeature(feature).osmType();
-            
+            const currentFeature = AsIdentifiableFeature(feature)
+            const osmId = currentFeature.osmId();
+            const osmType = currentFeature.osmType();
+            let areAllTypesValid;
             if (!osmId) {
               return null;
             }
 
             if (osmType) {
+              areAllTypesValid = currentFeature.checkValidTypeMultipleIds(osmType);
+            }
+            // We will use osm types defined by user if they exist and are consistent, if not fall back to geometry type 
+            if (osmType && areAllTypesValid) {
               switch(osmType) {
                 case "node":
                   return `${

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -391,11 +391,15 @@ export const constructLevel0URI = function (
 };
 
 /**
- * Extracts osm identifiers from the given task's (or array of tasks) features
+ * Extracts numerical osm identifiers and osm types from the given task's (or array of tasks) features
  * and returns them as a comma-separated string by default. Features with
  * missing osm ids are skipped, and an empty string is returned if the task has
  * no features or none of its features have osm ids
  *
+ * Osm types will be extracted from osm id properties("@id", "osmid", "osmIdentifier", "id") if defined 
+ * to allow for customization from user 
+ * if there is no osm type defined in osm id properties, it will be generated based on geometry type
+ * 
  * To support varying formats required by different editors, the output string
  * can optionally be customized with options that control whether the entity
  * type is abbreviated or not, a separator character to be used between
@@ -416,8 +420,25 @@ export const osmObjectParams = function (
         _compact(
           task.geometries.features.map((feature) => {
             const osmId = AsIdentifiableFeature(feature).osmId();
+            const osmType = AsIdentifiableFeature(feature).osmType();
+            
             if (!osmId) {
               return null;
+            }
+
+            if (osmType) {
+              switch(osmType) {
+                case "node":
+                  return `${
+                    abbreviated ? "n" : "node"
+                  }${entitySeparator}${osmId}`;
+                case "way":
+                  return `${abbreviated ? "w" : "way"}${entitySeparator}${osmId}`;
+                case "relation":
+                  return `${
+                    abbreviated ? "r" : "relation"
+                  }${entitySeparator}${osmId}`;
+              }
             }
 
             switch (feature.geometry.type) {


### PR DESCRIPTION
add capability to parse osm types from osm id properties```"id", "@id", "osmIdentifier", "osmid"``` when constructing editor uri.
fixes https://github.com/maproulette/maproulette3/issues/2017