### PR TITLE
Super Admin Settings

### DIFF
--- a/src/components/Navbar/Messages.js
+++ b/src/components/Navbar/Messages.js
@@ -66,7 +66,7 @@ export default defineMessages({
 
   superAdmin: {
     id: 'Navbar.links.superAdminMetrics',
-    defaultMessage: "Super Admin Metrics",
+    defaultMessage: "Super Admin Settings",
   },
 
   achievements: {

--- a/src/components/Navbar/Navbar.test.js
+++ b/src/components/Navbar/Navbar.test.js
@@ -34,7 +34,7 @@ describe("Profile Menu", () => {
         }] }}
       />
     );
-    const text = getByText("Super Admin Metrics");
+    const text = getByText("Super Admin Settings");
     expect(text).toBeInTheDocument();
   });
 });

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FormattedDate } from 'react-intl'
+import SuperUserToggle from './SuperUserToggle'
 
 const OSM_USER_LINK = `${process.env.REACT_APP_OSM_SERVER}/user/`
 
@@ -279,6 +280,20 @@ const setUserTab = () => {
             <FormattedDate value={props.value} />
           </span>
         ),
+    },
+    {
+      id: 'superUser',
+      Header: 'ROLE',
+      accessor: (user) => {
+        return user.superUser
+      },
+      maxWidth: 200,
+      sortable: true,
+      Cell: (props) => {
+        return (
+          <SuperUserToggle initialValue={props.value} userId={props?.original?.id} />
+        )
+      }
     },
   ]
 }

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -47,6 +47,7 @@ const MetricsTable = (props) => {
         score: u.score,
         created: u.created,
         modified: u.modified,
+        superUser: Boolean(u.grants?.find(grant => grant.role === -1))
       }))
 
       return setUserTab()

--- a/src/components/SuperAdmin/SuperUserToggle.js
+++ b/src/components/SuperAdmin/SuperUserToggle.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import Endpoint from '../../services/Server/Endpoint'
+import { defaultRoutes as api } from "../../services/Server/Server";
+import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
+
+const SuperUserToggle = (props) => {
+  const [selection, setSelection] = useState(props.initialValue ? "super" : "basic")
+
+  const updateValue = async (e) => {
+    const value = e.target.value
+
+    try {
+      if (e.target.value === "super") {
+        await new Endpoint(api.superUser.addSuperUserGrant, { variables: { userId: props.userId } }).execute()
+      } else {
+        await new Endpoint(api.superUser.deleteSuperUserGrant, { variables: { userId: props.userId } }).execute()
+      }
+
+      setSelection(value)
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  if (props.user?.id !== props.userId) {
+    return (
+      <div>
+        <select
+          className={selection === "super" ? "mr-bg-green" : "mr-bg-blue"}
+          value={selection}
+          onChange={updateValue}
+        >
+          <option id="basic" key="basic" value="basic">Basic User</option>
+          <option id="super" key="super" value="super">Super User</option>
+        </select>
+      </div>
+    )
+  }
+
+  return <div>Super User</div>
+}
+
+export default WithCurrentUser(SuperUserToggle)

--- a/src/lang/af.json
+++ b/src/lang/af.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Review",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Teken Uit",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Teams",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "User Metrics",

--- a/src/lang/cs_CZ.json
+++ b/src/lang/cs_CZ.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Kontrola",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Odhlásit",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Týmy",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "Metriky uživatele",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Prüfung",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Abmelden",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Teams",
   "Navbar.links.userAchievements": "Auszeichnungen",
   "Navbar.links.userMetrics": "Benutzerstatistik",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1138,7 +1138,7 @@
   "Navbar.links.review": "Review",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Sign out",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Teams",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "User Metrics",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Revisión",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Cerrar sesión",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Equipos",
   "Navbar.links.userAchievements": "Logros",
   "Navbar.links.userMetrics": "Métricas de usuario",

--- a/src/lang/fa_IR.json
+++ b/src/lang/fa_IR.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Review",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Sign out",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Teams",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "User Metrics",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Vérifier",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Déconnexion",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Équipes",
   "Navbar.links.userAchievements": "Récompenses",
   "Navbar.links.userMetrics": "Statistiques utilisateur",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "レビュー",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "サインアウト",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "チーム",
   "Navbar.links.userAchievements": "実績",
   "Navbar.links.userMetrics": "統計情報",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "검토",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "로그아웃",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "팀",
   "Navbar.links.userAchievements": "업적",
   "Navbar.links.userMetrics": "사용자 메트릭",

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Recenzja",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Wyloguj się",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Zespoły",
   "Navbar.links.userAchievements": "Osiągnięcia",
   "Navbar.links.userMetrics": "Metryki użytkownika",

--- a/src/lang/ru_RU.json
+++ b/src/lang/ru_RU.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Проверка",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Выход",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Команды",
   "Navbar.links.userAchievements": "Достижения",
   "Navbar.links.userMetrics": "Метрики пользователя",

--- a/src/lang/tr.json
+++ b/src/lang/tr.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Gözden geçir",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Çıkış yap",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Takımlar",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "Kullanıcı Metrikleri",

--- a/src/lang/vi.json
+++ b/src/lang/vi.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "Review",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "Sign out",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "Teams",
   "Navbar.links.userAchievements": "Achievements",
   "Navbar.links.userMetrics": "User Metrics",

--- a/src/lang/zh_TW.json
+++ b/src/lang/zh_TW.json
@@ -1134,7 +1134,7 @@
   "Navbar.links.review": "審核",
   "Navbar.links.sent": "Sent",
   "Navbar.links.signout": "登出",
-  "Navbar.links.superAdminMetrics": "Super Admin Metrics",
+  "Navbar.links.superAdminMetrics": "Super Admin Settings",
   "Navbar.links.teams": "團隊",
   "Navbar.links.userAchievements": "成就",
   "Navbar.links.userMetrics": "User Metrics",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -198,6 +198,10 @@ const apiRoutes = (factory) => {
       setProjectRole: factory.put("/team/:teamId/project/:projectId/:role"),
       removeFromProject: factory.delete("/team/:teamId/project/:projectId"),
     },
+    superUser: {
+      addSuperUserGrant: factory.put("/superuser/:userId"),
+      deleteSuperUserGrant: factory.delete("/superuser/:userId")
+    }
   };
 };
 


### PR DESCRIPTION
Add ability for Super Users to promote and demote other users to Basic/Super Users

Testing:

Prerequisites: Make sure your environment has at least 2 users, one of which is super, the other a basic user.

1. On profile dropdown, click on Super Admin Settings
<img width="396" alt="Screenshot 2023-11-28 at 1 22 54 PM" src="https://github.com/maproulette/maproulette3/assets/79289630/6b8aa113-7e95-4e0c-8395-a89994129b09">

2. Click on Users option
<img width="452" alt="Screenshot 2023-11-28 at 1 23 06 PM" src="https://github.com/maproulette/maproulette3/assets/79289630/d6fafc3d-91d8-4941-9512-0f79030f05cc">

3. Notice your super user cannot be changed, so it has no dropdown.  The other user has a dropdown under the Roles column
<img width="754" alt="Screenshot 2023-11-28 at 1 23 24 PM" src="https://github.com/maproulette/maproulette3/assets/79289630/cc658636-1e60-469d-89d6-9e4370412170">

4. Click on the dropdown, notice the 2 role options
<img width="757" alt="Screenshot 2023-11-28 at 1 23 30 PM" src="https://github.com/maproulette/maproulette3/assets/79289630/98620156-6b2d-4c0e-a227-fae20a5cf8d3">

5. Click the super user option, the select box will highlight green and immediately toggle the user to super user status.  Subsequently toggling them back to Basic status will do the opposite
<img width="737" alt="Screenshot 2023-11-28 at 1 23 38 PM" src="https://github.com/maproulette/maproulette3/assets/79289630/8716127e-96a1-432b-a276-fc8e95870237">

