### PR TITLE
add option to remove individual tasks from bundles

### DIFF
--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -4,8 +4,7 @@ import { bindActionCreators } from 'redux'
 import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
-import { bundleTasks, deleteTaskBundle, fetchTaskBundle }
-       from '../../../services/Task/Task'
+import { bundleTasks, deleteTaskBundle, removeTaskFromBundle, fetchTaskBundle } from '../../../services/Task/Task'
 
 /**
  * WithTaskBundle passes down methods for creating new task bundles and
@@ -42,6 +41,20 @@ export function WithTaskBundle(WrappedComponent) {
       }
     }
 
+    removeTaskFromBundle = async (bundleId, taskId) => {
+      this.setState({loading: true})
+      if(this.state.taskBundle.taskIds.length == 2) {
+        this.props.deleteTaskBundle(bundleId, this.state.taskBundle.taskIds[0])
+        this.clearActiveTaskBundle()
+        this.setState({loading: false})
+        return
+      }
+
+      this.props.removeTaskFromBundle(bundleId, taskId).then(taskBundle => {
+        this.setState({taskBundle, loading: false})
+      })
+    };
+
     clearActiveTaskBundle = () => {
       this.setState({taskBundle: null, loading: false})
     }
@@ -66,11 +79,12 @@ export function WithTaskBundle(WrappedComponent) {
     render() {
       return (
         <WrappedComponent
-          {..._omit(this.props, ['bundleTasks', 'deleteTaskBundle'])}
+          {..._omit(this.props, ['bundleTasks', 'deleteTaskBundle', 'removeTaskFromBundle'])}
           taskBundle={this.state.taskBundle}
           taskBundleLoading={this.state.loading}
           createTaskBundle={this.createTaskBundle}
           removeTaskBundle={this.removeTaskBundle}
+          removeTaskFromBundle={this.removeTaskFromBundle}
           clearActiveTaskBundle={this.clearActiveTaskBundle}
           setSelectedTasks={(selectedTasks) => this.setState({selectedTasks})}
           selectedTasks={this.state.selectedTasks}
@@ -86,6 +100,7 @@ export function WithTaskBundle(WrappedComponent) {
 export const mapDispatchToProps = dispatch => bindActionCreators({
   bundleTasks,
   deleteTaskBundle,
+  removeTaskFromBundle,
   fetchTaskBundle,
 }, dispatch)
 

--- a/src/components/TaskAnalysisTable/Messages.js
+++ b/src/components/TaskAnalysisTable/Messages.js
@@ -29,6 +29,11 @@ export default defineMessages({
     defaultMessage: "Feature Id",
   },
 
+  unbundle: {
+    id: "Task.fields.unbundle.label",
+    defaultMessage: "Remove",
+  },
+
   statusLabel: {
     id: "Task.fields.status.label",
     defaultMessage: "Status",

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -58,7 +58,7 @@ const ViewTaskSubComponent = WithLoadedTask(ViewTask)
 // columns
 const ALL_COLUMNS =
   Object.assign({featureId:{}, id:{}, status:{}, priority:{},
-    completedDuration:{}, mappedOn:{},
+    completedDuration:{}, mappedOn:{}, unbundle: {},
     reviewStatus:{group:"review"},
     reviewRequestedBy:{group:"review"},
     reviewedBy:{group:"review"}, reviewedAt:{group:"review"},
@@ -69,7 +69,7 @@ const ALL_COLUMNS =
        metaReviewedAt:{group:"review"}} : null
   )
 
-const DEFAULT_COLUMNS = ["featureId", "id", "status", "priority", "controls", "comments"]
+const DEFAULT_COLUMNS = ["featureId", "id", "status", "priority", "controls", "comments", "unbundle"]
 
 /**
  * TaskAnalysisTable renders a table of tasks using react-table.  Rendering is
@@ -229,6 +229,7 @@ export class TaskAnalysisTableInternal extends Component {
             SubComponent={props =>
               <ViewTaskSubComponent taskId={props.original.id} />
             }
+            unbundleTask={this.props.unbundleTask}
             collapseOnDataChange={false}
             minRows={1}
             manual
@@ -356,6 +357,33 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       </div>
     ),
   }
+
+  columns.unbundle = {
+    id: 'unbundle',
+    Header: '',
+    accessor: 'remove',
+    minWidth: 110,
+    Cell: ({ row }) => {
+      const isTaskSelected = props.taskId === row._original.id;
+      const isTaskEditable = props.task.status === 0 || props.task.reviewStatus === 2;
+      const isTaskRemovable = !props.taskReadOnly && isTaskEditable;
+
+      const enableRemove = props.task.completedBy ? props.task.completedBy === props.user.id : true;
+
+      return (
+        <div>
+          {isTaskRemovable && !isTaskSelected && enableRemove ? (
+            <button
+              className="mr-text-red"
+              onClick={() => props.unbundleTask(row._original.id)}
+            >
+              <FormattedMessage {...messages.unbundle} />
+            </button>
+          ) : null}
+        </div>
+      );
+    },
+  };
 
   columns.priority = {
     id: 'priority',

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -159,6 +159,10 @@ export default class TaskBundleWidget extends Component {
     this.setBoundsToNearbyTask()
   }
 
+  unbundleTask = (task) => {
+    this.props.removeTaskFromBundle(this.props.taskBundle.bundleId, task)
+  }
+
   updateBounds = (challengeId, bounds, zoom) => {
     this.props.updateTaskFilterBounds(bounds, zoom)
   }
@@ -271,6 +275,7 @@ export default class TaskBundleWidget extends Component {
           revertFilters={this.revertFilters}
           updateBounds={this.updateBounds}
           bundleTasks={this.bundleTasks}
+          unbundleTask={this.unbundleTask}
           unbundleTasks={this.unbundleTasks}
           loading={this.props.loading}
         />
@@ -289,6 +294,8 @@ const calculateTasksInChallenge = props => {
 }
 
 const ActiveBundle = props => {
+  const enableRemove = props.task.completedBy ? props.task.completedBy === props.user.id : true
+
   if (!props.taskBundle) {
     return null
   }
@@ -302,7 +309,7 @@ const ActiveBundle = props => {
             values={{taskCount: props.taskBundle.taskIds.length}}
           />
         </h3>
-        {!props.taskReadOnly && !props.disallowBundleChanges &&
+        {!props.taskReadOnly && props.task.status === 0 && enableRemove && !props.disallowBundleChanges &&
           <button
             className="mr-button mr-button--green-lighter mr-button--small"
             onClick={() => {
@@ -325,7 +332,7 @@ const ActiveBundle = props => {
         taskData={_get(props, 'taskBundle.tasks')}
         totalTaskCount={_get(props, 'taskInfo.totalCount') || _get(props, 'taskInfo.tasks.length')}
         totalTasksInChallenge={ calculateTasksInChallenge(props) }
-        showColumns={['featureId', 'id', 'status', 'priority']}
+        showColumns={['featureId', 'id', 'status', 'priority', 'unbundle']}
         taskSelectionStatuses={[TaskStatus.created, TaskStatus.skipped, TaskStatus.tooHard]}
         taskSelectionReviewStatuses={[]}
         suppressHeader

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -31,6 +31,7 @@ export default {
     locked: messages.taskLocked,
     lockRefreshFailure: messages.taskLockRefreshFailure,
     bundleFailure: messages.taskBundleFailure,
+    removeTaskFromBundleFailure: messages.removeTaskFromBundleFailure,
     bundleCooperative: messages.taskBundleCooperative,
     bundleNotCooperative: messages.taskBundleNotCooperative,
     lockReleaseFailure: messages.taskLockReleaseFailure,

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -85,6 +85,10 @@ export default defineMessages({
     id: "Errors.task.bundleFailure",
     defaultMessage: "Unable to bundle tasks together",
   },
+  removeTaskFromBundleFailure: {
+    id: "Errors.task.removeTaskFromBundleFailure",
+    defaultMessage: "Unable to remove task from bundle",
+  },
   taskBundleCooperative: {
     id: "Errors.task.bundleCooperative",
     defaultMessage: "The main task is Cooperative. All selected tasks must be Cooperative.",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -117,6 +117,7 @@ const apiRoutes = (factory) => {
       inCluster: factory.get("/tasksInCluster/:clusterId"),
       bundle: factory.post("/taskBundle"),
       deleteBundle: factory.delete("/taskBundle/:bundleId"),
+      removeTaskFromBundle: factory.post("/taskBundle/:id/unbundle"),
       fetchBundle: factory.get("/taskBundle/:bundleId"),
       bundled: {
         updateStatus: factory.put("/taskBundle/:bundleId/:status"),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -965,6 +965,29 @@ export const deleteTaskBundle = function(bundleId, primaryTaskId) {
   }
 }
 
+export const removeTaskFromBundle = function (bundleId, taskIds) {
+  return function (dispatch) {
+    return new Endpoint(api.tasks.removeTaskFromBundle, {
+      variables: { id: bundleId },
+      params: { id: bundleId, taskIds: taskIds },
+    })
+      .execute()
+      .then((results) => {
+        return results;
+      })
+      .catch((error) => {
+        if (isSecurityError(error)) {
+          dispatch(ensureUserLoggedIn()).then(() =>
+            dispatch(addError(AppErrors.user.unauthorized))
+          );
+        } else {
+          dispatch(addError(AppErrors.task.removeTaskFromBundleFailure));
+          console.log(error.response || error);
+        }
+      });
+  };
+};
+
 /**
  * Retrieve and process a single task retrieval from the given endpoint (next
  * task, previous task, random task, etc).


### PR DESCRIPTION
This feature will only be active for editors, and will prevent reviewers from breaking an editors bundles. This will make it so if a part of a bundle is wrong, it can be sent back to the editor for it to be fixed or for the unfinished task to be removed.