### PR TITLE
Fix issue where inverting filter columns in task analysis tables throws an error instead of inverting

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -66,6 +66,7 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true,
 
      invertField = (fieldName) => {
        const criteria = _cloneDeep(this.state.criteria)
+       criteria.invertFields = criteria.invertFields || {}
        criteria.invertFields[fieldName] = !criteria.invertFields[fieldName]
        this.setState({criteria})
        if (this.props.setSearchFilters) {


### PR DESCRIPTION
Fixes a bug where in certain circumstances, trying to invert filters in filterable table columns causes an error, specifically in the Challenge Admin and Task Bundling/Multi-Tasking views.