### PR TITLE
change leaderboard initial months past to 1 month

### DIFF
--- a/src/pages/Leaderboard/Leaderboard.js
+++ b/src/pages/Leaderboard/Leaderboard.js
@@ -21,7 +21,7 @@ import RowLeaderboard from './RowLeaderboard'
 import LeaderboardMap from './LeaderboardMap'
 import messages from './Messages'
 
-const INITIAL_MONTHS_PAST = -1;
+const INITIAL_MONTHS_PAST = 1;
 
 class Leaderboard extends Component {
   loggedInUserMissing = () => {


### PR DESCRIPTION
This was changed to make the leaderboard less intimidating and reduce load times on the initial render of the leaderboard.