### PR TITLE
react-leaflet-bing-v2 version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-intl": "^6.5.5",
     "react-intl-formatted-duration": "^4.0.0",
     "react-leaflet": "^2.7.0",
-    "react-leaflet-bing-v2": "^5.0.1",
+    "react-leaflet-bing-v2": "~5.1.2",
     "react-leaflet-markercluster": "^2.0.0",
     "react-onclickoutside": "^6.6.3",
     "react-popper": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,11 +2496,6 @@
     "@pixi/core" "7.2.4"
     "@pixi/math" "7.2.4"
 
-"@react-leaflet/core@^1.1.0", "@react-leaflet/core@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.1.1.tgz#827fd05bb542cf874116176d8ef48d5b12163f81"
-  integrity sha512-7PGLWa9MZ5x/cWy8EH2VzI4T8q5WpuHbixzCDXqixP/WyqwIrg5NDUPgYuFnB4IEIZF+6nA265mYzswFo/h1Pw==
-
 "@react-spring/animated@~9.3.0":
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.3.2.tgz#bda85e92e9e9b6861c259f2dacb54270a37b0f39"
@@ -7442,11 +7437,6 @@ globby@^12.0.0:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-google-maps@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/google-maps/-/google-maps-3.3.0.tgz#4432b4715406bc15268ad35b1dd1b04d974956a6"
-  integrity sha512-pj4En0cWKG+lcBvC7qrzu5ItiMsYNTgjG2capsPzAbAM/O8ftugGpUUftTTwdGL8KlNvB4CEZ6IBWwpWYzUEpw==
-
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -11580,21 +11570,10 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-leaflet-bing-v2@^5.0.1:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/react-leaflet-bing-v2/-/react-leaflet-bing-v2-5.2.3.tgz#0ffbbabd7e0bc6c67c9ad28fc78d6aabf6368394"
-  integrity sha512-gJ60D22Xn0xWVKsJTOTO1FSvJ+b0z9rCdEapNKdAhy1+ahRvIQe4k9A/vNNQhbrN79SXDPxqVcntMBNYbbgcIQ==
-  dependencies:
-    react-leaflet-google-v2 "^5.1.3"
-
-react-leaflet-google-v2@^5.1.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-leaflet-google-v2/-/react-leaflet-google-v2-5.2.0.tgz#7ca85925a6ac5462524fe9261611ad8849a82793"
-  integrity sha512-QKPuJvCYa0lEO+W0zqbDzYry8qpuuwE07vE1WzEQUIvyqPMeXQbyHJ/Hyn2F/zJO/Thaa0RE5oTNl8vw97JHKw==
-  dependencies:
-    "@react-leaflet/core" "^1.1.0"
-    google-maps "^3.3.0"
-    react-leaflet "^3.0.5"
+react-leaflet-bing-v2@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-leaflet-bing-v2/-/react-leaflet-bing-v2-5.1.2.tgz#ba426582d4c155b2d529b08ba2a21408790ef846"
+  integrity sha512-hZ7tAwVdosUdboXPayooQumCYGOb/Ue8U27btALFVzl/B6YWO6Uf0VNJ3WFIRGpUcbfsgap/oKXukbfOlP89TA==
 
 react-leaflet-markercluster@^2.0.0:
   version "2.0.0"
@@ -11614,13 +11593,6 @@ react-leaflet@^2.6.3, react-leaflet@^2.7.0:
     fast-deep-equal "^3.1.3"
     hoist-non-react-statics "^3.3.2"
     warning "^4.0.3"
-
-react-leaflet@^3.0.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-3.2.5.tgz#bec0bfab9dd8c2b030ea630f7a0687a60322ca7d"
-  integrity sha512-Z3KZ+4SijsRbbrt2I1a3ZDY6+V6Pm91eYTdxTN18G6IOkFRsJo1BuSPLFnyFrlF3WDjQFPEcTPkEgD1VEeAoBg==
-  dependencies:
-    "@react-leaflet/core" "^1.1.1"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Locked react-leaflet-bing-v2 to v5.1.x patch releases to fix react-leaflet dependency issue in v5.2.3 that was causing an error.