### PR TITLE
add catch to leaderboard

### DIFF
--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
@@ -21,8 +21,8 @@ import { fetchLeaderboard, fetchLeaderboardForUser, fetchReviewerLeaderboard,
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialOptions={}) {
-  class WithLeaderboardClass extends Component {
+const WithCurrentLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialOptions={}) {
+  class WithCurrentLeaderboardClass extends Component {
     state = {
       leaderboard: null,
       leaderboardLoading: false,
@@ -226,13 +226,14 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
                                {...this.props} />
     }
   }
-  return WithLeaderboardClass;
+  return WithCurrentLeaderboardClass;
 }
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchLeaderboard, fetchLeaderboardForUser, fetchReviewerLeaderboard }, dispatch)
 
 
-const WithCurrentLeaderboard = (WrappedComponent) =>
-  connect(null, mapDispatchToProps)(WithLeaderboard(WrappedComponent))
+const WithLeaderboard = (WrappedComponent) =>
+  connect(null, mapDispatchToProps)(WithCurrentLeaderboard(WrappedComponent))
 
-export default WithCurrentLeaderboard
+export default WithLeaderboard
+

--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
@@ -1,4 +1,7 @@
 import React, { Component } from 'react'
+import { connect } from "react-redux"
+import { bindActionCreators } from 'redux'
+import _omit from 'lodash/omit'
 import _isArray from 'lodash/isArray'
 import _isBoolean from 'lodash/isBoolean'
 import _map from 'lodash/map'
@@ -19,7 +22,7 @@ import { fetchLeaderboard, fetchLeaderboardForUser, fetchReviewerLeaderboard,
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialOptions={}) {
-  return class extends Component {
+  class WithLeaderboardClass extends Component {
     state = {
       leaderboard: null,
       leaderboardLoading: false,
@@ -89,7 +92,7 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
       this.setState({leaderboardLoading: true, showingCount, fetchId: currentFetch})
 
       const fetch = userType === USER_TYPE_REVIEWER ?
-        fetchReviewerLeaderboard : fetchLeaderboard
+        this.props.fetchReviewerLeaderboard : this.props.fetchLeaderboard
 
       fetch(...this.leaderboardParams(numberMonths, countryCode),
         showingCount, startDate, endDate).then(leaderboard => {
@@ -98,7 +101,7 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
 
             const userId = _get(this.props, 'user.id')
             if (userId && !options.ignoreUser && userType !== USER_TYPE_REVIEWER) {
-              fetchLeaderboardForUser(userId, 1,
+              this.props.fetchLeaderboardForUser(userId, 1,
                 ...this.leaderboardParams(numberMonths, countryCode),
                 startDate, endDate).then(userLeaderboard => {
                   this.mergeInUserLeaderboard(userLeaderboard)
@@ -207,7 +210,8 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
     render() {
       const moreResults = this.state.leaderboard ? this.state.showingCount <= this.state.leaderboard.length : true
 
-      return <WrappedComponent leaderboard={this.state.leaderboard}
+      return <WrappedComponent {..._omit(this.props, ['fetchLeaderboard', 'fetchLeaderboardForUser', 'fetchReviewerLeaderboard'])}
+                               leaderboard={this.state.leaderboard}
                                leaderboardLoading={this.state.leaderboardLoading}
                                monthsPast={this.monthsPast()}
                                startDate={this.startDate()}
@@ -222,6 +226,13 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
                                {...this.props} />
     }
   }
+  return WithLeaderboardClass;
 }
 
-export default WithLeaderboard
+const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchLeaderboard, fetchLeaderboardForUser, fetchReviewerLeaderboard }, dispatch)
+
+
+const WithCurrentLeaderboard = (WrappedComponent) =>
+  connect(null, mapDispatchToProps)(WithLeaderboard(WrappedComponent))
+
+export default WithCurrentLeaderboard

--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -1,6 +1,7 @@
 import format from 'date-fns/format'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
 import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import { fetchLeaderboardForUser } from '../../../services/Leaderboard/Leaderboard'
@@ -31,7 +32,7 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
       if ( this.props[userProp] &&
           (!_get(this.props[userProp], 'settings.leaderboardOptOut') ||
            _get(this.props[userProp], 'id') === _get(this.props.currentUser, 'userId'))) {
-        fetchLeaderboardForUser(this.props[userProp].id, 0, -1).then(userLeaderboard => {
+        this.props.fetchLeaderboardForUser(this.props[userProp].id, 0, -1).then(userLeaderboard => {
           this.setState({loading: false, leaderboardMetrics: userLeaderboard[0]})
         })
 
@@ -182,15 +183,14 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
                           setTasksReviewerMonthsPast={this.setTasksReviewerMonthsPast}
                           setTasksReviewerDateRange={this.setTasksReviewerDateRange}
                           loading={this.state.loading}
-                          {..._omit(this.props, ['updateLeaderboardMetrics'])} />)
+                          {..._omit(this.props, ['fetchLeaderboardForUser'])} />)
     }
   }
 }
 
 const mapStateToProps = () => ({})
 
-const mapDispatchToProps = () => ({
-})
+const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchLeaderboardForUser }, dispatch)
 
 export default (WrappedComponent, userProp="targetUser") =>
   connect(mapStateToProps, mapDispatchToProps)(WithUserMetrics(WrappedComponent, userProp))

--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -183,7 +183,7 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
                           setTasksReviewerMonthsPast={this.setTasksReviewerMonthsPast}
                           setTasksReviewerDateRange={this.setTasksReviewerDateRange}
                           loading={this.state.loading}
-                          {..._omit(this.props, ['fetchLeaderboardForUser'])} />)
+                          {..._omit(this.props, ['updateLeaderboardMetrics', 'fetchLeaderboardForUser'])} />)
     }
   }
 }

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -19,6 +19,8 @@ export default {
 
   leaderboard: {
     fetchFailure: messages.leaderboardFetchFailure,
+    reviewerLeaderboard: messages.reviewerLeaderboard,
+    userFetchFailure: messages.userFetchFailure,
   },
 
   task: {

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -43,6 +43,16 @@ export default defineMessages({
     defaultMessage: "Unable to fetch leaderboard.",
   },
 
+  reviewerLeaderboard: {
+    id: "Errors.leaderboard.reviewerLeaderboard",
+    defaultMessage: "Unable to retrieve reviewer leaderboard data.",
+  },
+
+  userFetchFailure: {
+    id: "Errors.leaderboard.userFetchFailure",
+    defaultMessage: "Unable to retrieve leaderboard data for user.",
+  },
+
   taskNone: {
     id: "Errors.task.none",
     defaultMessage: "No tasks remain in this challenge.",

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -51,13 +51,18 @@ export const fetchLeaderboard = async (numberMonths=null, onlyEnabled=true,
     return cachedLeaderboard;
   }
 
-  const results = await new Endpoint(api.users.leaderboard, {params}).execute()
+  try {
+    const results = await new Endpoint(api.users.leaderboard, { params }).execute()
 
-  if (results) {
-    leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
+    if (results) {
+      leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
+    }
+
+    return results
+  } catch (error) {
+    console.error('Error fetching leaderboard:', error)
+    return []
   }
-
-  return results
 }
 
 /**

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -39,35 +39,36 @@ export const fetchLeaderboard = (numberMonths=null, onlyEnabled=true,
                                        forProjects=null, forChallenges=null,
                                        forUsers=null, forCountries=null,
                                        limit=10, startDate=null, endDate=null) => {
-     const params = {
-     limit,
-     onlyEnabled
-     }
-     return async function (dispatch) {
-       initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
-       forUsers, forCountries, startDate, endDate)
-   
-       const cachedLeaderboard = leaderboardCache.get({}, params, GLOBAL_LEADERBOARD_CACHE);
-   
-       if (cachedLeaderboard) {
-         return cachedLeaderboard;
-       }
-   
-       try {
-         const results = await new Endpoint(api.users.leaderboard, { params }).execute()
+  const params = {
+    limit,
+    onlyEnabled
+  }
 
-         if (results) {
-         leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
-         }
-   
-         return results
-       } catch (error) {
-         console.error('Error fetching leaderboard:', error)
-         dispatch(addError(AppErrors.leaderboard.fetchFailure))
-         return []
-       }
-     }
-   }
+  return async function (dispatch) {
+    initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
+    forUsers, forCountries, startDate, endDate)
+
+    const cachedLeaderboard = leaderboardCache.get({}, params, GLOBAL_LEADERBOARD_CACHE);
+
+    if (cachedLeaderboard) {
+      return cachedLeaderboard;
+    }
+
+    try {
+      const results = await new Endpoint(api.users.leaderboard, { params }).execute()
+
+      if (results) {
+        leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
+      }
+
+      return results
+    } catch (error) {
+      console.error('Error fetching leaderboard:', error)
+      dispatch(addError(AppErrors.leaderboard.fetchFailure))
+      return []
+    }
+  }
+}
 
 /**
  * Retrieve leaderboard data for a user from the server for the given date range and
@@ -78,11 +79,12 @@ export const fetchLeaderboardForUser = (userId, bracket=0, numberMonths=1,
                                          onlyEnabled=true, forProjects=null, forChallenges=null,
                                          forUsers, forCountries=null, startDate=null,
                                          endDate=null) => {
-  return async function (dispatch) {
   const params = {
     bracket,
     onlyEnabled
   }
+
+  return async function (dispatch) {
 
   const variables = {
     id: userId
@@ -122,12 +124,14 @@ export const fetchReviewerLeaderboard = (numberMonths=null, onlyEnabled=true,
                                                  forProjects=null, forChallenges=null,
                                                  forUsers=null, forCountries=null,
                                                  limit=10, startDate=null, endDate=null) => {
+  
+  const params = {
+    limit,
+    onlyEnabled
+  }
+
   return async function (dispatch) {
     try {
-      const params = {
-        limit,
-        onlyEnabled
-      }
 
       initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
                                   forUsers, forCountries, startDate, endDate)


### PR DESCRIPTION
Add catch and new ui error modal to leaderboard that returns an empty array to prevent freezing when fetching users for leaderboard fails.
resolves: https://github.com/maproulette/maproulette3/issues/2224
<img width="1138" alt="Screenshot 2024-01-09 at 9 44 48 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/c1660f01-1e36-4253-a1f3-ccbbd5ca868a">
<img width="1140" alt="Screenshot 2024-01-09 at 10 59 18 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/57d84d6e-4cce-4d6e-99ff-924bdaa7c9ed">
<img width="1148" alt="Screenshot 2024-01-09 at 11 08 55 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/5c393965-abf7-4e2d-9dd6-0def52c050cc">
