### PR TITLE
add link previews

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#23395B">
     <meta name="title" content="MapRoulette" />
-    <meta name="description" content="Be an instant contributor to the world’s maps" />
+    <meta name="description" content="Be an instant contributor to the world’s maps." />
     <meta property="og:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="MapRoulette" />
-    <meta property="og:description" content="Be an instant contributor to the world’s maps" />
+    <meta property="og:description" content="Be an instant contributor to the world’s maps." />
     <meta property="twitter:title" content="MapRoulette" />
-    <meta property="twitter:description" content="twitter description" />
+    <meta property="twitter:description" content="Be an instant contributor to the world’s maps." />
     <meta property="twitter:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
     <!--
       manifest.json provides metadata used when your web app is added to the

--- a/public/index.html
+++ b/public/index.html
@@ -4,19 +4,18 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#23395B">
+
     <meta name="title" content="MapRoulette" />
-    <meta name="description" content="Navigate to Maproulette.org" />
-    <meta property="og:image" content="https://www.youtube.com/img/desktop/yt_1200.png" />
+    <meta name="description" content="Be an instant contributor to the world’s maps" />
+    <meta property="og:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+    <meta property="og:url" content="" />
     <meta property="og:title" content="MapRoulette" />
-    <meta property="og:description" content="Navigate to Maproulette.org" />
-    <meta property="twitter:site" content="@YourTwitterUsername" />
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+    <meta property="og:description" content="Be an instant contributor to the world’s maps" />
     <meta property="twitter:title" content="MapRoulette" />
     <meta property="twitter:description" content="twitter description" />
-    <meta property="twitter:image" content="https://metatags.io/images/meta-tags.png" />
+    <meta property="twitter:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
+
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/public/index.html
+++ b/public/index.html
@@ -4,18 +4,15 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#23395B">
-
     <meta name="title" content="MapRoulette" />
     <meta name="description" content="Be an instant contributor to the world’s maps" />
     <meta property="og:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="" />
     <meta property="og:title" content="MapRoulette" />
     <meta property="og:description" content="Be an instant contributor to the world’s maps" />
     <meta property="twitter:title" content="MapRoulette" />
     <meta property="twitter:description" content="twitter description" />
     <meta property="twitter:image" content="https://openstreetmap.us/img/pages/maproulette/sign.png" />
-
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
@@ -33,7 +30,6 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"
           integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ=="
           crossorigin=""/>
-
     <link
       href="https://unpkg.com/mapillary-js@4.0.0/dist/mapillary.css"
       rel="stylesheet"

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#23395B">
+    <meta name="title" content="MapRoulette" />
+    <meta name="description" content="Navigate to Maproulette.org" />
+    <meta property="og:image" content="https://www.youtube.com/img/desktop/yt_1200.png" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+    <meta property="og:title" content="MapRoulette" />
+    <meta property="og:description" content="Navigate to Maproulette.org" />
+    <meta property="twitter:site" content="@YourTwitterUsername" />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+    <meta property="twitter:title" content="MapRoulette" />
+    <meta property="twitter:description" content="twitter description" />
+    <meta property="twitter:image" content="https://metatags.io/images/meta-tags.png" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
@@ -21,6 +34,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"
           integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ=="
           crossorigin=""/>
+
     <link
       href="https://unpkg.com/mapillary-js@4.0.0/dist/mapillary.css"
       rel="stylesheet"

--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ import MobileNotSupported
 import CheckForToken from './components/CheckForToken/CheckForToken'
 import './components/Widgets/widget_registry'
 import './App.scss'
+import { HeadTitle } from './components/Head/Head'
 
 // Setup child components with necessary HOCs
 const TopNav = withRouter(WithCurrentUser(Navbar))
@@ -165,6 +166,7 @@ export const CachedRoute = ({ component: Component, ...rest }) => {
         resetCache()
         return (
           <>
+            <HeadTitle />
             <Component {...props} />
           </>
           

--- a/src/App.js
+++ b/src/App.js
@@ -166,7 +166,7 @@ export const CachedRoute = ({ component: Component, ...rest }) => {
         resetCache()
         return (
           <>
-            <HeadTitle {...props} />
+            <HeadTitle />
             <Component {...props} />
           </>
           

--- a/src/App.js
+++ b/src/App.js
@@ -166,10 +166,10 @@ export const CachedRoute = ({ component: Component, ...rest }) => {
         resetCache()
         return (
           <>
-            <HeadTitle />
+            <HeadTitle {...props} />
             <Component {...props} />
           </>
-
+          
         )
       }} />
   )

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import LoadRandomChallengeTask
        from './components/LoadRandomChallengeTask/LoadRandomChallengeTask'
 import LoadRandomVirtualChallengeTask
        from './components/LoadRandomVirtualChallengeTask/LoadRandomVirtualChallengeTask'
+import HeadTitle from './components/Head/Head'
 import Navbar from './components/Navbar/Navbar'
 import SystemNotices from './components/SystemNotices/SystemNotices'
 import FundraisingNotices from './components/FundraisingNotices/FundraisingNotices'
@@ -48,7 +49,6 @@ import MobileNotSupported
 import CheckForToken from './components/CheckForToken/CheckForToken'
 import './components/Widgets/widget_registry'
 import './App.scss'
-import { HeadTitle } from './components/Head/Head'
 
 // Setup child components with necessary HOCs
 const TopNav = withRouter(WithCurrentUser(Navbar))
@@ -169,7 +169,6 @@ export const CachedRoute = ({ component: Component, ...rest }) => {
             <HeadTitle />
             <Component {...props} />
           </>
-          
         )
       }} />
   )

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,6 @@ import LoadRandomChallengeTask
        from './components/LoadRandomChallengeTask/LoadRandomChallengeTask'
 import LoadRandomVirtualChallengeTask
        from './components/LoadRandomVirtualChallengeTask/LoadRandomVirtualChallengeTask'
-import HeadTitle from './components/Head/Head'
 import Navbar from './components/Navbar/Navbar'
 import SystemNotices from './components/SystemNotices/SystemNotices'
 import FundraisingNotices from './components/FundraisingNotices/FundraisingNotices'
@@ -166,7 +165,6 @@ export const CachedRoute = ({ component: Component, ...rest }) => {
         resetCache()
         return (
           <>
-            <HeadTitle />
             <Component {...props} />
           </>
           

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -18,7 +18,6 @@ import ProjectDashboard from "./Manage/ProjectDashboard/ProjectDashboard";
 import ChallengeDashboard from "./Manage/ChallengeDashboard/ChallengeDashboard";
 import BusySpinner from "../BusySpinner/BusySpinner";
 import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequirementNotice";
-import HeadTitle from "../Head/Head";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
 
@@ -131,7 +130,6 @@ export const CustomRoute = ({ component: Component, ...rest }) => {
       render={props => {
         return (
           <>
-            <HeadTitle />
             <Component {...props} />
           </>
           

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -18,9 +18,9 @@ import ProjectDashboard from "./Manage/ProjectDashboard/ProjectDashboard";
 import ChallengeDashboard from "./Manage/ChallengeDashboard/ChallengeDashboard";
 import BusySpinner from "../BusySpinner/BusySpinner";
 import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequirementNotice";
+import HeadTitle from "../Head/Head";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
-import { HeadTitle } from "../Head/Head";
 
 /**
  * AdminPane is the top-level component for administration functions. It has a
@@ -131,10 +131,9 @@ export const CustomRoute = ({ component: Component, ...rest }) => {
       render={props => {
         return (
           <>
-            <HeadTitle /> 
+            <HeadTitle />
             <Component {...props} />
           </>
-          
         )
       }} />
   )

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -131,7 +131,7 @@ export const CustomRoute = ({ component: Component, ...rest }) => {
       render={props => {
         return (
           <>
-            <HeadTitle {...props} />
+            <HeadTitle />
             <Component {...props} />
           </>
           

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -131,10 +131,10 @@ export const CustomRoute = ({ component: Component, ...rest }) => {
       render={props => {
         return (
           <>
-            <HeadTitle />
+            <HeadTitle {...props} />
             <Component {...props} />
           </>
-
+          
         )
       }} />
   )

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -20,6 +20,7 @@ import BusySpinner from "../BusySpinner/BusySpinner";
 import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequirementNotice";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
+import { HeadTitle } from "../Head/Head";
 
 /**
  * AdminPane is the top-level component for administration functions. It has a
@@ -130,6 +131,7 @@ export const CustomRoute = ({ component: Component, ...rest }) => {
       render={props => {
         return (
           <>
+            <HeadTitle /> 
             <Component {...props} />
           </>
           

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -5,7 +5,6 @@ import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
 import WithCurrentProject from '../AdminPane/HOCs/WithCurrentProject/WithCurrentProject';
 import WithCurrentChallenge from '../AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge';
 import { injectIntl } from 'react-intl';
-import Image from '../../static/images/bg-highway.jpg'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -74,18 +74,6 @@ export const HeadTitle = (props) => {
     <Helmet>
       <title>{formatTitle(props)}</title>
       <meta name="title" content="MapRoulette" />
-      <meta name="description" content="Navigate to Maproulette.org" />
-      <meta property="og:image" content="https://www.youtube.com/img/desktop/yt_1200.png" />
-      <meta property="og:type" content="website" />
-      <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
-      <meta property="og:title" content="MapRoulette" />
-      <meta property="og:description" content="Navigate to Maproulette.org" />
-      <meta property="twitter:site" content="@YourTwitterUsername" />
-      <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
-      <meta property="twitter:title" content="MapRoulette" />
-      <meta property="twitter:description" content="twitter description" />
-      <meta property="twitter:image" content="https://metatags.io/images/meta-tags.png" />
     </Helmet>
   )
 }

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -75,13 +75,13 @@ export const HeadTitle = (props) => {
     <Helmet>
       <title>{formatTitle(props)}</title>
       <meta name="title" content="MapRoulette" />
-      <meta name="description" content="Description" />
+      <meta name="description" property="og:description" content="Navigate to Maproulette.org" />
+      <meta name="image" property="og:image" content={Image} />
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="og:title" content="MapRoulette" />
       <meta property="og:description" content="Navigate to Maproulette.org" />
       <meta property="twitter:site" content="@YourTwitterUsername" />
-      <meta property="og:image" content={Image} />
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="twitter:title" content="MapRoulette" />

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -61,26 +61,31 @@ export const formatTitle = (props) => {
         return capitalize(param)
       }
     })
-    const newTitle = _isEmpty(pathArr) ? REACT_APP_TITLE : REACT_APP_TITLE + ' - ' + pathArr.join(' - ')
+
+    pathArr.reverse();
+
+    const newTitle = _isEmpty(pathArr) ? REACT_APP_TITLE : pathArr.join(' - ') + ' - ' +  REACT_APP_TITLE
     return newTitle
   }
 }
 
 export const HeadTitle = (props) => {
+
   return (
     <Helmet>
       <title>{formatTitle(props)}</title>
-      <meta property="og:title" content={formatTitle(props)} />
-      <meta name="description" content={props.challenge ? props.challenge?.description: "Navigate to Maproulette.org"} />
-      <meta property="og:description" content={"description"} />
-      <meta property="og:image" content={Image} />
-      <meta
-        property="og:url"
-        content={window.location.pathname + window.location.search}
-      />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:image:alt" content={"maproulette image"} />
-      <meta name="twitter:site" content={""} />
+      <meta name="title" content="MapRoulette" />
+      <meta name="description" content="Description" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+      <meta property="og:title" content="MapRoulette" />
+      <meta property="og:description" content="" />
+      <meta property="og:image" content="https://metatags.io/images/meta-tags.png" />
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
+      <meta property="twitter:title" content="MapRoulette" />
+      <meta property="twitter:description" content="twitter description" />
+      <meta property="twitter:image" content="https://metatags.io/images/meta-tags.png" />
     </Helmet>
   )
 }

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -79,8 +79,9 @@ export const HeadTitle = (props) => {
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="og:title" content="MapRoulette" />
-      <meta property="og:description" content="asdfasdfasdd" />
-      <meta property="og:image" content="https://metatags.io/images/meta-tags.png" />
+      <meta property="og:description" content="Navigate to Maproulette.org" />
+      <meta property="twitter:site" content="@YourTwitterUsername" />
+      <meta property="og:image" content={Image} />
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="twitter:title" content="MapRoulette" />

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -79,7 +79,7 @@ export const HeadTitle = (props) => {
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="og:title" content="MapRoulette" />
-      <meta property="og:description" content="" />
+      <meta property="og:description" content="asdfasdfasdd" />
       <meta property="og:image" content="https://metatags.io/images/meta-tags.png" />
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -5,6 +5,7 @@ import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
 import WithCurrentProject from '../AdminPane/HOCs/WithCurrentProject/WithCurrentProject';
 import WithCurrentChallenge from '../AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge';
 import { injectIntl } from 'react-intl';
+import Image from '../../static/images/bg-highway.jpg'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 
@@ -69,6 +70,17 @@ export const HeadTitle = (props) => {
   return (
     <Helmet>
       <title>{formatTitle(props)}</title>
+      <meta property="og:title" content={formatTitle(props)} />
+      <meta name="description" content={props.challenge ? props.challenge?.description: "Navigate to Maproulette.org"} />
+      <meta property="og:description" content={"description"} />
+      <meta property="og:image" content={Image} />
+      <meta
+        property="og:url"
+        content={window.location.pathname + window.location.search}
+      />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:image:alt" content={"maproulette image"} />
+      <meta name="twitter:site" content={""} />
     </Helmet>
   )
 }

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -69,11 +69,9 @@ export const formatTitle = (props) => {
 }
 
 export const HeadTitle = (props) => {
-
   return (
     <Helmet>
       <title>{formatTitle(props)}</title>
-      <meta name="title" content="MapRoulette" />
     </Helmet>
   )
 }

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -75,8 +75,8 @@ export const HeadTitle = (props) => {
     <Helmet>
       <title>{formatTitle(props)}</title>
       <meta name="title" content="MapRoulette" />
-      <meta name="description" property="og:description" content="Navigate to Maproulette.org" />
-      <meta name="image" property="og:image" content={Image} />
+      <meta name="description" content="Navigate to Maproulette.org" />
+      <meta property="og:image" content="https://www.youtube.com/img/desktop/yt_1200.png" />
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://staging.maproulette.org/challenge/40012/task/169368684" />
       <meta property="og:title" content="MapRoulette" />

--- a/src/components/Head/Head.test.js
+++ b/src/components/Head/Head.test.js
@@ -34,6 +34,6 @@ describe("formatTitle", () => {
         }
       } 
     });
-    expect(title).toBe(' - Foo - Bar - Project Name - 3 - User - 2 - 5' + REACT_APP_TITLE);
+    expect(title).toBe('5 - 2 - User - 3 - Project Name - Bar - Foo - ' + REACT_APP_TITLE);
   });
 });

--- a/src/components/Head/Head.test.js
+++ b/src/components/Head/Head.test.js
@@ -34,6 +34,6 @@ describe("formatTitle", () => {
         }
       } 
     });
-    expect(title).toBe(REACT_APP_TITLE + ' - Foo - Bar - Project Name - 3 - User - 2 - 5');
+    expect(title).toBe(' - Foo - Bar - Project Name - 3 - User - 2 - 5' + REACT_APP_TITLE);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import { Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
 import { Provider } from 'react-redux'

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ import './theme.scss'
 import './index.css'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
-import HeadTitle from './components/Head/Head';
 
 // Setup Apollo graphql client
 const graphqlClient = new ApolloClient({
@@ -107,7 +106,6 @@ ReactDOM.render(
       <ApolloProvider client={graphqlClient}>
         <ConnectedIntl>
           <Router history={routerHistory}>
-            <HeadTitle />
             <App />
           </Router>
         </ConnectedIntl>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+import { Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
 import { Provider } from 'react-redux'
@@ -26,6 +27,7 @@ import './theme.scss'
 import './index.css'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
+import HeadTitle from './components/Head/Head';
 
 // Setup Apollo graphql client
 const graphqlClient = new ApolloClient({
@@ -106,6 +108,7 @@ ReactDOM.render(
       <ApolloProvider client={graphqlClient}>
         <ConnectedIntl>
           <Router history={routerHistory}>
+            <HeadTitle />
             <App />
           </Router>
         </ConnectedIntl>


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2248
Resolves: https://github.com/maproulette/maproulette3/issues/1755

There are some interesting discoveries with this PR. There is a library called react-helmet, this library can be used to add meta tags to the <head> of the page dynamically. However, there is a problem when using it for creating meta tags for link previews. The issue being that the tags are added after the initial render, and websites only look at the initial render to get the meta tags for the link previews. So for now, this PR sets up static link previews until we can find a solution to create dynamic meta tags on the initial render.

<img width="334" alt="Screenshot 2024-01-23 at 1 38 50 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/34f08ee7-3e2b-49c0-b6d4-f9b4def87f68">
