### PR TITLE
fix small form geojson issue

### DIFF
--- a/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -335,7 +335,7 @@ export const DropzoneTextUpload = ({id, onChange, readonly, formContext, dropAre
       disablePreview
       onDrop={files => {
         formContext[id] = {file: files[0]}
-        onChange(files[0])
+        onChange(files[0] ? files[0].name : files[0])
       }}
     >
       {({acceptedFiles, getRootProps, getInputProps}) => {


### PR DESCRIPTION
Issue: The small form has schema configuration that checks for a type of string, and ended up throwing an error message because the field was being passed an object that was implemented due to the creation of new features.

Solution: Add an if statement in the onChange function in the DropZone function to manage both an empty array and an array with a file in it to pass the validation for the small form while keeping the new validation feature for both types of forms.