### PR TITLE
update header of challenge/projects widgets in review to persist while challenges are loading

### DIFF
--- a/src/pages/Review/TasksReview/TasksReviewChallenges.js
+++ b/src/pages/Review/TasksReview/TasksReviewChallenges.js
@@ -40,8 +40,24 @@ class TasksReviewChallenges extends Component {
 
   render() {
     if (!this.props.challenges) {
-      return <BusySpinner />
-    }
+      return (
+        <div className="mr-mt-8">
+          <h3 className="mr-flex mr-justify-between mr-items-center mr-ml-8">
+            <span>
+              <FormattedMessage {...messages.chooseFilter} />
+            </span>
+    
+            <div
+              className="mr-inline-block mr-mx-4 mr-text-green-lighter mr-text-sm hover:mr-text-white mr-cursor-pointer"
+              onClick={() => this.props.selectProject('')}
+            >
+              <FormattedMessage {...messages.viewAllTasks} />
+            </div>
+          </h3>
+          <BusySpinner />
+        </div>
+      )
+    }    
 
     const filteredChallenges = _filter(this.props.challenges,
       challenge => this.matchesQuery(challenge.name, 'challenge'))


### PR DESCRIPTION
This allows users to select the option to view all tasks even if the challenge list is still loading.

<img width="1135" alt="Screenshot 2024-01-10 at 11 08 59 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/698ecca1-f7eb-4b4a-93ab-3a548a707e02">
