### PR TITLE
fix infinite loop when inspecting task after challenge save

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -304,8 +304,12 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true,
          this.refreshTasks(typedCriteria)
        }
        else if (_get(this.props.history.location, 'state.refreshAfterSave')) {
-         this.refreshTasks(typedCriteria)
-       }
+        this.refreshTasks(typedCriteria)
+        this.props.history.push({
+          pathname: this.props.history.location.pathname,
+          state: { refreshAfterSave: false }
+        })
+      }
      }
 
      render() {


### PR DESCRIPTION
Fixes the infinite loop of fetching tasks caused by a condition in a componentDidUpdate being true always after a challenge is saved.
<img width="592" alt="Screenshot 2024-02-19 at 9 21 14 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/df5c070b-2f31-4ba7-a9d3-4406b2aff2a8">
