### PR TITLE
add bundling restrictions and deletion of new bundles that weren't completed on redirect

### DIFF
--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -36,7 +36,7 @@ export function WithTaskBundle(WrappedComponent) {
         if (_isFinite(_get(task, 'bundleId'))) {
           this.setupBundle(task.bundleId)
         }
-        if ((this.state.taskBundle || this.state.initialBundle) && 
+        if ((prevState.taskBundle || prevState.initialBundle) && 
             prevState.taskBundle !== prevState.initialBundle  && 
             (!prevState.completingTask || prevProps.task.status === 3)) {
           if (initialBundle) {

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -4,12 +4,7 @@ import { bindActionCreators } from 'redux'
 import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
-import {
-  bundleTasks,
-  deleteTaskBundle,
-  removeTaskFromBundle,
-  fetchTaskBundle
-} from '../../../services/Task/Task'
+import { bundleTasks, deleteTaskBundle, removeTaskFromBundle, fetchTaskBundle } from '../../../services/Task/Task'
 
 /**
  * WithTaskBundle passes down methods for creating new task bundles and
@@ -151,9 +146,9 @@ export function WithTaskBundle(WrappedComponent) {
 }
 
 export const mapDispatchToProps = dispatch => bindActionCreators({
-      bundleTasks,
-      deleteTaskBundle,
-      removeTaskFromBundle,
+  bundleTasks,
+  deleteTaskBundle,
+  removeTaskFromBundle,
   fetchTaskBundle,
 }, dispatch)
 

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -286,7 +286,8 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       const isMapper = props.task?.completedBy ? props.task.completedBy === props.user.id : true
       
       const isTagFix = AsCooperativeWork(props.task).isTagType()
-      const enableEditForMapper = props.task?.status === 0 || (props.task?.reviewStatus === ( 2 || 4 || 5 ))
+      const enableEditForMapper = [0, 3].includes(props.task?.status) || [2, 4, 5].includes(props.task?.reviewStatus)
+
       const disableSelecting = props.taskReadOnly || isTagFix || !isMapper || !enableEditForMapper
 
       return (
@@ -376,7 +377,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     minWidth: 110,
     Cell: ({ row }) => {
       const isTaskSelected = props.taskId === row._original.id
-      const enableEditForMapper = props.task?.status === 0 || (props.task?.reviewStatus === ( 2 || 4 || 5 ))
+      const enableEditForMapper = [0, 3].includes(props.task?.status) || [2, 4, 5].includes(props.task?.reviewStatus)
       const isTaskRemovable = !props.taskReadOnly && enableEditForMapper
 
       const enableRemove = props.task?.completedBy ? props.task.completedBy === props.user.id : true

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -372,7 +372,8 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
 
   columns.unbundle = {
     id: 'unbundle',
-    Header: '',
+    Header: null,
+    sortable: false,
     accessor: 'remove',
     minWidth: 110,
     Cell: ({ row }) => {

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -92,7 +92,6 @@ export class TaskPane extends Component {
      * id of task once user initiates completion. This is used to help our
      * animation transitions.
      */
-    completingTask: null,
     completionResponses: null,
     showLockFailureDialog: false,
     needsResponses: false,
@@ -126,19 +125,18 @@ export class TaskPane extends Component {
    */
   completeTask = (task, challengeId, taskStatus, comment, tags, taskLoadBy, userId,
                   needsReview, requestedNextTask, osmComment, tagEdits, taskBundle) => {
-    this.setState({completingTask: task.id})
+    this.props.setCompletingTask(task.id)
     this.props.completeTask(task, challengeId, taskStatus, comment, tags, taskLoadBy, userId,
                             needsReview, requestedNextTask, osmComment, tagEdits,
                             this.state.completionResponses, taskBundle).then(() => {
       this.clearCompletingTask()
     })
-    this.props.clearActiveTaskBundle()
   }
 
   clearCompletingTask = () => {
     // Clear on next tick to give our animation transition a chance to clean up.
     setTimeout(() => {
-      this.setState({completingTask: null})
+      this.props.setCompletingTask(null)
     }, 0)
   }
 
@@ -390,14 +388,14 @@ export class TaskPane extends Component {
               </div>
             }
             completeTask={this.completeTask}
-            completingTask={this.state.completingTask}
+            completingTask={this.props.completingTask}
             setCompletionResponse={this.setCompletionResponse}
             setNeedsResponses={this.setNeedsResponses}
             completionResponses={completionResponses}
             needsResponses={this.state.needsResponses}
             templateRevision={isCompletionStatus(this.props.task.status)}
           />
-          {this.state.completingTask && this.state.completingTask === this.props.task.id &&
+          {this.props.completingTask && this.props.completingTask === this.props.task.id &&
            <div
              className="mr-fixed mr-top-0 mr-bottom-0 mr-left-0 mr-right-0 mr-z-200 mr-bg-blue-firefly-75 mr-flex mr-justify-center mr-items-center"
            >
@@ -406,7 +404,7 @@ export class TaskPane extends Component {
           }
         </MediaQuery>
         <MediaQuery query="(max-width: 1023px)">
-          <MapPane completingTask={this.state.completingTask}>
+          <MapPane completingTask={this.props.completingTask}>
             <TaskMap isMobile
                      task={this.props.task}
                      challenge={this.props.task.parent}

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -309,7 +309,7 @@ const ActiveBundle = props => {
             values={{taskCount: props.taskBundle.taskIds.length}}
           />
         </h3>
-        {!props.taskReadOnly && props.task.status === 0 && enableRemove && !props.disallowBundleChanges &&
+        {!props.taskReadOnly && props.task?.status === 0 || props.task?.status === 3 && enableRemove && !props.disallowBundleChanges ?
           <button
             className="mr-button mr-button--green-lighter mr-button--small"
             onClick={() => {
@@ -317,7 +317,7 @@ const ActiveBundle = props => {
             }}
           >
             <FormattedMessage {...messages.unbundleTasksLabel} />
-          </button>
+          </button> : null
         }
       </div>
 

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -37,6 +37,7 @@ export default {
     bundleCooperative: messages.taskBundleCooperative,
     addCommentFailure: messages.addCommentFailure,
     bundleNotCooperative: messages.taskBundleNotCooperative,
+    unableToBundleTasks: messages.unableToBundleTasks,
     lockReleaseFailure: messages.taskLockReleaseFailure,
     cooperativeFailure: messages.taskCooperativeFailure,
   },

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -115,7 +115,11 @@ export default defineMessages({
     id: "Errors.task.cooperativeFailure",
     defaultMessage: "Failed to load cooperative task{details}",
   },
-
+  unableToBundleTasks: {
+    id: "Errors.task.unableToBundleTasks",
+    defaultMessage: "The tasks with these IDs are locked by another user{details}. This most likely happened because a user completed or " +
+    "bundled a task while you've been looking at this task. Refresh the page to view only tasks that are unlocked.",
+  },
   osmRequestTooLarge: {
     id: "Errors.osm.requestTooLarge",
     defaultMessage: "OpenStreetMap data request too large",

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -943,7 +943,6 @@ export const bundleTasks = function(taskIds, bundleTypeMismatch, bundleName="") 
             dispatch(addErrorWithDetails(AppErrors.task.unableToBundleTasks, numbersOnly))
           } else {
             console.log("No task IDs found in the error message.")
-            dispatch(addError(AppErrors.task.bundleFailure))
           }
         }
         dispatch(addError(AppErrors.task.bundleFailure))

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -929,9 +929,9 @@ export const bundleTasks = function(taskIds, bundleTypeMismatch, bundleName="") 
       }
       else {
         if (bundleTypeMismatch === "cooperative") {
-          dispatch(addError(AppErrors.task.bundleCooperative));
+          dispatch(addError(AppErrors.task.bundleCooperative))
         } else if (bundleTypeMismatch === "notCooperative") {
-          dispatch(addError(AppErrors.task.bundleNotCooperative));
+          dispatch(addError(AppErrors.task.bundleNotCooperative))
         }
 
         const errorMessage = await error.response.text()

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -937,8 +937,14 @@ export const bundleTasks = function(taskIds, bundleTypeMismatch, bundleName="") 
         const errorMessage = await error.response.text()
         if (errorMessage.includes('task IDs were locked')) {
           const numberPattern = /\d+/g
-          const numbersOnly = errorMessage.match(numberPattern).map(Number)
-          dispatch(addErrorWithDetails(AppErrors.task.unableToBundleTasks, numbersOnly))
+          const matchedNumbers = errorMessage.match(numberPattern)
+          if (matchedNumbers) {
+            const numbersOnly = matchedNumbers.map(Number)
+            dispatch(addErrorWithDetails(AppErrors.task.unableToBundleTasks, numbersOnly))
+          } else {
+            console.log("No task IDs found in the error message.")
+            dispatch(addError(AppErrors.task.bundleFailure))
+          }
         }
         dispatch(addError(AppErrors.task.bundleFailure))
         console.log(error.response || error)


### PR DESCRIPTION
Reliant on https://github.com/maproulette/maproulette-backend/pull/1104

There was an issue where multiple users could add the same task into their bundle, and this would cause problems on submission. The first user to submit their bundle had no issue but any other user that had bundled the same task would would get a "Bundle Failed" due to that task being officially in a bundle because of that first users submission. To prevent this issue, in this commit we made it so tasks were locked on bundle, and bundles would fail to create if they try to bundle with that now locked task, or any other locked task.

This error message will be displayed whenever a user attempts to bundle a task thats been locked since starting their session(locked tasks are filtered out on table load) to help with troubleshooting. 

<img width="1109" alt="Screenshot 2024-02-12 at 11 56 00 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/d836058d-ebd0-4fe4-b6b4-39808421d304">
