### PR TITLE
Fix hotkeys preventing typing in Rapid search box

### DIFF
--- a/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
+++ b/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
@@ -17,14 +17,17 @@ const mapStateToProps = state => {
   }
 }
 const textInputActive = function(event) {
-  if (event.target.type === 'text')
+  if (event.target.type === 'text' || event.target.type === 'search') {
     return true
+  }
 
   return (event.target.nodeName != null &&
           event.target.getAttribute('type') != null &&
           event.target.nodeName.toLowerCase() === 'input' &&
-          event.target.getAttribute('type').toLowerCase() === 'text') ||
-          event.target.nodeName.toLowerCase() === 'textarea'
+          (event.target.getAttribute('type').toLowerCase() === 'text' ||
+          event.target.getAttribute('type').toLowerCase() === 'search')) ||
+          event.target.nodeName.toLowerCase() === 'textarea' 
+          
 }
 
 const mapDispatchToProps = dispatch => {


### PR DESCRIPTION
addresses #2084, where keyboard shortcut settings were disallowing typing into search inputs in embedded Rapid editor.