### PR TITLE
Add tag configuration and another widget to mobile workspace

### DIFF
--- a/src/components/CommentList/CommentCountBadge/CommentCountBadge.js
+++ b/src/components/CommentList/CommentCountBadge/CommentCountBadge.js
@@ -15,13 +15,11 @@ import './CommentCountBadge.scss'
 export default class CommentCountBadge extends Component {
   render() {
     return (
-      <div className={classNames("comment-count-badge", this.props.className)}>
-        <span className={classNames("badge is-badge-outlined",
+        <div className={classNames("badge is-badge-outlined",
                                     {"is-empty": this.props.comments.length === 0})}
               data-badge={this.props.comments.length}>
           <SvgSymbol viewBox='0 0 20 20' sym="chat-icon" />
-        </span>
-      </div>
+        </div>
     )
   }
 }

--- a/src/components/TaskPane/MobileTaskDetails/MobileTaskDetails.js
+++ b/src/components/TaskPane/MobileTaskDetails/MobileTaskDetails.js
@@ -17,6 +17,8 @@ import TaskInstructions from '../TaskInstructions/TaskInstructions'
 import TaskTrackControls from '../TaskTrackControls/TaskTrackControls'
 import TaskRandomnessControl
        from '../TaskRandomnessControl/TaskRandomnessControl'
+import AsCooperativeWork from '../../../interactions/Task/AsCooperativeWork'
+import { TaskCompletionWidget, TagDiffWidget, TaskHistoryWidget } from '../../Widgets/widget_registry'
 import ChallengeShareControls
        from '../ChallengeShareControls/ChallengeShareControls'
 import MarkdownContent from '../../MarkdownContent/MarkdownContent'
@@ -61,8 +63,19 @@ export default class MobileTaskDetails extends Component {
   }, {
     name: "edit",
     icon: "evaluate-icon",
-    component: () => null,
-  }, {
+    component: props => (
+      console.log(props.task),
+        <TaskCompletionWidget {...props} />
+    )
+  }, { 
+    name: "tags",
+    icon: "pencil-icon",
+    component: props => (
+      AsCooperativeWork(this.props.task).isTagType() ? 
+      <TagDiffWidget {...props} /> : 
+      <TaskHistoryWidget {...props} />
+    )
+  }, { 
     name: "comments",
     icon: props => <CommentCountBadge comments={_get(props, 'task.comments')} />,
     component: props => (


### PR DESCRIPTION
Issue: https://github.com/maproulette/maproulette3/issues/2050
Tag Fix Mobile Workspace:
<img width="377" alt="Screen Shot 2023-08-07 at 5 42 01 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/51eb5c88-80a9-4ef3-bd03-421280b5f004">
<img width="375" alt="Screen Shot 2023-08-07 at 5 42 18 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/f743994a-bf3f-43a0-af58-f8c49d94a468">

Edit Task Mobile Workspace:
<img width="375" alt="Screen Shot 2023-08-07 at 5 42 44 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/7c7cfb49-7dfe-4b62-af2f-e242e1d30ced">
