### PR TITLE
add defaults for short url to env

### DIFF
--- a/.env
+++ b/.env
@@ -173,6 +173,11 @@ REACT_APP_EMAIL_ENFORCEMENT='required'
 # Supported values = ["enabled", "disabled", undefined]
 REACT_APP_CHANGESET_URL=''
 
+# Variables to allow changeset comments to point to a designated MapRoulette short URL and path
+# Supported values = ["enabled", "disabled", undefined]
+REACT_APP_SHORT_URL=''
+REACT_APP_SHORT_PATH='disabled'
+
 # Limit how many challenges per owner appear in the browse page
 # Supported values = [numbers, string numbers, undefined (no limit)]
 REACT_APP_BROWSE_CHALLENGES_OWNER_LIMIT=5


### PR DESCRIPTION
Is part of and should have been included in https://github.com/maproulette/maproulette3/pull/2156