### PR TITLE
Fix hot module reload undefined window.process error in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,5 +150,9 @@
       "react-app",
       "react-app/jest"
     ]
+  },
+  "resolutions": {
+    "//": "See https://github.com/facebook/create-react-app/issues/11773",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     ]
   },
   "resolutions": {
-    "//": "See https://github.com/facebook/create-react-app/issues/11773",
     "react-error-overlay": "6.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13218,10 +13218,10 @@ react-elastic-carousel@^0.9.0:
     react-swipeable "^5.5.1"
     resize-observer-polyfill "1.5.0"
 
-react-error-overlay@^6.0.9:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.0"


### PR DESCRIPTION
See [this issue](https://github.com/facebook/create-react-app/issues/11773). Pins react-error-overlay dependency to v6.0.9, which should prevent needing to refresh the browser tab to clear the overlay error after every file save in development.
