### PR TITLE
edit error message on failed challenge creation to not include unique name constraint

### DIFF
--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -173,7 +173,7 @@ export default defineMessages({
   },
   challengeSaveDetailsFailure: {
     id: "Errors.challengeSaveFailure.challengeSaveDetailsFailure",
-    defaultMessage: "Unable to save your changes. It is likely a duplicate challenge name.",
+    defaultMessage: "Unable to save your changes.",
   },
   challengeSaveNameFailure: {
     id: "Errors.challengeSaveFailure.challengeSaveNameFailure",


### PR DESCRIPTION
Related to https://github.com/maproulette/maproulette3/issues/2150 fix.