### PR TITLE
Update the GH actions to improve build times

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,7 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -22,11 +22,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+        cache-dependency-path: 'yarn.lock'
 
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
We don't need actions to run on every `push` _and_ `pull_request`, so limit it to only `push` (this will still cause a build for an open PR which is updated).

Set up a yarn cache to improve CI build times.