### PR TITLE
fix tab change in review section

### DIFF
--- a/src/pages/Review/Review.js
+++ b/src/pages/Review/Review.js
@@ -79,7 +79,9 @@ export class ReviewTasksDashboard extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if(this.state.showType !== ReviewTasksType.myReviewedTasks){
+    const user = AsEndUser(this.props.user)
+    
+    if(user.isReviewer()) {
       if (_isUndefined(_get(this.props, 'match.params.showType')) &&
           this.state.showType !== ReviewTasksType.toBeReviewed ) {
         this.setState({showType:ReviewTasksType.toBeReviewed})


### PR DESCRIPTION
Issue: Reviewer were getting stuck on the "myReviewedTasks" tab. This was caused by a condition implemented in the non reviewer filtering fix on their review table(https://github.com/maproulette/maproulette3/pull/2273)