### PR TITLE
restore resolve/view link in all review related tasks tab

### DIFF
--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1344,14 +1344,14 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     minWidth: 90,
     maxWidth: 120,
     Cell: ({ row }) => {
-      const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
-  
-      let message =
-        row._original.reviewStatus === TaskReviewStatus.rejected ? (
-          <FormattedMessage {...messages.fixTaskLabel} />
-        ) : (
-          <FormattedMessage {...messages.viewTaskLabel} />
-        )
+      let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
+      let message = <FormattedMessage {...messages.viewTaskLabel} />
+
+      if (row._original.reviewStatus === TaskReviewStatus.disputed ||
+          row._original.metaReviewStatus === TaskReviewStatus.rejected) {
+        linkTo += "/review"
+        message = <FormattedMessage {...messages.resolveTaskLabel} />
+      }
   
       return (
         <div className="row-controls-column mr-links-green-lighter">
@@ -1367,24 +1367,6 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           >
             {message}
           </Link>
-          {!props.metaReviewEnabled &&
-            row._original.reviewStatus !== TaskReviewStatus.needed &&
-            row._original.reviewedBy &&
-            row._original.reviewedBy.id !== props.user?.id && (
-              <Link
-                to={`${linkTo}/review`}
-                onClick={(e) => {
-                  e.preventDefault()
-                  props.history.push({
-                    pathname: `${linkTo}/review`,
-                    criteria,
-                  })
-                }}
-                className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
-              >
-                <FormattedMessage {...messages.reviewFurtherTaskLabel} />
-              </Link>
-            )}
         </div>
       )
     }

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -1260,9 +1260,14 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     maxWidth: 110,
     Cell: ({ row }) => {
       let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
-      let message = row._original.reviewStatus === TaskReviewStatus.rejected ?
-        <FormattedMessage {...messages.fixTaskLabel} /> :
-        <FormattedMessage {...messages.viewTaskLabel} />
+      let message = <FormattedMessage {...messages.viewTaskLabel} />
+
+      // The mapper needs to rereview a contested task.
+      if (row._original.reviewStatus === TaskReviewStatus.disputed ||
+          row._original.metaReviewStatus === TaskReviewStatus.rejected) {
+        linkTo += "/review"
+        message = <FormattedMessage {...messages.resolveTaskLabel} />
+      }
 
       return (
         <div className="row-controls-column mr-links-green-lighter">
@@ -1272,17 +1277,6 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
           >
             {message}
           </Link>
-          {!props.metaReviewEnabled &&
-            row._original.reviewStatus !== TaskReviewStatus.needed &&
-            row._original.reviewedBy && row._original.reviewedBy.id !== props.user?.id &&
-            <Link 
-              to={`${linkTo}/review`} 
-              className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
-              onClick={(e) => handleClick(e, `${linkTo}/review`)}
-            >
-              <FormattedMessage {...messages.reviewFurtherTaskLabel} />
-            </Link>
-          }
         </div>
       )
     }
@@ -1344,29 +1338,34 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
     minWidth: 90,
     maxWidth: 120,
     Cell: ({ row }) => {
-      let linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
-      let message = <FormattedMessage {...messages.viewTaskLabel} />
-
-      if (row._original.reviewStatus === TaskReviewStatus.disputed ||
-          row._original.metaReviewStatus === TaskReviewStatus.rejected) {
-        linkTo += "/review"
-        message = <FormattedMessage {...messages.resolveTaskLabel} />
-      }
+      const linkTo = `/challenge/${row._original.parent.id}/task/${row._original.id}`
+      let message =
+        row._original.reviewStatus === TaskReviewStatus.rejected ? (
+          <FormattedMessage {...messages.fixTaskLabel} />
+        ) : (
+          <FormattedMessage {...messages.viewTaskLabel} />
+        )
   
       return (
         <div className="row-controls-column mr-links-green-lighter">
           <Link
             to={linkTo}
-            onClick={(e) => {
-              e.preventDefault()
-              props.history.push({
-                pathname: linkTo,
-                criteria,
-              })
-            }}
+            onClick={(e) => handleClick(e, linkTo)}
           >
             {message}
           </Link>
+          {!props.metaReviewEnabled &&
+            row._original.reviewStatus !== TaskReviewStatus.needed &&
+            row._original.reviewedBy &&
+            row._original.reviewedBy.id !== props.user?.id && (
+              <Link
+                to={`${linkTo}/review`}
+                onClick={(e) => handleClick(e, `${linkTo}/review`)}
+                className="mr-text-green-lighter hover:mr-text-white mr-cursor-pointer mr-transition"
+              >
+                <FormattedMessage {...messages.reviewFurtherTaskLabel} />
+              </Link>
+            )}
         </div>
       )
     }


### PR DESCRIPTION
Wrong links implemented in all review related tasks view:
<img width="251" alt="Screenshot 2024-02-19 at 4 49 16 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/9f99d9d7-f79c-428e-9c21-6dd39d609249">

Correct view reimplemented
<img width="362" alt="Screenshot 2024-02-19 at 4 51 36 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/7923daa8-0edb-4d21-a81e-2e9c76787787">
