### PR TITLE
Fix error caused by cloning react table internal state instance

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -19,10 +19,10 @@ import _reverse from 'lodash/reverse'
 import _keys from 'lodash/keys'
 import _concat from 'lodash/concat'
 import _filter from 'lodash/filter'
-import _cloneDeep from 'lodash/cloneDeep'
 import _split from 'lodash/split'
 import _isEmpty from 'lodash/isEmpty'
 import _merge from 'lodash/merge'
+import _pick from 'lodash/pick'
 import parse from 'date-fns/parse'
 import differenceInSeconds from 'date-fns/difference_in_seconds'
 import { messagesByStatus,
@@ -104,7 +104,9 @@ export class TaskAnalysisTableInternal extends Component {
       boundingBox: this.props.boundingBox,
       includeTags: !!_get(this.props.addedColumns, 'tags')})
 
-    this.setState({lastTableState: _cloneDeep(tableState)})
+    // Use pick instead of cloneDeep, as cloning the entire tableState seems to cause an error
+    // when any column with a "makeInvertable" header is present.
+    this.setState({lastTableState: _pick(tableState, ["sorted", "filtered", "page"])})
   }
 
   configureColumns() {


### PR DESCRIPTION
Fixes strange recursion/stack overflow error that happens when filtering tasks if any table column with an "invertible" header button is present in the Task Analysis table in the challenge admin page.