### PR TITLE
fix links in review table

### DIFF
--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1153,8 +1153,8 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     id: 'controls',
     Header: props.intl.formatMessage(messages.actionsColumnHeader),
     sortable: false,
-    minWidth: 110,
-    Cell: ({row}) => {
+    maxWidth: 110,
+    Cell: ({ row }) => {
       let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
       let message = row._original.reviewStatus === TaskReviewStatus.rejected ?
         <FormattedMessage {...messages.fixTaskLabel} /> :
@@ -1207,12 +1207,12 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           )
         }
       }
-  
+
       return <div className="row-controls-column">
           {action}
         </div>
     }
-  }  
+  }
 
   columns.mapperControls = {
     id: 'controls',

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1120,7 +1120,17 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     Cell: ({ row }) => {
       const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}/review`
       let action = (
-        <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+        <Link 
+          to={linkTo} 
+          onClick={(e) => {
+            e.preventDefault()
+            props.history.push({
+              pathname: linkTo,
+              criteria,
+            })
+          }} 
+          className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+        >
           <FormattedMessage {...messages.reviewTaskLabel} />
         </Link>
       )
@@ -1128,13 +1138,33 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       if (row._original.reviewedBy) {
         if (row._original.reviewStatus === TaskReviewStatus.needed) {
           action = (
-            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            <Link 
+              to={linkTo} 
+              onClick={(e) => {
+                e.preventDefault()
+                props.history.push({
+                  pathname: linkTo,
+                  criteria,
+                })
+              }} 
+              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+            >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
             </Link>
           )
         } else if (row._original.reviewStatus === TaskReviewStatus.disputed) {
           action = (
-            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            <Link 
+              to={linkTo} 
+              onClick={(e) => {
+                e.preventDefault()
+                props.history.push({
+                  pathname: linkTo,
+                  criteria,
+                })
+              }} 
+              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+            >
               <FormattedMessage {...messages.resolveTaskLabel} />
             </Link>
           )
@@ -1162,13 +1192,32 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
 
       return (
         <div className="row-controls-column mr-links-green-lighter">
-          <Link to={linkTo}>
+          <Link
+            to={linkTo} 
+            onClick={(e) => {
+              e.preventDefault()
+              props.history.push({
+                pathname: linkTo,
+                criteria,
+              })
+            }} 
+          >
             {message}
           </Link>
           {!props.metaReviewEnabled &&
             row._original.reviewStatus !== TaskReviewStatus.needed &&
             row._original.reviewedBy && row._original.reviewedBy.id !== props.user?.id &&
-            <Link to={`${linkTo}/review`} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            <Link 
+              to={`${linkTo}/review`} 
+              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+              onClick={(e) => {
+                e.preventDefault()
+                props.history.push({
+                  pathname: `${linkTo}/review`,
+                  criteria,
+                })
+              }} 
+            >
               <FormattedMessage {...messages.reviewFurtherTaskLabel} />
             </Link>
           }
@@ -1186,7 +1235,17 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     Cell: ({row}) =>{
       const linkTo =`/challenge/${row._original.parent.id}/task/${row._original.id}/meta-review`
       let action =(
-        <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+        <Link 
+          to={linkTo} 
+          onClick={(e) => {
+            e.preventDefault()
+            props.history.push({
+              pathname: linkTo,
+              criteria,
+            })
+          }} 
+          className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+        >
           <FormattedMessage {...messages.metaReviewTaskLabel} />
         </Link>
       )
@@ -1194,14 +1253,34 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       if (row._original.reviewedBy) {
         if (row._original.reviewStatus === TaskReviewStatus.needed) {
           action = (
-            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            <Link 
+              to={linkTo}  
+              onClick={(e) => {
+                e.preventDefault()
+                props.history.push({
+                  pathname: linkTo,
+                  criteria,
+                })
+              }} 
+              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+            >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
             </Link>
           )
         } 
         else if (row._original.reviewStatus === TaskReviewStatus.disputed) {
           action = (
-            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            <Link 
+              to={linkTo}  
+              onClick={(e) => {
+                e.preventDefault()
+                props.history.push({
+                  pathname: linkTo,
+                  criteria,
+                })
+              }} 
+              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+            >
               <FormattedMessage {...messages.resolveTaskLabel} />
             </Link>
           )
@@ -1220,27 +1299,53 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     sortable: false,
     minWidth: 90,
     maxWidth: 120,
-    Cell: ({row}) =>{
-      let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
-      let message = row._original.reviewStatus === TaskReviewStatus.rejected ?
-                        <FormattedMessage {...messages.fixTaskLabel} /> :
-                        <FormattedMessage {...messages.viewTaskLabel} />
-
-      return <div className="row-controls-column mr-links-green-lighter">
-        <Link to={linkTo}>
-          {message}
-        </Link>
-        {!props.metaReviewEnabled &&
-         row._original.reviewStatus !== TaskReviewStatus.needed &&
-         row._original.reviewedBy && row._original.reviewedBy.id !== props.user?.id &&
-          <div onClick={() => props.history.push(linkTo + "/review", criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
-            <FormattedMessage {...messages.reviewFurtherTaskLabel} />
-          </div>
-        }
-      </div>
+    Cell: ({ row }) => {
+      const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
+  
+      let message =
+        row._original.reviewStatus === TaskReviewStatus.rejected ? (
+          <FormattedMessage {...messages.fixTaskLabel} />
+        ) : (
+          <FormattedMessage {...messages.viewTaskLabel} />
+        )
+  
+      return (
+        <div className="row-controls-column mr-links-green-lighter">
+          <Link
+            to={linkTo}
+            onClick={(e) => {
+              e.preventDefault()
+              props.history.push({
+                pathname: linkTo,
+                criteria,
+              })
+            }}
+          >
+            {message}
+          </Link>
+          {!props.metaReviewEnabled &&
+            row._original.reviewStatus !== TaskReviewStatus.needed &&
+            row._original.reviewedBy &&
+            row._original.reviewedBy.id !== props.user?.id && (
+              <Link
+                to={`${linkTo}/review`}
+                onClick={(e) => {
+                  e.preventDefault()
+                  props.history.push({
+                    pathname: `${linkTo}/review`,
+                    criteria,
+                  })
+                }}
+                className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+              >
+                <FormattedMessage {...messages.reviewFurtherTaskLabel} />
+              </Link>
+            )}
+        </div>
+      )
     }
   }
-
+  
   columns.viewComments = {
     id: 'viewComments',
     Header: () => <FormattedMessage {...messages.viewCommentsLabel} />,

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1115,8 +1115,8 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     id: 'controls',
     Header: props.intl.formatMessage(messages.actionsColumnHeader),
     sortable: false,
-    minWidth: 90,
     maxWidth: 120,
+    minWidth: 110,
     Cell: ({ row }) => {
       const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}/review`
       let action = (
@@ -1124,7 +1124,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           <FormattedMessage {...messages.reviewTaskLabel} />
         </Link>
       )
-  
+
       if (row._original.reviewedBy) {
         if (row._original.reviewStatus === TaskReviewStatus.needed) {
           action = (
@@ -1140,7 +1140,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           )
         }
       }
-  
+
       return (
         <div className="row-controls-column">
           {action}
@@ -1153,14 +1153,13 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     id: 'controls',
     Header: props.intl.formatMessage(messages.actionsColumnHeader),
     sortable: false,
-    minWidth: 90,
-    maxWidth: 120,
+    minWidth: 110,
     Cell: ({row}) => {
       let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
       let message = row._original.reviewStatus === TaskReviewStatus.rejected ?
         <FormattedMessage {...messages.fixTaskLabel} /> :
         <FormattedMessage {...messages.viewTaskLabel} />
-  
+
       return (
         <div className="row-controls-column mr-links-green-lighter">
           <Link to={linkTo}>

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1115,33 +1115,37 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     id: 'controls',
     Header: props.intl.formatMessage(messages.actionsColumnHeader),
     sortable: false,
+    minWidth: 90,
     maxWidth: 120,
-    minWidth: 110,
-    Cell: ({row}) =>{
-      const linkTo =`/challenge/${row._original.parent.id}/task/${row._original.id}/review`
-      let action =
-        <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+    Cell: ({ row }) => {
+      const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}/review`
+      let action = (
+        <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
           <FormattedMessage {...messages.reviewTaskLabel} />
-        </div>
-
+        </Link>
+      )
+  
       if (row._original.reviewedBy) {
         if (row._original.reviewStatus === TaskReviewStatus.needed) {
-          action =
-            <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+          action = (
+            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
-            </div>
-        }
-        else if (row._original.reviewStatus === TaskReviewStatus.disputed) {
-          action =
-            <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+            </Link>
+          )
+        } else if (row._original.reviewStatus === TaskReviewStatus.disputed) {
+          action = (
+            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
               <FormattedMessage {...messages.resolveTaskLabel} />
-            </div>
+            </Link>
+          )
         }
       }
-
-      return <div className="row-controls-column">
-              {action}
-            </div>
+  
+      return (
+        <div className="row-controls-column">
+          {action}
+        </div>
+      )
     }
   }
 
@@ -1149,23 +1153,28 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     id: 'controls',
     Header: props.intl.formatMessage(messages.actionsColumnHeader),
     sortable: false,
-    maxWidth: 110,
-    Cell: ({row}) =>{
+    minWidth: 90,
+    maxWidth: 120,
+    Cell: ({row}) => {
       let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
-      let message = <FormattedMessage {...messages.viewTaskLabel} />
-
-      // The mapper needs to rereview a contested task.
-      if (row._original.reviewStatus === TaskReviewStatus.disputed ||
-          row._original.metaReviewStatus === TaskReviewStatus.rejected) {
-        linkTo += "/review"
-        message = <FormattedMessage {...messages.resolveTaskLabel} />
-      }
-
-      return <div className="row-controls-column">
-        <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
-          {message}
+      let message = row._original.reviewStatus === TaskReviewStatus.rejected ?
+        <FormattedMessage {...messages.fixTaskLabel} /> :
+        <FormattedMessage {...messages.viewTaskLabel} />
+  
+      return (
+        <div className="row-controls-column mr-links-green-lighter">
+          <Link to={linkTo}>
+            {message}
+          </Link>
+          {!props.metaReviewEnabled &&
+            row._original.reviewStatus !== TaskReviewStatus.needed &&
+            row._original.reviewedBy && row._original.reviewedBy.id !== props.user?.id &&
+            <Link to={`${linkTo}/review`} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+              <FormattedMessage {...messages.reviewFurtherTaskLabel} />
+            </Link>
+          }
         </div>
-      </div>
+      )
     }
   }
 
@@ -1177,31 +1186,34 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     minWidth: 110,
     Cell: ({row}) =>{
       const linkTo =`/challenge/${row._original.parent.id}/task/${row._original.id}/meta-review`
-      let action =
-        <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+      let action =(
+        <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
           <FormattedMessage {...messages.metaReviewTaskLabel} />
-        </div>
-
+        </Link>
+      )
+  
       if (row._original.reviewedBy) {
         if (row._original.reviewStatus === TaskReviewStatus.needed) {
-          action =
-            <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+          action = (
+            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
-            </div>
-        }
+            </Link>
+          )
+        } 
         else if (row._original.reviewStatus === TaskReviewStatus.disputed) {
-          action =
-            <div onClick={() => props.history.push(linkTo, criteria)} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
+          action = (
+            <Link to={linkTo} className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition">
               <FormattedMessage {...messages.resolveTaskLabel} />
-            </div>
+            </Link>
+          )
         }
       }
-
+  
       return <div className="row-controls-column">
-              {action}
-            </div>
+          {action}
+        </div>
     }
-  }
+  }  
 
   columns.mapperControls = {
     id: 'controls',

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -579,12 +579,13 @@ export class TaskReviewTable extends Component {
 }
 
 export const setupColumnTypes = (props, openComments, data, criteria) => {
-  const handleClick = () => {
+  const handleClick = (e, linkTo) => {
+    e.preventDefault()
     props.history.push({
+      pathname: linkTo,
       criteria,
     })
   }
-  
   const columns = {}
   columns.id = {
     id: 'id',
@@ -1128,7 +1129,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       let action = (
         <Link 
           to={linkTo} 
-          onClick={() => handleClick()}
+          onClick={(e) => handleClick(e, linkTo)}
           className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
         >
           <FormattedMessage {...messages.reviewTaskLabel} />
@@ -1140,7 +1141,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo} 
-              onClick={() => handleClick()}
+              onClick={(e) => handleClick(e, linkTo)}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
@@ -1150,7 +1151,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo} 
-              onClick={() => handleClick()}
+              onClick={(e) => handleClick(e, linkTo)}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.resolveTaskLabel} />
@@ -1182,7 +1183,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
         <div className="row-controls-column mr-links-green-lighter">
           <Link
             to={linkTo} 
-            onClick={() => handleClick()}
+            onClick={(e) => handleClick(e, linkTo)}
           >
             {message}
           </Link>
@@ -1192,7 +1193,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
             <Link 
               to={`${linkTo}/review`} 
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
-              onClick={() => handleClick()}
+              onClick={(e) => handleClick(e, `${linkTo}/review`)}
             >
               <FormattedMessage {...messages.reviewFurtherTaskLabel} />
             </Link>
@@ -1213,7 +1214,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       let action =(
         <Link 
           to={linkTo} 
-          onClick={() => handleClick()}
+          onClick={(e) => handleClick(e, linkTo)}
           className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
         >
           <FormattedMessage {...messages.metaReviewTaskLabel} />
@@ -1225,7 +1226,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo}  
-              onClick={() => handleClick()}
+              onClick={(e) => handleClick(e, linkTo)}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
@@ -1236,7 +1237,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo}  
-              onClick={() => handleClick()}
+              onClick={(e) => handleClick(e, linkTo)}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.resolveTaskLabel} />

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -579,6 +579,12 @@ export class TaskReviewTable extends Component {
 }
 
 export const setupColumnTypes = (props, openComments, data, criteria) => {
+  const handleClick = () => {
+    props.history.push({
+      criteria,
+    })
+  }
+  
   const columns = {}
   columns.id = {
     id: 'id',
@@ -1122,13 +1128,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       let action = (
         <Link 
           to={linkTo} 
-          onClick={(e) => {
-            e.preventDefault()
-            props.history.push({
-              pathname: linkTo,
-              criteria,
-            })
-          }} 
+          onClick={() => handleClick()}
           className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
         >
           <FormattedMessage {...messages.reviewTaskLabel} />
@@ -1140,13 +1140,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo} 
-              onClick={(e) => {
-                e.preventDefault()
-                props.history.push({
-                  pathname: linkTo,
-                  criteria,
-                })
-              }} 
+              onClick={() => handleClick()}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
@@ -1156,13 +1150,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo} 
-              onClick={(e) => {
-                e.preventDefault()
-                props.history.push({
-                  pathname: linkTo,
-                  criteria,
-                })
-              }} 
+              onClick={() => handleClick()}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.resolveTaskLabel} />
@@ -1194,13 +1182,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
         <div className="row-controls-column mr-links-green-lighter">
           <Link
             to={linkTo} 
-            onClick={(e) => {
-              e.preventDefault()
-              props.history.push({
-                pathname: linkTo,
-                criteria,
-              })
-            }} 
+            onClick={() => handleClick()}
           >
             {message}
           </Link>
@@ -1210,13 +1192,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
             <Link 
               to={`${linkTo}/review`} 
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
-              onClick={(e) => {
-                e.preventDefault()
-                props.history.push({
-                  pathname: `${linkTo}/review`,
-                  criteria,
-                })
-              }} 
+              onClick={() => handleClick()}
             >
               <FormattedMessage {...messages.reviewFurtherTaskLabel} />
             </Link>
@@ -1237,13 +1213,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       let action =(
         <Link 
           to={linkTo} 
-          onClick={(e) => {
-            e.preventDefault()
-            props.history.push({
-              pathname: linkTo,
-              criteria,
-            })
-          }} 
+          onClick={() => handleClick()}
           className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
         >
           <FormattedMessage {...messages.metaReviewTaskLabel} />
@@ -1255,13 +1225,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo}  
-              onClick={(e) => {
-                e.preventDefault()
-                props.history.push({
-                  pathname: linkTo,
-                  criteria,
-                })
-              }} 
+              onClick={() => handleClick()}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.reviewAgainTaskLabel} />
@@ -1272,13 +1236,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           action = (
             <Link 
               to={linkTo}  
-              onClick={(e) => {
-                e.preventDefault()
-                props.history.push({
-                  pathname: linkTo,
-                  criteria,
-                })
-              }} 
+              onClick={() => handleClick()}
               className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
             >
               <FormattedMessage {...messages.resolveTaskLabel} />


### PR DESCRIPTION
Some of the action links were being used as links with a button format, this makes right clicking act as a button element, so a user wont get the regular link options to copy a url, or look up the link in a new tab, etc. This pr fixes that issue for the review table action columns.

This is what it looked like before when you right click:
<img width="341" alt="Screenshot 2024-01-17 at 12 59 15 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/79a0de04-7b8c-4076-af44-e0a27dbbdaa9">

This is what it looks like now when you right click:
<img width="335" alt="Screenshot 2024-01-17 at 12 54 10 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/888fd624-a915-4d55-9df6-eb4add19e174">
