### PR TITLE
add mr tags to review widget and prevent duplicate tags

### DIFF
--- a/src/components/TaskTags/TaskTags.js
+++ b/src/components/TaskTags/TaskTags.js
@@ -105,12 +105,12 @@ export class TaskTags extends Component {
             /> {this.tagList()}
           </div>
 
-          {!this.props.taskReadOnly &&
+          {!this.props.taskReadOnly && (this.props.completedBy === this.props.user || this.props.task.reviewClaimedBy === this.props.user) ?
            <div className="mr-links-green-lighter mr-flex-grow-0">
              <a onClick={() => this.setState({edit: true})}>
                <FormattedMessage {...messages.updateTags} />
              </a>
-           </div>
+           </div> : null
           }
         </div>
       )


### PR DESCRIPTION
Add the ability for all reviewers, Meta-Reviews, and Editors to edit MR Tags. These changes also solve the duplication of MR tags issue that was happening when revisions were sent back to the reviewer.
<img width="624" alt="Screenshot 2023-11-29 at 11 31 43 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/fb354052-12bc-4c62-9d8e-5dbdd00bc4a7">
