### PR TITLE
Fix validation issue/error in challenge editor

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -131,11 +131,12 @@ export class EditChallenge extends Component {
    * should be displayed as a single, long-form step. This will cause this
    * component to re-render with the updated settings
    */
-  setIsLongForm = (isLongForm) =>
+  setIsLongForm = (isLongForm) => {
+    if(this.isFinishing) this.isFinishing = false
     this.props.updateUserAppSetting(this.props.user.id, {
       longFormChallenge: isLongForm,
     });
-
+  }
   /**
    * Returns the list of challenge form groups that are to be rendered as
    * collapsed when in longform mode (does not affect stepped mode)


### PR DESCRIPTION
Fixes a problem where failing form validation on submit for any reason in the long form view would then prevent any progress if subsequently switching to the short form view by triggering the same submit error.