### PR TITLE
Add scale bar Leaflet control to TaskBundleWidget

### DIFF
--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { ZoomControl, Marker, LayerGroup, Rectangle, Polyline, Pane, Tooltip }
+import { ZoomControl, ScaleControl, Marker, LayerGroup, Rectangle, Polyline, Pane, Tooltip }
        from 'react-leaflet'
 import { latLng } from 'leaflet'
 import bbox from '@turf/bbox'
@@ -714,6 +714,7 @@ export class TaskClusterMap extends Component {
         onZoomOrMoveStart={this.debouncedUpdateBounds.cancel}
       >
         <ZoomControl className="mr-z-10" position='topright' />
+        {this.props.showScaleControl && <ScaleControl className="mr-z-10" position='topleft'/>}
         {this.props.showFitWorld && <FitWorldControl />}
         {this.props.taskCenter &&
           <FitBoundsControl key={this.props.taskCenter.toString()} centerPoint={this.props.taskCenter} />

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -714,7 +714,7 @@ export class TaskClusterMap extends Component {
         onZoomOrMoveStart={this.debouncedUpdateBounds.cancel}
       >
         <ZoomControl className="mr-z-10" position='topright' />
-        {this.props.showScaleControl && <ScaleControl className="mr-z-10" position='topleft'/>}
+        {this.props.showScaleControl && <ScaleControl className="mr-z-10" position='bottomleft'/>}
         {this.props.showFitWorld && <FitWorldControl />}
         {this.props.taskCenter &&
           <FitBoundsControl key={this.props.taskCenter.toString()} centerPoint={this.props.taskCenter} />

--- a/src/components/TaskClusterMap/TaskClusterMap.scss
+++ b/src/components/TaskClusterMap/TaskClusterMap.scss
@@ -54,6 +54,10 @@
   .leaflet-container {
     height: 100%;
   }
+
+  .leaflet-control-scale {
+    top: 0px !important;
+  }
 }
 
 .greyscale-cluster {

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -349,6 +349,7 @@ const BuildBundle = props => {
       allowClusterToggle={false}
       hideSearchControl
       allowSpidering
+      showScaleControl
       showSelectMarkersInView
       {..._omit(props, 'className')}
     />


### PR DESCRIPTION
Addresses #1907: add scale bar to multi task widget map to give reference to distance between task markers.

![Screen Shot 2023-08-02 at 2 46 17 PM](https://github.com/maproulette/maproulette3/assets/45773707/f79e4252-0c2f-433e-bf54-9ae61b131fa5)


