### PR TITLE
Update Rapid editor url

### DIFF
--- a/.env
+++ b/.env
@@ -77,7 +77,7 @@ REACT_APP_GEOGRAPHIC_INDEXING_DELAY=2
 REACT_APP_ID_EDITOR_SERVER_URL='https://www.openstreetmap.org/edit'
 
 # RapiD editor base URL
-REACT_APP_RAPID_EDITOR_SERVER_URL='https://mapwith.ai/rapid'
+REACT_APP_RAPID_EDITOR_SERVER_URL='https://rapideditor.org/edit'
 
 # Level0 editor base URL
 REACT_APP_LEVEL0_EDITOR_SERVER_URL='https://level0.osmz.ru/index.php'


### PR DESCRIPTION
Closes https://github.com/facebook/Rapid/issues/1203

Rapid has changed domains from mapwith.ai to rapideditor.org