### PR TITLE
capture user settings changes in local state

### DIFF
--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -221,7 +221,7 @@ const setProjectTab = () => {
   ]
 }
 
-const setUserTab = () => {
+const setUserTab = (userChanges, setUserChanges) => {
   return [
     {
       id: 'id',
@@ -291,7 +291,12 @@ const setUserTab = () => {
       sortable: true,
       Cell: (props) => {
         return (
-          <SuperUserToggle initialValue={props.value} userId={props?.original?.id} />
+          <SuperUserToggle
+            initialValue={props.value}
+            userId={props?.original?.id}
+            userChanges={userChanges}
+            setUserChanges={setUserChanges}
+          />
         )
       }
     },

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import WithSortedChallenges from '../HOCs/WithSortedChallenges/WithSortedChallenges'
 import WithMetricsSearchResults from './WithMetricsSearchResults'
 import WithSortedProjects from './WithSortedProjects'
@@ -9,6 +9,7 @@ import { injectIntl } from 'react-intl'
 import BusySpinner from '../BusySpinner/BusySpinner'
 
 const MetricsTable = (props) => {
+  const [userChanges, setUserChanges] = useState({})
   let data
   const constructHeader = () => {
     if (props.currentTab === 'challenges') {
@@ -50,7 +51,7 @@ const MetricsTable = (props) => {
         superUser: Boolean(u.grants?.find(grant => grant.role === -1))
       }))
 
-      return setUserTab()
+      return setUserTab(userChanges, setUserChanges)
     }
   }
 

--- a/src/components/SuperAdmin/SuperUserToggle.js
+++ b/src/components/SuperAdmin/SuperUserToggle.js
@@ -1,10 +1,15 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import Endpoint from '../../services/Server/Endpoint'
 import { defaultRoutes as api } from "../../services/Server/Server";
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
 
 const SuperUserToggle = (props) => {
   const [selection, setSelection] = useState(props.initialValue ? "super" : "basic")
+
+  useEffect(() => {
+    const localState = props.userChanges[props.userId]
+    setSelection(localState || props.initialValue ? "super" : "basic")
+  }, [props.userId])
 
   const updateValue = async (e) => {
     const value = e.target.value
@@ -16,6 +21,10 @@ const SuperUserToggle = (props) => {
         await new Endpoint(api.superUser.deleteSuperUserGrant, { variables: { userId: props.userId } }).execute()
       }
 
+      props.setUserChanges({
+        ...props.userChanges,
+        [props.userId]: value
+      })
       setSelection(value)
     } catch (e) {
       console.log(e)


### PR DESCRIPTION
Since we use frontend pagination and sorting on Admin User settings page, we need to capture any changes in local state until page is reloaded.  With this change, if a user's superuser status is changed, it will persist after a page is changed or a filter is triggered