### PR TITLE
Add Map With Toggle To Review Table Widget

### DIFF
--- a/src/components/Widgets/ReviewTableWidget/ReviewTableWidget.js
+++ b/src/components/Widgets/ReviewTableWidget/ReviewTableWidget.js
@@ -3,6 +3,9 @@ import { WidgetDataTarget, registerWidgetType }
        from '../../../services/Widget/Widget'
 import TasksReviewTable from '../../../pages/Review/TasksReview/TasksReviewTable'
 import QuickWidget from '../../QuickWidget/QuickWidget'
+import TaskClusterMap from '../../TaskClusterMap/TaskClusterMap'
+import WithReviewTaskClusters from '../../HOCs/WithReviewTaskClusters/WithReviewTaskClusters'
+import WithTaskClusterMarkers from '../../HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers'
 import messages from './Messages'
 
 const descriptor = {
@@ -10,10 +13,13 @@ const descriptor = {
   label: messages.label,
   targets: [WidgetDataTarget.review],
   minWidth: 10,
-  defaultWidth: 10,
+  defaultWidth: 18,
   minHeight: 6,
   defaultHeight: 18,
 }
+
+const BrowseMap =
+  WithReviewTaskClusters(WithTaskClusterMarkers(TaskClusterMap('reviewBrowse')))
 
 export default class ReviewTableWidget extends Component {
   render() {
@@ -23,7 +29,7 @@ export default class ReviewTableWidget extends Component {
         className="review-table-widget"
         noMain
       >
-        <TasksReviewTable {...this.props} />
+        <TasksReviewTable {...this.props} BrowseMap={BrowseMap} />
       </QuickWidget>
     )
   }

--- a/src/pages/Review/TasksReview/Messages.js
+++ b/src/pages/Review/TasksReview/Messages.js
@@ -14,6 +14,11 @@ export default defineMessages({
     defaultMessage: "Refresh",
   },
 
+  toggleMap: {
+    id: "Review.TaskAnalysisTable.toggleMap",
+    defaultMessage: "Toggle Map",
+  },
+
   startReviewing: {
     id: "Review.TaskAnalysisTable.startReviewing",
     defaultMessage: "Review these Tasks",

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -47,6 +47,7 @@ import { ViewCommentsButton, StatusLabel, makeInvertable }
 import WithSavedFilters from '../../../components/HOCs/WithSavedFilters/WithSavedFilters'
 import SavedFiltersList from '../../../components/SavedFilters/SavedFiltersList'
 import ManageSavedFilters from '../../../components/SavedFilters/ManageSavedFilters'
+import MapPane from '../../../components/EnhancedMap/MapPane/MapPane'
 import { Link } from 'react-router-dom'
 import ReactTable from 'react-table-6'
 
@@ -75,6 +76,7 @@ export class TaskReviewTable extends Component {
   componentIsMounted: false
 
   state = {
+    displayMap: false,
     openComments: null,
     showConfigureColumns: false,
     challengeFilterIds: getFilterIds(this.props.location.search, 'filters.challengeId'),
@@ -411,111 +413,141 @@ export class TaskReviewTable extends Component {
         break
     }
 
+
+    //Used to add a map to the "Tasks Review Table" widget format to create the "Review Table With Map" widget.
+    const BrowseMap = this.state.displayMap == true ? this.props.BrowseMap : '';
+    let IncludeMap = '';
+    if (BrowseMap === '') {
+      IncludeMap = '';
+    } else {
+      IncludeMap = (
+        <div className="mr-h-100 mr-mb-8">
+          <MapPane>
+            <BrowseMap {..._omit(this.props, ['className'])} />
+          </MapPane>
+        </div>
+      );
+    }
+
+    const checkBoxes = (
+      this.props.reviewTasksType === ReviewTasksType.toBeReviewed && (
+        <div className="xl:mr-flex mr-mr-4">
+          <div className="field favorites-only-switch mr-mt-2 mr-mr-4" onClick={() => this.toggleShowFavorites()}>
+            <input
+              type="checkbox"
+              className="mr-checkbox-toggle mr-mr-px"
+              checked={!!this.props.reviewCriteria.savedChallengesOnly}
+              onChange={() => null}
+            />
+            <label> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
+          </div>
+          <div className="field favorites-only-switch mr-mt-2" onClick={() => this.toggleExcludeOthers()}>
+            <input
+              type="checkbox"
+              className="mr-checkbox-toggle mr-mr-px"
+              checked={!!this.props.reviewCriteria.excludeOtherReviewers}
+              onChange={() => null}
+            />
+            <label> {this.props.intl.formatMessage(messages.excludeOtherReviewers)}</label>
+          </div>
+        </div>
+      )
+    );
+    
+    
     return (
       <React.Fragment>
         <div className="mr-flex-grow mr-w-full mr-mx-auto mr-text-white mr-rounded mr-py-2 mr-px-6 md:mr-py-2 md:mr-px-8 mr-mb-12">
-          <header className="sm:mr-flex sm:mr-items-center sm:mr-justify-between">
-            <div>
-              <h1 className="mr-h2 mr-text-yellow md:mr-mr-4">
-                {subheader}
-              </h1>
-              {this.props.reviewTasksType === ReviewTasksType.toBeReviewed &&
-                <div className="mr-flex">
-                  <div className="field favorites-only-switch mr-mt-2 mr-mr-4" onClick={() => this.toggleShowFavorites()}>
-                    <input
-                      type="checkbox"
-                      className="mr-checkbox-toggle mr-mr-px"
-                      checked={!!this.props.reviewCriteria.savedChallengesOnly}
-                      onChange={() => null}
-                    />
-                    <label> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
-                  </div>
-                  <div className="field favorites-only-switch mr-mt-2" onClick={() => this.toggleExcludeOthers()}>
-                    <input
-                      type="checkbox"
-                      className="mr-checkbox-toggle mr-mr-px"
-                      checked={!!this.props.reviewCriteria.excludeOtherReviewers}
-                      onChange={() => null}
-                    />
-                    <label> {this.props.intl.formatMessage(messages.excludeOtherReviewers)}</label>
-                  </div>
-                </div>
-              }
-            </div>
-            <div>
-              {this.props.reviewTasksType === ReviewTasksType.toBeReviewed && data.length > 0 &&
-                <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4" onClick={() => this.startReviewing()}>
-                  <FormattedMessage {...messages.startReviewing} />
-                </button>
-              }
-              {this.props.reviewTasksType === ReviewTasksType.metaReviewTasks && data.length > 0 &&
-                <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4"
-                        onClick={() => this.startMetaReviewing()}>
-                  <FormattedMessage {...messages.startMetaReviewing} />
-                </button>
-              }
-              <button
-                className={classNames(
-                  "mr-button mr-button-small", {
-                  "mr-button--green-lighter": !_get(this.props, 'reviewData.dataStale', false),
-                  "mr-button--orange": _get(this.props, 'reviewData.dataStale', false)
-                })}
-                onClick={() => this.props.refresh()}
-              >
-                <FormattedMessage {...messages.refresh} />
-              </button>
-              <div className="mr-float-right mr-mt-3 mr-ml-3">
-                <div className="mr-flex mr-justify-start mr-ml-4">
-                  {this.filterDropdown(this.props.reviewTasksType)}
-                  {this.gearDropdown(this.props.reviewTasksType)}
-                </div>
+          <div className={BrowseMap === '' ? 'sm:mr-flex sm:mr-items-center sm:mr-justify-between' : ''}>
+            <header className="sm:mr-flex sm:mr-items-center sm:mr-justify-between">
+              <div>
+                <h1 className={`mr-h2 mr-text-yellow md:mr-mr-4 ${BrowseMap === '' ? '' : 'mr-mb-4'}`}>
+                  {subheader}
+                </h1>
+                {BrowseMap === '' ? checkBoxes : ''}
               </div>
-              <ManageSavedFilters
-                searchFilters={this.props.reviewCriteria}
-                {...this.props}
-              />
+            </header>
+            {IncludeMap}
+            <div className='sm:mr-flex sm:mr-items-center sm:mr-justify-between'>
+              {BrowseMap === '' ? '' : checkBoxes}
+              <div className="mr-ml-auto">
+                {this.props.reviewTasksType === ReviewTasksType.toBeReviewed && data.length > 0 && (
+                  <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4" onClick={() => this.startReviewing()}>
+                    <FormattedMessage {...messages.startReviewing} />
+                  </button>
+                )}
+                {this.props.reviewTasksType === ReviewTasksType.metaReviewTasks && data.length > 0 && (
+                  <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4" onClick={() => this.startMetaReviewing()}>
+                    <FormattedMessage {...messages.startMetaReviewing} />
+                  </button>
+                )}
+                <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4"
+                  onClick={() => this.setState({ displayMap: !this.state.displayMap })}
+                >
+                  <FormattedMessage {...messages.toggleMap} />
+                </button>
+                <button
+                  className={classNames("mr-button mr-button-small", {
+                    "mr-button--green-lighter": !_get(this.props, 'reviewData.dataStale', false),
+                    "mr-button--orange": _get(this.props, 'reviewData.dataStale', false)
+                  })}
+                  onClick={() => this.props.refresh()}
+                >
+                  <FormattedMessage {...messages.refresh} />
+                </button>
+                <div className="mr-float-right mr-mt-3 mr-ml-3">
+                  <div className="mr-flex mr-justify-start mr-ml-4">
+                    {this.filterDropdown(this.props.reviewTasksType)}
+                    {this.gearDropdown(this.props.reviewTasksType)}
+                  </div>
+                </div>
+                <ManageSavedFilters searchFilters={this.props.reviewCriteria} {...this.props} />
+              </div>
             </div>
-          </header>
+          </div>
           <div className="mr-mt-6 review">
-            <ReactTable data={data} columns={columns} key={this.props.reviewTasksType}
-                        pageSize={pageSize}
-                        totalCount={totalRows}
-                        defaultSorted={defaultSorted}
-                        defaultFiltered={defaultFiltered}
-                        minRows={1}
-                        manual
-                        multiSort={false}
-                        noDataText={<FormattedMessage {...messages.noTasks} />}
-                        pages={totalPages}
-                        onFetchData={(state, instance) => this.debouncedUpdateTasks(state, instance)}
-                        onPageSizeChange={(pageSize) => this.props.changePageSize(pageSize)}
-                        getTheadFilterThProps={() => {
-                          return {style: {position: "inherit", overflow: "inherit"}}}
-                        }
-                        onFilteredChange={filtered => {
-                          this.setState({ filtered })
-                          if (this.fetchData) {
-                            this.fetchData()
-                          }
-                        }}
-                        loading={this.props.loading}
-                        {...intlTableProps(this.props.intl)}
-                        PaginationComponent={IntlTablePagination}
+            <ReactTable
+              data={data}
+              columns={columns}
+              key={this.props.reviewTasksType}
+              pageSize={pageSize}
+              totalCount={totalRows}
+              defaultSorted={defaultSorted}
+              defaultFiltered={defaultFiltered}
+              minRows={1}
+              manual
+              multiSort={false}
+              noDataText={<FormattedMessage {...messages.noTasks} />}
+              pages={totalPages}
+              onFetchData={(state, instance) => this.debouncedUpdateTasks(state, instance)}
+              onPageSizeChange={pageSize => this.props.changePageSize(pageSize)}
+              getTheadFilterThProps={() => {
+                return { style: { position: "inherit", overflow: "inherit" } };
+              }}
+              onFilteredChange={filtered => {
+                this.setState({ filtered });
+                if (this.fetchData) {
+                  this.fetchData();
+                }
+              }}
+              loading={this.props.loading}
+              {...intlTableProps(this.props.intl)}
+              PaginationComponent={IntlTablePagination}
             />
           </div>
         </div>
-        {_isFinite(this.state.openComments) &&
-         <TaskCommentsModal
-           taskId={this.state.openComments}
-           onClose={() => this.setState({openComments: null})}
-         />
-        }
-        {this.state.showConfigureColumns &&
-         <ConfigureColumnsModal
-           {...this.props}
-           onClose={() => this.setState({showConfigureColumns: false})}
-         />
-        }
+        {_isFinite(this.state.openComments) && (
+          <TaskCommentsModal
+            taskId={this.state.openComments}
+            onClose={() => this.setState({ openComments: null })}
+          />
+        )}
+        {this.state.showConfigureColumns && (
+          <ConfigureColumnsModal
+            {...this.props}
+            onClose={() => this.setState({ showConfigureColumns: false })}
+          />
+        )}
       </React.Fragment>
     )
   }

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -76,7 +76,7 @@ export class TaskReviewTable extends Component {
   componentIsMounted: false
 
   state = {
-    displayMap: false,
+    displayMap: localStorage.getItem('displayMap') === 'true' ? true : false,    
     openComments: null,
     showConfigureColumns: false,
     challengeFilterIds: getFilterIds(this.props.location.search, 'filters.challengeId'),
@@ -414,20 +414,16 @@ export class TaskReviewTable extends Component {
     }
 
 
-    //Used to add a map to the "Tasks Review Table" widget format to create the "Review Table With Map" widget.
-    const BrowseMap = this.state.displayMap == true ? this.props.BrowseMap : '';
-    let IncludeMap = '';
-    if (BrowseMap === '') {
-      IncludeMap = '';
-    } else {
-      IncludeMap = (
-        <div className="mr-h-100 mr-mb-8">
-          <MapPane>
-            <BrowseMap {..._omit(this.props, ['className'])} />
-          </MapPane>
-        </div>
-      );
-    }
+    
+    const BrowseMap = this.props.BrowseMap
+    
+    const IncludeMap = this.state.displayMap ? (
+      <div className="mr-h-100 mr-mb-8">
+        <MapPane>
+          <BrowseMap {..._omit(this.props, ['className'])} />
+        </MapPane>
+      </div>
+    ) : null;
 
     const checkBoxes = (
       this.props.reviewTasksType === ReviewTasksType.toBeReviewed && (
@@ -458,18 +454,18 @@ export class TaskReviewTable extends Component {
     return (
       <React.Fragment>
         <div className="mr-flex-grow mr-w-full mr-mx-auto mr-text-white mr-rounded mr-py-2 mr-px-6 md:mr-py-2 md:mr-px-8 mr-mb-12">
-          <div className={BrowseMap === '' ? 'sm:mr-flex sm:mr-items-center sm:mr-justify-between' : ''}>
+          <div className={IncludeMap === null ? 'sm:mr-flex sm:mr-items-center sm:mr-justify-between' : null}>
             <header className="sm:mr-flex sm:mr-items-center sm:mr-justify-between">
               <div>
                 <h1 className={`mr-h2 mr-text-yellow md:mr-mr-4 ${BrowseMap === '' ? '' : 'mr-mb-4'}`}>
                   {subheader}
                 </h1>
-                {BrowseMap === '' ? checkBoxes : ''}
+                {IncludeMap === null ? checkBoxes : null}
               </div>
             </header>
             {IncludeMap}
             <div className='sm:mr-flex sm:mr-items-center sm:mr-justify-between'>
-              {BrowseMap === '' ? '' : checkBoxes}
+              {IncludeMap === null ? null : checkBoxes}
               <div className="mr-ml-auto">
                 {this.props.reviewTasksType === ReviewTasksType.toBeReviewed && data.length > 0 && (
                   <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4" onClick={() => this.startReviewing()}>
@@ -482,7 +478,11 @@ export class TaskReviewTable extends Component {
                   </button>
                 )}
                 <button className="mr-button mr-button-small mr-button--green-lighter mr-mr-4"
-                  onClick={() => this.setState({ displayMap: !this.state.displayMap })}
+                  onClick={() => {
+                    const newDisplayMap = !this.state.displayMap;
+                    localStorage.setItem('displayMap', JSON.stringify(newDisplayMap));
+                    this.setState({ displayMap: newDisplayMap })
+                  }}
                 >
                   <FormattedMessage {...messages.toggleMap} />
                 </button>


### PR DESCRIPTION
Adds a map toggle button that allows a reviewer to toggle on and off a map above their review table.
<img width="1240" alt="Screen Shot 2023-06-08 at 3 19 23 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/aa5572dc-4789-4b25-bebd-09a5a5b1b0cc">
<img width="1233" alt="Screen Shot 2023-06-08 at 3 19 16 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/edafa9e5-b734-4cf6-b1ee-2b60c1976034">


Additional notes: Fixed formatting issues caused by adjusting code to accommodate the map and other elements around it. Local storage will be used for now for the map toggle, but an enhancement to have the map toggled in some other way, like user settings, could be discussed.