### PR TITLE
move active filters at top of filter list fo auto suggest text box

### DIFF
--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -143,11 +143,13 @@ export default class AutosuggestTextBox extends Component {
     const preferredResults = this.getPreferredResults()
     
     const reorderedSearchResults = searchResults.sort((a, b) => {
-      if(a.id === FILTER_SEARCH_ALL || a.name === this.props.inputValue) return -1 
-      if(b.id === FILTER_SEARCH_ALL || b.name === this.props.inputValue) return 1 
+      if (a.id === FILTER_SEARCH_ALL) return -1
+      if (b.id === FILTER_SEARCH_ALL) return 1
+      if (a.name === this.props.inputValue) return -1
+      if (b.name === this.props.inputValue) return 1
       return isChecked(b) - isChecked(a)
     })
-
+    
     if (!_isEmpty(preferredResults)) {
       let className = "mr-font-medium"
       items = items.concat(_map(reorderedSearchResults,

--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -94,40 +94,47 @@ export default class AutosuggestTextBox extends Component {
    * @private
    */
   dropdownItems(getItemProps) {
-    const isChecked = (result) =>
-      (result.id === FILTER_SEARCH_ALL || this.props.multiselect?.includes(result.id)) ||
-      false
-
+    const isChecked = (result) => {
+      const isAllOption = result.id === FILTER_SEARCH_ALL
+  
+      if (this.props.multiselect) {
+        const isItemSelected = this.props.multiselect.includes(result.id)
+        return this.props.multiselect.length === 0 ? isAllOption : isItemSelected
+      }
+  
+      return isAllOption
+    }
+  
     const generateResult = (result, className = "", index) => {
       if (this.state.highlightResult === index) {
         className += this.props.highlightClassName
       }
-
+  
       return !_isEmpty(result) ? (
-          <a
-            {...getItemProps({
-              key: this.props.resultKey(result),
-              item: result,
-              className: classNames(
-                className,
+        <a
+          {...getItemProps({
+            key: this.props.resultKey(result),
+            item: result,
+            className: classNames(
+              className,
               this.props.resultClassName ? this.props.resultClassName(result) : null
-              ),
-            })}
-          >
-            <div className="mr-flex mr-items-center">
+            ),
+          })}
+        >
+          <div className="mr-flex mr-items-center">
             {this.props.multiselect && result.id !== FILTER_SEARCH_TEXT && (
               <input
-                    type="checkbox"
-                    className="mr-checkbox-toggle mr-mr-2"
-                    id={result.id}
-                    name={result.id}
-                    checked={isChecked(result)}
-                    readOnly
-                  />
+                type="checkbox"
+                className="mr-checkbox-toggle mr-mr-2"
+                id={result.id}
+                name={result.id}
+                checked={isChecked(result)}
+                readOnly
+              />
             )}
-              {this.props.resultLabel(result)}
-            </div>
-          </a>
+            {this.props.resultLabel(result)}
+          </div>
+        </a>
       ) : null
     }
 

--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -94,38 +94,29 @@ export default class AutosuggestTextBox extends Component {
    * @private
    */
   dropdownItems(getItemProps) {
-    const isChecked = (result) => {
-      if (result.id === FILTER_SEARCH_ALL && this.props.multiselect?.includes(FILTER_SEARCH_ALL)) {
-        return true
-      }
-
-      if (this.props.multiselect?.includes(result.id)) {
-        return true
-      }
-
-      return false
-    }
+    const isChecked = (result) =>
+      (result.id === FILTER_SEARCH_ALL || this.props.multiselect?.includes(result.id)) ||
+      false
 
     const generateResult = (result, className = "", index) => {
       if (this.state.highlightResult === index) {
         className += this.props.highlightClassName
       }
 
-      if (!_isEmpty(result)) {
-        return (
+      return !_isEmpty(result) ? (
           <a
             {...getItemProps({
               key: this.props.resultKey(result),
               item: result,
               className: classNames(
                 className,
-                (this.props.resultClassName ? this.props.resultClassName(result) : null)
+              this.props.resultClassName ? this.props.resultClassName(result) : null
               ),
             })}
           >
             <div className="mr-flex mr-items-center">
-              {this.props.multiselect && result.id !== FILTER_SEARCH_TEXT
-                ? <input 
+            {this.props.multiselect && result.id !== FILTER_SEARCH_TEXT && (
+              <input
                     type="checkbox"
                     className="mr-checkbox-toggle mr-mr-2"
                     id={result.id}
@@ -133,14 +124,11 @@ export default class AutosuggestTextBox extends Component {
                     checked={isChecked(result)}
                     readOnly
                   />
-                : null
-              }
+            )}
               {this.props.resultLabel(result)}
             </div>
           </a>
-        )
-      }
-      else return null
+      ) : null
     }
 
     let items = []

--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -146,13 +146,20 @@ export default class AutosuggestTextBox extends Component {
     let items = []
     const searchResults = this.getSearchResults()
     const preferredResults = this.getPreferredResults()
+    
+    const reorderedSearchResults = searchResults.sort((a, b) => {
+      if (a.id === (FILTER_SEARCH_ALL || this.props.inputValue)) return -1
+      if (b.id === (FILTER_SEARCH_ALL || this.props.inputValue)) return 1
+      return isChecked(b) - isChecked(a)
+    })
+
     if (!_isEmpty(preferredResults)) {
       let className = "mr-font-medium"
-      items = items.concat(_map(preferredResults,
+      items = items.concat(_map(reorderedSearchResults,
         (result, index) => {
           // Add a border bottom to the last entry if there are more
           // search results.
-          if (index === preferredResults.length - 1 && searchResults.length > 0) {
+          if (index === reorderedSearchResults.length - 1 && reorderedSearchResults.length > 0) {
             className += " mr-border-b-2 mr-border-white-50 mr-mb-2 mr-pb-2"
           }
 

--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -136,8 +136,8 @@ export default class AutosuggestTextBox extends Component {
     const preferredResults = this.getPreferredResults()
     
     const reorderedSearchResults = searchResults.sort((a, b) => {
-      if (a.id === (FILTER_SEARCH_ALL || this.props.inputValue)) return -1
-      if (b.id === (FILTER_SEARCH_ALL || this.props.inputValue)) return 1
+      if(a.id === FILTER_SEARCH_ALL || a.name === this.props.inputValue) return -1 
+      if(b.id === FILTER_SEARCH_ALL || b.name === this.props.inputValue) return 1 
       return isChecked(b) - isChecked(a)
     })
 


### PR DESCRIPTION
It is hard to see which filters are active in longer lists, so to make this easier, active filters in the auto suggest text boxes that are prone to having longer lists will have active filters moved to the top of the list.
<img width="465" alt="Screenshot 2024-01-16 at 11 42 31 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/327b9a16-1bea-4d89-abd1-49b5cba05d7f">
<img width="513" alt="Screenshot 2024-01-16 at 11 43 16 AM" src="https://github.com/maproulette/maproulette3/assets/88843144/c4a9e94d-6a34-4ea7-9eaa-baf3f2a9a63c">
