### PR TITLE
Fix workspace layout name keypress crash bug

### DIFF
--- a/src/components/QuickTextBox/QuickTextBox.js
+++ b/src/components/QuickTextBox/QuickTextBox.js
@@ -28,10 +28,10 @@ export default class QuickTextBox extends Component {
     if (e.metaKey || e.altKey || e.ctrlKey) {
       return
     }
-    else if (e.key === "Escape") {
+    else if (e.key === "Escape" && !this.props.suppressControls) {
       this.props.cancel()
     }
-    else if (e.key === "Enter") {
+    else if (e.key === "Enter" && !this.props.suppressControls) {
       this.props.done()
     }
   }
@@ -90,7 +90,7 @@ QuickTextBox.propTypes = {
   placeHolder: PropTypes.string,
   /** Set to true for smaller size */
   small: PropTypes.bool,
-  /** Set to true to suppress done/cancel controls */
+  /** Set to true to suppress done/cancel button and keyboard controls */
   suppressControls: PropTypes.bool,
 }
 


### PR DESCRIPTION
Addresses #2122, where when editing a workspace layout, pressing enter or escape when the workspace layout name text input is focused causes an error.