### PR TITLE
support short url and short path in changesets

### DIFF
--- a/src/utils/constructChangesetUrl.js
+++ b/src/utils/constructChangesetUrl.js
@@ -1,11 +1,15 @@
 export const constructChangesetUrl = (task) => {
   if (
     process.env.REACT_APP_CHANGESET_URL === "enabled" &&
+    task?.id &&
     task?.parent?.id &&
     task?.parent?.enabled &&
     task?.parent?.parent?.enabled
   ) {
-    return ` ${window.location.origin}/browse/challenges/${task.parent.id}`;
+    const rootUrl = process.env.REACT_APP_SHORT_URL || window.location.origin
+    const path = process.env.REACT_APP_SHORT_PATH === 'enabled' ? `/c/${task.parent.id}/t/${task.id}` : `/challenge/${task.parent.id}/task/${task.id}`
+
+    return ` ${rootUrl}${path}`;
   } else {
     return "";
   }

--- a/src/utils/constructChangesetUrl.test.js
+++ b/src/utils/constructChangesetUrl.test.js
@@ -5,7 +5,7 @@ describe("constructChangesetUrl", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...cachedEnv, REACT_APP_CHANGESET_URL: "enabled" };
+    process.env = { ...cachedEnv, REACT_APP_CHANGESET_URL: "enabled", REACT_APP_SHORT_URL: '', REACT_APP_SHORT_PATH: 'disabled' };
   });
 
   afterAll(() => {
@@ -18,24 +18,42 @@ describe("constructChangesetUrl", () => {
 
   it("returns empty string if env variable is disabled", () => {
     process.env.REACT_APP_CHANGESET_URL = "disabled";
-    const task = { parent: { enabled: true, id: 1 } };
+    const task = { parent: { enabled: true, id: 1 }, id: 2 };
     expect(constructChangesetUrl(task)).toBe("");
   });
 
   it("returns empty string if challenge is not enabled", () => {
-    const task = { parent: { enabled: false, id: 1 } };
+    const task = { parent: { enabled: false, id: 1 }, id: 2 };
     expect(constructChangesetUrl(task)).toBe("");
   });
 
   it("returns empty string if project is not enabled", () => {
-    const task = { parent: { parent: { enabled: false }, id: 1 } };
+    const task = { parent: { parent: { enabled: false }, id: 1 }, id: 2 };
     expect(constructChangesetUrl(task)).toBe("");
   });
 
-  it("returns correct url if challenge and project are enabled", () => {
-    const task = { parent: { enabled: true, parent: { enabled: true }, id: 1 } };
+  it("returns long url if challenge and project are enabled", () => {
+    const task = { parent: { enabled: true, parent: { enabled: true }, id: 1 }, id: 2 };
     expect(constructChangesetUrl(task)).toBe(
-      " http://localhost/browse/challenges/1"
+      " http://localhost/challenge/1/task/2"
+    );
+  });
+
+  it("returns short root url if REACT_APP_SHORT_URL is provided", () => {
+    process.env.REACT_APP_SHORT_URL = "mpr.lt";
+    process.env.REACT_APP_SHORT_PATH = "disabled";
+    const task = { parent: { enabled: true, parent: { enabled: true }, id: 1 }, id: 2 };
+    expect(constructChangesetUrl(task)).toBe(
+      " mpr.lt/challenge/1/task/2"
+    );
+  });
+
+  it("returns short root url and short path if REACT_APP_SHORT_URL is provided and REACT_APP_SHORT_PATH is enabled", () => {
+    process.env.REACT_APP_SHORT_URL = "mpr.lt";
+    process.env.REACT_APP_SHORT_PATH = "enabled";
+    const task = { parent: { enabled: true, parent: { enabled: true }, id: 1 }, id: 2 };
+    expect(constructChangesetUrl(task)).toBe(
+      " mpr.lt/c/1/t/2"
     );
   });
 });


### PR DESCRIPTION
- Adds support for using the SHORT_URL and SHORT_PATH env variables to generate shorter changeset reference URLs. 
- This also uses task specific changeset URLs, now that the external task page is available 

Part of https://github.com/maproulette/maproulette3/issues/225