### PR TITLE
add map and more bundling options to work on multiple tasks together widget

### DIFF
--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
@@ -47,12 +47,6 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
         const criteria = _cloneDeep(this.props.criteria)
         criteria.boundingBox = arrayBounds.join(',')
         this.props.updateTaskFilterBounds(bounds, zoom, fromUserAction)
-
-        // If task selection is active, prune any selections that no longer
-        // intersect with the new map bounds
-        this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
-          booleanDisjoint(AsMappableTask(task).normalizedGeometries(), bboxPolygon(arrayBounds))
-        )
       }
     }
 

--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -85,16 +85,16 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       this.setState({includeStatuses, filteredTasks})
 
       // If task selection is active, prune any selections that no longer pass filters
-      this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
-        !this.taskPassesFilters(
-          task,
-          includeStatuses,
-          this.state.includeReviewStatuses,
-          this.state.includeMetaReviewStatuses,
-          this.state.includePriorities,
-          this.state.includeLocked
-        )
-      )
+      // !this.props.bundling && this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
+      //   !this.taskPassesFilters(
+      //     task,
+      //     includeStatuses,
+      //     this.state.includeReviewStatuses,
+      //     this.state.includeMetaReviewStatuses,
+      //     this.state.includePriorities,
+      //     this.state.includeLocked
+      //   )
+      // )
     }
 
     /**
@@ -122,16 +122,16 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       this.setState({includeReviewStatuses, filteredTasks})
 
       // If task selection is active, prune any selections that no longer pass filters
-      this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
-        !this.taskPassesFilters(
-          task,
-          this.state.includeStatuses,
-          includeReviewStatuses,
-          this.state.includeMetaReviewStatuses,
-          this.state.includePriorities,
-          this.state.includeLocked
-        )
-      )
+      // !this.props.bundling && this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
+      //   !this.taskPassesFilters(
+      //     task,
+      //     this.state.includeStatuses,
+      //     includeReviewStatuses,
+      //     this.state.includeMetaReviewStatuses,
+      //     this.state.includePriorities,
+      //     this.state.includeLocked
+      //   )
+      // )
     }
 
     /**
@@ -159,16 +159,16 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       this.setState({includeMetaReviewStatuses, filteredTasks})
 
       // If task selection is active, prune any selections that no longer pass filters
-      this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
-        !this.taskPassesFilters(
-          task,
-          this.state.includeStatuses,
-          this.state.includeReviewStatuses,
-          includeMetaReviewStatuses,
-          this.state.includePriorities,
-          this.state.includeLocked
-        )
-      )
+      // !this.props.bundling && this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
+      //   !this.taskPassesFilters(
+      //     task,
+      //     this.state.includeStatuses,
+      //     this.state.includeReviewStatuses,
+      //     includeMetaReviewStatuses,
+      //     this.state.includePriorities,
+      //     this.state.includeLocked
+      //   )
+      // )
     }
 
     /**
@@ -271,16 +271,16 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       this.setState({filteredTasks})
 
       // If task selection is active, prune any selections that no longer pass filters
-      this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
-        !this.taskPassesFilters(
-          task,
-          this.state.includeStatuses,
-          this.state.includeReviewStatuses,
-          this.state.includeMetaReviewStatuses,
-          this.state.includePriorities,
-          this.state.includeLocked
-        )
-      )
+      // !this.props.bundling && this.props.pruneSelectedTasks && this.props.pruneSelectedTasks(task =>
+      //   !this.taskPassesFilters(
+      //     task,
+      //     this.state.includeStatuses,
+      //     this.state.includeReviewStatuses,
+      //     this.state.includeMetaReviewStatuses,
+      //     this.state.includePriorities,
+      //     this.state.includeLocked
+      //   )
+      // )
     }
 
     // This will check for saved filters if the 'useSavedFilters' prop is true and a valid user

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -21,14 +21,16 @@ export function WithTaskBundle(WrappedComponent) {
 
     setupBundle = bundleId => {
       this.setState({loading: true})
+      if(bundleId) {
       this.props.fetchTaskBundle(bundleId).then(taskBundle => {
         this.setState({taskBundle, loading: false})
       })
     }
+    }
 
     createTaskBundle = (taskIds, bundleTypeMismatch, name) => {
       this.setState({loading: true})
-      this.props.bundleTasks(taskIds, bundleTypeMismatch, name).then(taskBundle => {
+      this.props.bundleTasks(this.props.taskId, taskIds, bundleTypeMismatch, name).then(taskBundle => {
         this.setState({taskBundle, loading: false})
       })
     }
@@ -45,6 +47,7 @@ export function WithTaskBundle(WrappedComponent) {
     removeTaskFromBundle = (bundleId, taskId) => {
       this.setState({loading: true})
       if(this.state.taskBundle.taskIds.length === 2) {
+        //need to make sure this deletes all columns related to the bundle related to restrictions on bundling
         this.removeTaskBundle(bundleId, this.state.taskBundle.taskIds[0])
         this.setState({loading: false})
         return
@@ -81,6 +84,8 @@ export function WithTaskBundle(WrappedComponent) {
         else {
           this.clearActiveTaskBundle()
         }
+      } else if (_isFinite(_get(this.props, 'task.bundleId')) !== _isFinite(_get(prevProps, 'task.bundleId'))){
+        this.setupBundle(this.props.task.bundleId)
       }
     }
 
@@ -94,6 +99,7 @@ export function WithTaskBundle(WrappedComponent) {
           removeTaskBundle={this.removeTaskBundle}
           removeTaskFromBundle={this.removeTaskFromBundle}
           addTaskToBundle={this.addTaskToBundle}
+          setupBundle={this.setupBundle}
           clearActiveTaskBundle={this.clearActiveTaskBundle}
           setSelectedTasks={(selectedTasks) => this.setState({selectedTasks})}
           selectedTasks={this.state.selectedTasks}

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux'
 import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
-import { bundleTasks, deleteTaskBundle, removeTaskFromBundle, fetchTaskBundle } from '../../../services/Task/Task'
+import { bundleTasks, deleteTaskBundle, removeTaskFromBundle, addTaskToBundle, fetchTaskBundle } from '../../../services/Task/Task'
 
 /**
  * WithTaskBundle passes down methods for creating new task bundles and
@@ -27,8 +27,9 @@ export function WithTaskBundle(WrappedComponent) {
     }
 
     createTaskBundle = (taskIds, bundleTypeMismatch, name) => {
+      this.setState({loading: true})
       this.props.bundleTasks(taskIds, bundleTypeMismatch, name).then(taskBundle => {
-        this.setState({taskBundle})
+        this.setState({taskBundle, loading: false})
       })
     }
 
@@ -41,11 +42,10 @@ export function WithTaskBundle(WrappedComponent) {
       }
     }
 
-    removeTaskFromBundle = async (bundleId, taskId) => {
+    removeTaskFromBundle = (bundleId, taskId) => {
       this.setState({loading: true})
       if(this.state.taskBundle.taskIds.length === 2) {
-        this.props.deleteTaskBundle(bundleId, this.state.taskBundle.taskIds[0])
-        this.clearActiveTaskBundle()
+        this.removeTaskBundle(bundleId, this.state.taskBundle.taskIds[0])
         this.setState({loading: false})
         return
       }
@@ -54,6 +54,14 @@ export function WithTaskBundle(WrappedComponent) {
         this.setState({taskBundle, loading: false})
       })
     };
+
+    addTaskToBundle = (bundleId, taskId) => {
+      this.setState({loading: true})
+      this.props.addTaskToBundle(bundleId, taskId).then(taskBundle => {
+        this.setState({taskBundle, loading: false})
+      })
+    };
+
 
     clearActiveTaskBundle = () => {
       this.setState({taskBundle: null, loading: false})
@@ -85,6 +93,7 @@ export function WithTaskBundle(WrappedComponent) {
           createTaskBundle={this.createTaskBundle}
           removeTaskBundle={this.removeTaskBundle}
           removeTaskFromBundle={this.removeTaskFromBundle}
+          addTaskToBundle={this.addTaskToBundle}
           clearActiveTaskBundle={this.clearActiveTaskBundle}
           setSelectedTasks={(selectedTasks) => this.setState({selectedTasks})}
           selectedTasks={this.state.selectedTasks}
@@ -101,6 +110,7 @@ export const mapDispatchToProps = dispatch => bindActionCreators({
   bundleTasks,
   deleteTaskBundle,
   removeTaskFromBundle,
+  addTaskToBundle,
   fetchTaskBundle,
 }, dispatch)
 

--- a/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.js
+++ b/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.js
@@ -33,11 +33,20 @@ export const WithTaskClusterMarkers = function(WrappedComponent) {
      */
     updateMapMarkers() {
       const markers = _map(this.props.taskClusters, cluster => {
+        const bundleConflict = Boolean(
+          this.props.task &&
+          !(cluster.taskStatus === 0 || cluster.status === 0) &&
+          !this.props.taskBundle?.taskIds?.includes(cluster.id || cluster.taskId) &&
+          (cluster.id || cluster.taskId) ||
+          (cluster?.bundleId && cluster.bundleId !== this.props.task?.bundleId)  
+        );
+   
         return AsMappableCluster(cluster).mapMarker(
           this.props.monochromaticClusters,
           this.props.selectedTasks,
           this.props.highlightPrimaryTask,
-          this.props.selectedClusters
+          this.props.selectedClusters,
+          bundleConflict
         )
       })
 

--- a/src/components/TaskAnalysisTable/Messages.js
+++ b/src/components/TaskAnalysisTable/Messages.js
@@ -31,7 +31,12 @@ export default defineMessages({
 
   unbundle: {
     id: "Task.fields.unbundle.label",
-    defaultMessage: "Remove",
+    defaultMessage: "Unbundle",
+  },
+
+  bundle: {
+    id: "Task.fields.bundle.label",
+    defaultMessage: "Bundle",
   },
 
   statusLabel: {

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -289,7 +289,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       const isTagFix = AsCooperativeWork(props.task).isTagType()
       const enableEditForMapper = props.task?.status === 0 || (props.task?.reviewStatus === ( 2 || 4 || 5 ))
       const disableSelecting = props.taskReadOnly || isTagFix || !isMapper || !enableEditForMapper
- console.log(original.bundleId)
+
       return (
       props.highlightPrimaryTask && original.id === props.task.id && !original.bundleId ?
       <span className="mr-text-green-lighter">✓</span> : !disableSelecting && !original.bundleId ?
@@ -331,13 +331,27 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
           </span>
         )
       }
-      else if (_isFinite(t.bundleId)) {
+      else if (_isFinite(t.bundleId) && t.bundleId && t.bundleId == props.taskBundle?.bundleId) {
         return (
           <span className="mr-flex mr-items-center">
             <SvgSymbol
               sym="puzzle-icon"
               viewBox="0 0 20 20"
               className="mr-fill-current mr-w-4 mr-h-4 mr-absolute mr-left-0 mr--ml-2"
+              title={props.intl.formatMessage(messages.bundleMemberTooltip)}
+            />
+            {t.id}
+          </span>
+        )
+      } else if (_isFinite(t.bundleId)) {
+        return (
+          <span className="mr-flex mr-items-center" title={
+            'This task has been bundled by someone else, check back later to see if this task is open to edits'
+          }>
+            <SvgSymbol
+              sym="box-icon"
+              viewBox="0 0 20 20"
+              className="mr-fill-green mr-w-4 mr-h-4 mr-absolute mr-left-0 mr--ml-2"
               title={props.intl.formatMessage(messages.bundleMemberTooltip)}
             />
             {t.id}
@@ -376,22 +390,20 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     accessor: 'remove',
     minWidth: 110,
     Cell: ({ row }) => {
-      const isTaskSelected = props.taskId === row._original.id
-      const enableEditForMapper = props.task?.status === 0 || (props.task?.reviewStatus === ( 2 || 4 || 5 ))
-      const isTaskRemovable = !props.taskReadOnly && enableEditForMapper
-      
-      const alreadyBundled = row._original.bundleId !== props.task.bundleId
-      const enableRemove = props.task?.completedBy ? props.task.completedBy === props.user.id : true
+      const alreadyBundled = row._original?.bundleId && row._original?.bundleId !== props.taskBundle?.bundleId
+      const enableRemove = props.task?.completedBy ? props.task?.completedBy === props.user?.id : true 
+      const isTaskRemovable = !props.taskReadOnly && props.task
+      const isTaskSelected = row._original.isBundlePrimary
 
       return (
         <div>
-          {isTaskRemovable && !isTaskSelected && enableRemove && props.taskBundle.taskIds.includes(row._original.id) && (
+          {isTaskRemovable && !isTaskSelected && enableRemove && props.taskBundle?.taskIds.includes(row._original.id) && (
             <button className="mr-text-red-light" onClick={() => props.unbundleTask(row._original)}>
               <FormattedMessage {...messages.unbundle} />
             </button>
           )}
         
-          {isTaskRemovable && !isTaskSelected && enableRemove && !props.taskBundle.taskIds.includes(row._original.id) && !alreadyBundled && (
+          {isTaskRemovable && !isTaskSelected && enableRemove && !props.taskBundle?.taskIds.includes(row._original.id) && !alreadyBundled && (
             <button className="mr-text-green-lighter" onClick={() => props.bundleTask(row._original)}>
               <FormattedMessage {...messages.bundle} />
             </button>

--- a/src/components/Widgets/ReviewNearbyTasksWidget/ReviewNearbyTasksWidget.js
+++ b/src/components/Widgets/ReviewNearbyTasksWidget/ReviewNearbyTasksWidget.js
@@ -282,7 +282,6 @@ registerWidgetType(
             )
           ),
           'nearbyTasks',
-          // 'taskClusters',
           'filteredClusteredTasks',
           {
             includeLocked: false,

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -60,13 +60,13 @@ export default defineMessages({
   },
 
   bundleTasksLabel: {
-    id: "Widgets.TaskBundleWidget.controls.bundleTasks.label",
-    defaultMessage: "Complete Together",
+    id: "Widgets.TaskBundleWidget.controls.startBundling.label",
+    defaultMessage: "Start Bundling Tasks",
   },
 
   unbundleTasksLabel: {
-    id: "Widgets.TaskBundleWidget.controls.unbundleTasks.label",
-    defaultMessage: "Unbundle",
+    id: "Widgets.TaskBundleWidget.controls.stopBundling.label",
+    defaultMessage: "Stop Bundling Tasks",
   },
 
   currentTask: {

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
@@ -16,6 +16,11 @@ class TaskMarkerContent extends Component {
   render() {
     const bundle = this.props.taskBundleData?.map((bundleObject) => bundleObject.id) || []
     const selected = this.props.isTaskSelected(this.props.marker.options.taskId)
+
+    //include other mappers in the future
+    const enableEdit = this.props.task.completedBy ? this.props.task.completedBy === this.props.user.id : true
+    const disableBundling = this.props.marker.options.taskStatus !== 0
+
     const isChecked = (
       !this.props.bundling && 
       this.props.marker.options.taskId !== this.props.task.id && 
@@ -75,6 +80,7 @@ class TaskMarkerContent extends Component {
                 </span>
               )}
 
+              { enableEdit && this.props.bundling ?
                 <div>
                   {this.props.task.id === this.props.marker.options.id ? 
                     <div>Cannot edit primary task</div> : 
@@ -86,15 +92,16 @@ class TaskMarkerContent extends Component {
                     >
                       Remove from Bundle
                     </button>
-                  ) : this.props.bundling && !this.props.marker.options.bundleId ? (
+                  ) : this.props.bundling && !this.props.marker.options.bundleId && !disableBundling ? (
                     <button
                       onClick={() => this.props.bundleTask(this.props.marker.options)}
                       className="mr-text-green mr-border-solid mr-border mr-border-green mr-px-2 mr-mb-1"
                     >
                       Add to Bundle
                     </button>
-                  ) : this.props.bundling ? <div>This task is currently bundled by someone else</div> : null}
-                </div>
+                  ) : this.props.marker.options.bundleId ? <div>You do not have permission to edit this bundle this task.</div> : null}
+                </div> : !enableEdit ? <div>You do not have permission to edit this bundle this task.</div> : null
+              }
             </label>
           </div>
         </div>

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
@@ -14,59 +14,88 @@ class TaskMarkerContent extends Component {
   }
 
   render() {
+    const bundle = this.props.taskBundleData?.map((bundleObject) => bundleObject.id) || []
     const selected = this.props.isTaskSelected(this.props.marker.options.taskId)
+    const isChecked = (
+      !this.props.bundling && 
+      this.props.marker.options.taskId !== this.props.task.id && 
+      !this.props.marker.options.bundleId
+    )
     const statusMessage = messagesByStatus[
-      _isFinite(this.props.marker.options.taskStatus) ?
-      this.props.marker.options.taskStatus :
+      _isFinite(this.props.marker.options.taskStatus) ? 
+      this.props.marker.options.taskStatus : 
       this.props.marker.options.status
     ]
     const priorityMessage = messagesByPriority[
-      _isFinite(this.props.marker.options.taskPriority) ?
-      this.props.marker.options.taskPriority :
+      _isFinite(this.props.marker.options.taskPriority) ? 
+      this.props.marker.options.taskPriority : 
       this.props.marker.options.priority
     ]
 
     return (
       <div className="mr-flex mr-justify-center">
         <div className="mr-flex-col mr-w-full">
-          <div className="mr-flex">
-            <div className="mr-w-1/2 mr-mr-2 mr-text-right"><FormattedMessage {...messages.nameLabel} /></div>
-            <div className="mr-w-1/2 mr-text-left">{this.props.marker.options.name}</div>
-          </div>
-          <div className="mr-flex">
-            <div className="mr-w-1/2 mr-mr-2 mr-text-right"><FormattedMessage {...messages.taskIdLabel} /></div>
-            <div className="mr-w-1/2 mr-text-left">{this.props.marker.options.taskId}</div>
-          </div>
-          <div className="mr-flex">
-            <div className="mr-w-1/2 mr-mr-2 mr-text-right"><FormattedMessage {...messages.statusLabel} /></div>
-            <div className="mr-w-1/2 mr-text-left">
-              {statusMessage ? this.props.intl.formatMessage(statusMessage) : null}
+          {[
+            ['nameLabel', this.props.marker.options.name],
+            ['taskIdLabel', this.props.marker.options.taskId],
+            ['statusLabel', statusMessage && this.props.intl.formatMessage(statusMessage)],
+            ['priorityLabel', priorityMessage && this.props.intl.formatMessage(priorityMessage)],
+          ].map(([labelMessageId, content]) => (
+            <div key={labelMessageId} className="mr-flex">
+              <div className="mr-w-1/2 mr-mr-2 mr-text-right">
+                <FormattedMessage {...messages[labelMessageId]} />
+              </div>
+              <div className="mr-w-1/2 mr-text-left">{content}</div>
             </div>
-          </div>
-          <div className="mr-flex">
-            <div className="mr-w-1/2 mr-mr-2 mr-text-right"><FormattedMessage {...messages.priorityLabel} /></div>
-            <div className="mr-w-1/2 mr-text-left">
-              {priorityMessage ? this.props.intl.formatMessage(priorityMessage) : null}
-            </div>
-          </div>
+          ))}
+
           <div className="mr-flex mr-justify-center mr-mt-2">
-            <span>
-              <label>
-                {this.props.marker.options.taskId !== this.props.task.id ?
-                 <input
-                   type="checkbox"
-                   className="mr-mr-1"
-                   checked={selected}
-                   onChange={this.toggleSelection}
-                 /> :
-                 <span className="mr-mr-1">✓</span>
-                }
-                <FormattedMessage {...messages.selectedLabel} />
-                {this.props.marker.options.taskId === this.props.task.id &&
-                  <span className="mr-ml-1"><FormattedMessage {...messages.currentTask} /></span>
-                }
-              </label>
-             </span>
+            <label>
+              {isChecked ? (
+                <input
+                  type="checkbox"
+                  className="mr-mr-1"
+                  checked={selected}
+                  onChange={this.toggleSelection}
+                />
+              ) : (
+                !this.props.bundling && !this.props.marker.options.bundleId && (
+                  <span className="mr-mr-1">✓</span>
+                )
+              )}
+
+              {!this.props.bundling && !this.props.marker.options.bundleId && (
+                <span>
+                  <FormattedMessage {...messages.selectedLabel} />
+                  {this.props.marker.options.taskId === this.props.task.id && (
+                    <span className="mr-ml-1">
+                      <FormattedMessage {...messages.currentTask} />
+                    </span>
+                  )}
+                </span>
+              )}
+
+                <div>
+                  {this.props.task.id === this.props.marker.options.id ? 
+                    <div>Cannot edit primary task</div> : 
+                    this.props.bundling && bundle.includes(this.props.marker.options.taskId) ? 
+                  (
+                    <button
+                      onClick={() => this.props.unbundleTask(this.props.marker.options)}
+                      className="mr-text-red mr-border-solid mr-border mr-border-red mr-px-2 mr-mb-1"
+                    >
+                      Remove from Bundle
+                    </button>
+                  ) : this.props.bundling && !this.props.marker.options.bundleId ? (
+                    <button
+                      onClick={() => this.props.bundleTask(this.props.marker.options)}
+                      className="mr-text-green mr-border-solid mr-border mr-border-green mr-px-2 mr-mb-1"
+                    >
+                      Add to Bundle
+                    </button>
+                  ) : this.props.bundling ? <div>This task is currently bundled by someone else</div> : null}
+                </div>
+            </label>
           </div>
         </div>
       </div>

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -209,7 +209,7 @@ export class AsMappableTask {
    * FeatureCollection type
    */
   normalizedGeometries() {
-    if (_isArray(this.geometries.features) && !this.geometries.type) {
+    if (_isArray(this.geometries?.features) && !this.geometries?.type) {
       return Object.assign({type: "FeatureCollection"}, this.geometries)
     }
 

--- a/src/interactions/TaskCluster/AsMappableCluster.js
+++ b/src/interactions/TaskCluster/AsMappableCluster.js
@@ -58,14 +58,14 @@ export class AsMappableCluster {
    * Generates a map marker object suitable for use with a Leaflet map, with
    * optionally customized appearance for the given map layer
    */
-  mapMarker(monochromatic, selectedTasks, highlightPrimaryTask, selectedClusters=null) {
+  mapMarker(monochromatic, selectedTasks, highlightPrimaryTask, selectedClusters=null, bundleConflict) {
     return {
       position: [this.point.lat, this.point.lng],
       options: {...(_merge(this.rawData, {taskStatus: this.rawData.status,
                                           taskPriority: this.rawData.priority,
                                           name: this.rawData.title,
                                           taskId: this.rawData.id}))},
-      icon: this.leafletMarkerIcon(monochromatic, selectedTasks, highlightPrimaryTask, selectedClusters),
+      icon: this.leafletMarkerIcon(monochromatic, selectedTasks, highlightPrimaryTask, selectedClusters, bundleConflict),
     }
   }
 
@@ -73,7 +73,7 @@ export class AsMappableCluster {
    * Generates a Leaflet Icon object appropriate for the given cluster based on
    * its size, including using a standard marker for a single point
    */
-  leafletMarkerIcon(monochromatic=false, selectedTasks, highlightPrimaryTask=false, selectedClusters=null) {
+  leafletMarkerIcon(monochromatic=false, selectedTasks, highlightPrimaryTask=false, selectedClusters=null, bundleConflict=false) {
     const count = _isFunction(this.rawData.getChildCount) ?
                   this.rawData.getChildCount() :
                   _get(this.options, 'numberOfPoints', this.numberOfPoints)
@@ -129,6 +129,14 @@ export class AsMappableCluster {
 
       let icon = _cloneDeep(statusIcons[markerData.taskStatus] || statusIcons[0])
 
+      if (bundleConflict) {
+        const red = parseInt(icon.options.style.fill.slice(1, 3), 16);
+        const green = parseInt(icon.options.style.fill.slice(3, 5), 16);
+        const blue = parseInt(icon.options.style.fill.slice(5, 7), 16);
+        
+        icon.options.style.fill = `rgba(${red}, ${green}, ${blue}, 0.4)`;
+      }
+      
       if (_isFinite(highlightPrimaryTask) && highlightPrimaryTask === markerData.taskId) {
         // Make marker for current task larger
         icon = _cloneDeep(primaryTaskStatusIcons[markerData.taskStatus])

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -34,6 +34,7 @@ export default {
     lockRefreshFailure: messages.taskLockRefreshFailure,
     bundleFailure: messages.taskBundleFailure,
     removeTaskFromBundleFailure: messages.removeTaskFromBundleFailure,
+    addTaskToBundleFailure: messages.addTaskToBundleFailure,
     bundleCooperative: messages.taskBundleCooperative,
     addCommentFailure: messages.addCommentFailure,
     bundleNotCooperative: messages.taskBundleNotCooperative,

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -99,6 +99,10 @@ export default defineMessages({
     id: "Errors.task.removeTaskFromBundleFailure",
     defaultMessage: "Unable to remove task from bundle",
   },
+  addTaskToBundleFailure: {
+    id: "Errors.task.addTaskToBundleFailure",
+    defaultMessage: "Can't Bundle",
+  },
   taskBundleCooperative: {
     id: "Errors.task.bundleCooperative",
     defaultMessage: "The main task is Cooperative. All selected tasks must be Cooperative.",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -117,6 +117,7 @@ const apiRoutes = (factory) => {
       inCluster: factory.get("/tasksInCluster/:clusterId"),
       bundle: factory.post("/taskBundle"),
       deleteBundle: factory.delete("/taskBundle/:bundleId"),
+      addTaskToBundle: factory.post("/taskBundle/:id/bundle"),
       removeTaskFromBundle: factory.post("/taskBundle/:id/unbundle"),
       fetchBundle: factory.get("/taskBundle/:bundleId"),
       bundled: {

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -914,10 +914,10 @@ export const deleteTask = function(taskId) {
   }
 }
 
-export const bundleTasks = function(taskIds, bundleTypeMismatch, bundleName="") {
+export const bundleTasks = function(primaryId, taskIds, bundleTypeMismatch, bundleName="") {
   return function(dispatch) {
     return new Endpoint(api.tasks.bundle, {
-      json: {name: bundleName, taskIds},
+      json: {name: bundleName, primaryId, taskIds},
     }).execute().then(results => {
       return results
     }).catch(error => {

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -965,6 +965,29 @@ export const deleteTaskBundle = function(bundleId, primaryTaskId) {
   }
 }
 
+export const addTaskToBundle = function (bundleId, taskIds) {
+  return function (dispatch) {
+    return new Endpoint(api.tasks.addTaskToBundle, {
+      variables: { id: bundleId },
+      params: { id: bundleId, taskIds: taskIds },
+    })
+      .execute()
+      .then((results) => {
+        return results
+      })
+      .catch((error) => {
+        if (isSecurityError(error)) {
+          dispatch(ensureUserLoggedIn()).then(() =>
+            dispatch(addError(AppErrors.user.unauthorized))
+          )
+        } else {
+          dispatch(addError(AppErrors.task.addTaskToBundleFailure))
+          console.log(error.response || error)
+        }
+      })
+  }
+}
+
 export const removeTaskFromBundle = function (bundleId, taskIds) {
   return function (dispatch) {
     return new Endpoint(api.tasks.removeTaskFromBundle, {


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2222
This change will allow the user to have the ability to add to bundles, and have a better understanding of which tasks they are removing.

You can edit tasks in bundle mode by clicking on the markers and clicking the option available. You can also click on the option(if available) in the table rows to add or remove a task from a bundle.
<img width="853" alt="Screenshot 2024-01-31 at 11 18 59 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/3075f528-3c14-431d-9b6e-cb3e9b49db0c">

There is a mode to display all tasks in the bundle in the table as displayed above. And below there is an alternate mode to display all tasks within the viewport.
<img width="846" alt="Screenshot 2024-01-31 at 11 19 55 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/a935886e-e857-4913-a248-090370d0ae2e">
