### PR TITLE
Fix mobile instructions widget error

### DIFF
--- a/src/hooks/UseMRProperties/UseMRProperties.js
+++ b/src/hooks/UseMRProperties/UseMRProperties.js
@@ -18,7 +18,7 @@ const useMRProperties = workspaceContext => {
   const [properties, setProperties] = useState({})
 
   useEffect(() => {
-    if(workspaceContext){
+    if(!workspaceContext){
       return null
     }
 

--- a/src/hooks/UseMRProperties/UseMRProperties.js
+++ b/src/hooks/UseMRProperties/UseMRProperties.js
@@ -17,45 +17,47 @@ import AsIdentifiableFeature
 const useMRProperties = workspaceContext => {
   const [properties, setProperties] = useState({})
 
-  if(workspaceContext){
-    useEffect(() => {
-      const mrProperties = {
-        '#mapZoom': workspaceContext['taskMapZoom'],
+  useEffect(() => {
+    if(workspaceContext){
+      return null
+    }
+
+    const mrProperties = {
+      '#mapZoom': workspaceContext['taskMapZoom'],
+    }
+
+    const task = workspaceContext['taskMapTask']
+    if (task) {
+      const primaryFeature =
+        AsIdentifiableFeature(AsMappableTask(task).normalizedGeometries().features[0])
+
+      mrProperties['#mrTaskId'] = task.id
+      mrProperties['#osmId'] = primaryFeature.osmId()
+      mrProperties['#osmType'] = primaryFeature.osmType()
+
+      //map the task specific properties to the workspace properties
+      const { properties } = primaryFeature;
+      if (properties) {
+        Object.keys(properties).map((key) => {
+          mrProperties[key] = properties[key];
+          return null;
+        });
       }
+    }
 
-      const task = workspaceContext['taskMapTask']
-      if (task) {
-        const primaryFeature =
-          AsIdentifiableFeature(AsMappableTask(task).normalizedGeometries().features[0])
+    const mapBounds = workspaceContext['taskMapBounds']
+    if (mapBounds) {
+      mrProperties['#mapLat'] = mapBounds.getCenter().lat
+      mrProperties['#mapLon'] = mapBounds.getCenter().lng
+      mrProperties['#mapBBox'] = mapBounds.toBBoxString()
+      mrProperties['#mapWest'] = mapBounds.getWest()
+      mrProperties['#mapSouth'] = mapBounds.getSouth()
+      mrProperties['#mapEast'] = mapBounds.getEast()
+      mrProperties['#mapNorth'] = mapBounds.getNorth()
+    }
 
-        mrProperties['#mrTaskId'] = task.id
-        mrProperties['#osmId'] = primaryFeature.osmId()
-        mrProperties['#osmType'] = primaryFeature.osmType()
-
-        //map the task specific properties to the workspace properties
-        const { properties } = primaryFeature;
-        if (properties) {
-          Object.keys(properties).map((key) => {
-            mrProperties[key] = properties[key];
-            return null;
-          });
-        }
-      }
-
-      const mapBounds = workspaceContext['taskMapBounds']
-      if (mapBounds) {
-        mrProperties['#mapLat'] = mapBounds.getCenter().lat
-        mrProperties['#mapLon'] = mapBounds.getCenter().lng
-        mrProperties['#mapBBox'] = mapBounds.toBBoxString()
-        mrProperties['#mapWest'] = mapBounds.getWest()
-        mrProperties['#mapSouth'] = mapBounds.getSouth()
-        mrProperties['#mapEast'] = mapBounds.getEast()
-        mrProperties['#mapNorth'] = mapBounds.getNorth()
-      }
-
-      setProperties(mrProperties)
-    }, [workspaceContext])
-  }
+    setProperties(mrProperties)
+  }, [workspaceContext])
 
   return properties
 }

--- a/src/hooks/UseMRProperties/UseMRProperties.js
+++ b/src/hooks/UseMRProperties/UseMRProperties.js
@@ -17,43 +17,45 @@ import AsIdentifiableFeature
 const useMRProperties = workspaceContext => {
   const [properties, setProperties] = useState({})
 
-  useEffect(() => {
-    const mrProperties = {
-      '#mapZoom': workspaceContext['taskMapZoom'],
-    }
-
-    const task = workspaceContext['taskMapTask']
-    if (task) {
-      const primaryFeature =
-        AsIdentifiableFeature(AsMappableTask(task).normalizedGeometries().features[0])
-
-      mrProperties['#mrTaskId'] = task.id
-      mrProperties['#osmId'] = primaryFeature.osmId()
-      mrProperties['#osmType'] = primaryFeature.osmType()
-
-      //map the task specific properties to the workspace properties
-      const { properties } = primaryFeature;
-      if (properties) {
-        Object.keys(properties).map((key) => {
-          mrProperties[key] = properties[key];
-          return null;
-        });
+  if(workspaceContext){
+    useEffect(() => {
+      const mrProperties = {
+        '#mapZoom': workspaceContext['taskMapZoom'],
       }
-    }
 
-    const mapBounds = workspaceContext['taskMapBounds']
-    if (mapBounds) {
-      mrProperties['#mapLat'] = mapBounds.getCenter().lat
-      mrProperties['#mapLon'] = mapBounds.getCenter().lng
-      mrProperties['#mapBBox'] = mapBounds.toBBoxString()
-      mrProperties['#mapWest'] = mapBounds.getWest()
-      mrProperties['#mapSouth'] = mapBounds.getSouth()
-      mrProperties['#mapEast'] = mapBounds.getEast()
-      mrProperties['#mapNorth'] = mapBounds.getNorth()
-    }
+      const task = workspaceContext['taskMapTask']
+      if (task) {
+        const primaryFeature =
+          AsIdentifiableFeature(AsMappableTask(task).normalizedGeometries().features[0])
 
-    setProperties(mrProperties)
-  }, [workspaceContext])
+        mrProperties['#mrTaskId'] = task.id
+        mrProperties['#osmId'] = primaryFeature.osmId()
+        mrProperties['#osmType'] = primaryFeature.osmType()
+
+        //map the task specific properties to the workspace properties
+        const { properties } = primaryFeature;
+        if (properties) {
+          Object.keys(properties).map((key) => {
+            mrProperties[key] = properties[key];
+            return null;
+          });
+        }
+      }
+
+      const mapBounds = workspaceContext['taskMapBounds']
+      if (mapBounds) {
+        mrProperties['#mapLat'] = mapBounds.getCenter().lat
+        mrProperties['#mapLon'] = mapBounds.getCenter().lng
+        mrProperties['#mapBBox'] = mapBounds.toBBoxString()
+        mrProperties['#mapWest'] = mapBounds.getWest()
+        mrProperties['#mapSouth'] = mapBounds.getSouth()
+        mrProperties['#mapEast'] = mapBounds.getEast()
+        mrProperties['#mapNorth'] = mapBounds.getNorth()
+      }
+
+      setProperties(mrProperties)
+    }, [workspaceContext])
+  }
 
   return properties
 }


### PR DESCRIPTION
Issue: There was an undefined prop called workspaceContext in the useMRProperties function. This undefined prop being called would freeze the user interface. In these cases where this prop is not provided, an empty object will be passed to prevent the interface from crashing.