### PR TITLE
add id's and htmlFor attributes to labels and inputs

### DIFF
--- a/src/components/ActivityListing/ActivityListing.js
+++ b/src/components/ActivityListing/ActivityListing.js
@@ -27,13 +27,14 @@ export const Activity = props => {
          {props.toggleIsGrouped &&
           <React.Fragment>
             <input
+              id="group-label"
               type="checkbox"
               className="mr-checkbox-toggle mr-ml-4 mr-mr-px"
               checked={props.isGrouped}
               onClick={props.toggleIsGrouped}
               onChange={() => null}
             />
-            <label className="mr-ml-2"><FormattedMessage {...messages.groupLabel} /></label>
+            <label htmlFor="group-label" className="mr-ml-2"><FormattedMessage {...messages.groupLabel} /></label>
           </React.Fragment>
          }
          <div className="mr-timeline mr-links-green-lighter">

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -999,18 +999,20 @@ function configureCustomTaskStyles(props, configureTaskStyleRules) {
       <div>
         <div className="radio">
           <input
+            id="custom-task-style-default-label" 
             type="radio"
             name="no-styles"
             className="mr-mr-1.5"
             checked={!props.formData}
             onChange={() => props.onChange(false)}
           />
-          <label className="mr-mr-2 mr-text-grey-lighter">
+          <label htmlFor="custom-task-style-default-label" className="mr-mr-2 mr-text-grey-lighter">
             <FormattedMessage {...messages.customTaskStyleDefaultLabel} />
           </label>
         </div>
         <div className="radio">
           <input
+            id="custom-task-style-custom-label"
             type="radio"
             name="custom-styles"
             className="mr-mr-1.5"
@@ -1019,7 +1021,7 @@ function configureCustomTaskStyles(props, configureTaskStyleRules) {
               props.onChange(true);
             }}
           />
-          <label className="mr-text-grey-lighter">
+          <label htmlFor="custom-task-style-custom-label" className="mr-text-grey-lighter">
             <FormattedMessage {...messages.customTaskStyleCustomLabel} />
           </label>
         </div>

--- a/src/components/AdminPane/Manage/ProjectOverview/ProjectOverview.js
+++ b/src/components/AdminPane/Manage/ProjectOverview/ProjectOverview.js
@@ -77,8 +77,14 @@ export default class ProjectOverview extends Component {
                   prompt={<FormattedMessage {...messages.confirmDisablePrompt} />}
                   skipConfirmation={() => !this.props.project.enabled}
                 >
-                  <label className="switch-container" onClick={() => this.props.toggleProjectEnabled(this.props.project)}>
-                    <input type="checkbox" checked={this.props.project.enabled} disabled={!manager.canWriteProject(this.props.project)} onChange={() => null} />
+                  <label htmlFor="switch-input" className="switch-container" onClick={() => this.props.toggleProjectEnabled(this.props.project)}>
+                    <input 
+                      id="switch-input" 
+                      type="checkbox" 
+                      checked={this.props.project.enabled} 
+                      disabled={!manager.canWriteProject(this.props.project)} 
+                      onChange={() => null} 
+                    />
                     <span className="slider round" onClick={() => null}></span>
                   </label>
                 </ConfirmAction>

--- a/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
@@ -87,10 +87,11 @@ export class RebuildTasksControl extends Component {
     if (challenge.dataSource() === 'local') {
       originDateField = (
         <div>
-          <label className="mr-text-orange mr-mr-2">
+          <label htmlFor="data-origin-date-input" className="mr-text-orange mr-mr-2">
             <FormattedMessage {...messages.dataOriginDateLabel} />
           </label>
           <input
+            id="data-origin-date-input"
             className="mr-text-white mr-bg-transparent mr-border mr-border-white mr-rounded mr-p-2"
             type="date"
             label={this.props.intl.formatMessage(messages.dataOriginDateLabel)}
@@ -168,12 +169,13 @@ export class RebuildTasksControl extends Component {
                 <div className="mr-w-full mr-flex mr-justify-between mr-items-center mr-mt-2">
                   <div>
                     <input
+                      id="remove-unmatched-input"
                       type="checkbox"
                       className="mr-mr-2"
                       checked={this.state.removeUnmatchedTasks}
                       onChange={this.toggleRemoveUnmatchedTasks}
                     />
-                    <label className="mr-text-orange">
+                    <label htmlFor="remove-unmatched-input" className="mr-text-orange">
                       <FormattedMessage {...messages.removeUnmatchedLabel} />
                     </label>
                   </div>

--- a/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.js
+++ b/src/components/AdminPane/Manage/VisibilitySwitch/VisibilitySwitch.js
@@ -25,8 +25,13 @@ export class VisibilitySwitch extends Component {
 
     return (
       <div className="mr-flex mr-justify-center">
-        <label className="switch-container">
-          <input type="checkbox" checked={this.props.challenge.enabled} onChange={() => null}/>
+        <label htmlFor="switch-label" className="switch-container">
+          <input 
+            type="checkbox" 
+            id="switch-label" 
+            checked={this.props.challenge.enabled} 
+            onChange={() => null}
+          />
           <span className="slider round" onClick={this.toggleVisible}></span>
         </label>
       </div>

--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -96,6 +96,7 @@ export default class LeaderboardWidget extends Component {
       <div className="mr-text-xs mr--mb-5">
         <span>
           <input
+            id="user-mapper-type-label"
             type="radio"
             name="showByMappers"
             className="mr-radio mr-mr-1"
@@ -103,12 +104,13 @@ export default class LeaderboardWidget extends Component {
             onClick={() => this.setUserType(USER_TYPE_MAPPER)}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="user-mapper-type-label" className="mr-ml-1 mr-mr-4">
             <FormattedMessage {...messages[USER_TYPE_MAPPER]}/>
           </label>
         </span>
         <span>
           <input
+            id="user-reviewer-type-label"
             type="radio"
             name="showByReviewers"
             className="mr-radio mr-mr-1"
@@ -116,7 +118,7 @@ export default class LeaderboardWidget extends Component {
             onClick={() => this.setUserType(USER_TYPE_REVIEWER)}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="user-reviewer-type-label" className="mr-ml-1 mr-mr-4">
             <FormattedMessage {...messages[USER_TYPE_REVIEWER]}/>
           </label>
         </span>

--- a/src/components/ChallengeDetail/FlagCommentInput.js
+++ b/src/components/ChallengeDetail/FlagCommentInput.js
@@ -72,7 +72,7 @@ export class FlagCommentInput extends Component {
     const minCharacterCount = 100
     return (
       <div className="mr-mt-2">
-        <label className="mr-text-white-50">
+        <label htmlFor="root_email" className="mr-text-white-50">
         <FormattedMessage {...messages.email} />
         </label>
         <input className="form-control mr-mb-4" type="email" id="root_email" label="Email address" placeholder="Enter your email" value={this.state.emailValue} onChange={(event) => this.setState({ emailValue: event.target.value })} />
@@ -139,12 +139,13 @@ export class FlagCommentInput extends Component {
         )}
         <div className="form mr-flex mr-items-baseline">
           <input
+            id="review-label"
             type="checkbox"
             className="mr-mr-2"
             checked={this.state.checked}
             onChange={this.handleToggle}
           />
-          <label className="mr-text-white-50">
+          <label htmlFor="review-label" className="mr-text-white-50">
             <FormattedMessage {...messages.review} />
           </label>
         </div>

--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByCategorizationKeywords.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByCategorizationKeywords.js
@@ -144,7 +144,7 @@ const ListFilterItems = function (props) {
         </div>
       ) : null}
       <div className="mr-flex mr-items-center mr-py-3">
-        <label className="mr-text-green-lighter mr-mr-4 mr-cursor-pointer"><FormattedMessage {...messages.add}/></label>
+        <label htmlFor="input-name" className="mr-text-green-lighter mr-mr-4 mr-cursor-pointer"><FormattedMessage {...messages.add}/></label>
         <form onSubmit={(e) => {
           e.preventDefault() // Prevent the default form submission behavior
           const value = e.target.elements.inputName.value // Replace 'inputName' with the actual name attribute of the input
@@ -156,6 +156,7 @@ const ListFilterItems = function (props) {
           <input
             className="mr-flex mr-items-center mr-border-none mr-text-white mr-rounded mr-bg-black-15 mr-shadow-inner mr-px-2"
             name="inputName"
+            id="input-name"
           />
         </form>
       </div>

--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
@@ -55,6 +55,7 @@ export class FilterByLocation extends Component {
         </span>
         <span>
           <input
+            id="location-input"
             type="radio"
             name="intersectsMap"
             className="mr-radio mr-mr-1"
@@ -62,12 +63,13 @@ export class FilterByLocation extends Component {
             onClick={() => this.updateFilter(ChallengeLocation.intersectingMapBounds)}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="location-input" className="mr-ml-1 mr-mr-4">
             {localizedLocationLabels[ChallengeLocation.intersectingMapBounds]}
           </label>
         </span>
         <span>
           <input
+            id="any-location-input"
             type="radio"
             name="intersectsMap"
             className="mr-radio mr-mr-1"
@@ -75,7 +77,7 @@ export class FilterByLocation extends Component {
             onClick={() => this.updateFilter(null)}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="any-location-input" className="mr-ml-1 mr-mr-4">
             {localizedLocationLabels.any}
           </label>
         </span>

--- a/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -232,6 +232,7 @@ export const ColumnRadioField = function(props) {
       {props.schema.enum.map((option, index) =>
         <div key={option} className="mr-flex mr-items-center mr-my-2">
           <input
+            id={props.schema.enumNames ? props.schema.enumNames[index] : props.schema.enum[index]}
             type="radio"
             name={props.name}
             value={option}
@@ -239,7 +240,7 @@ export const ColumnRadioField = function(props) {
             className="mr-radio mr-mr-2"
             onChange={() => props.onChange(option)}
           />
-          <label onClick={() => props.onChange(option)}>
+          <label htmlFor={props.schema.enumNames ? props.schema.enumNames[index] : props.schema.enum[index]} onClick={() => props.onChange(option)}>
             <MarkdownContent
               compact
               markdown={

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.js
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.js
@@ -281,12 +281,13 @@ const SimpleLayerToggle = props => {
       onClick={props.toggleLayerActive}
     >
       <input
+        id={props.layerLabel}
         type="checkbox"
         className="mr-checkbox-toggle"
         checked={props.isLayerActive}
         onChange={_noop}
       />
-      <label className="mr-ml-3 mr-text-orange">{props.layerLabel}</label>
+      <label htmlFor={props.layerLabel} className="mr-ml-3 mr-text-orange">{props.layerLabel}</label>
     </div>
   )
 }

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -88,7 +88,7 @@ export default class SearchBox extends Component {
           this.props.className
         )}
       >
-        <label className="mr-mr-2 mr-flex mr-items-center" htmlFor="input-search">
+        <label className="mr-mr-2 mr-flex mr-items-center">
           {!isLoading && !this.props.suppressIcon &&
            <SvgSymbol
              sym="search-icon"

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -805,8 +805,9 @@ export class TaskClusterMap extends Component {
     return (
       <div className={classNames('taskcluster-map', {"full-screen-map": this.props.isMobile}, this.props.className)}>
         {canClusterToggle && !this.state.searchOpen && !this.props.loading &&
-         <label className="mr-absolute mr-z-10 mr-top-0 mr-left-0 mr-mt-2 mr-ml-2 mr-shadow mr-rounded-sm mr-bg-black-50 mr-px-2 mr-py-1 mr-text-white mr-text-xs mr-flex mr-items-center">
+         <label htmlFor="show-clusters-input" className="mr-absolute mr-z-10 mr-top-0 mr-left-0 mr-mt-2 mr-ml-2 mr-shadow mr-rounded-sm mr-bg-black-50 mr-px-2 mr-py-1 mr-text-white mr-text-xs mr-flex mr-items-center">
            <input
+             id="show-clusters-input"
              type="checkbox"
              className="mr-mr-2"
              checked={this.props.showAsClusters}

--- a/src/components/TaskConfirmationModal/AdjustFiltersOverlay.js
+++ b/src/components/TaskConfirmationModal/AdjustFiltersOverlay.js
@@ -26,10 +26,11 @@ export default class AdjustFiltersOverlay extends Component {
 
     const reviewStatusFilter =
       <div className="mr-mt-4">
-        <label className="mr-w-32 mr-inline-block">
+        <label htmlFor="review-status-label" className="mr-w-32 mr-inline-block">
           <FormattedMessage {...messages.reviewStatusLabel} />
         </label>
         <select
+          id="review-status-label"
           className="mr-text-white mr-select mr-w-48"
           onChange={event => this.props.filterChange('reviewStatus', event.target.value)}
           value={currentFilters.reviewStatus ? currentFilters.reviewStatus : 'all'}
@@ -51,10 +52,11 @@ export default class AdjustFiltersOverlay extends Component {
 
     const statusFilter =
       <div className="mr-mt-4">
-        <label className="mr-w-32 mr-inline-block">
+        <label htmlFor="status-select" className="mr-w-32 mr-inline-block">
           <FormattedMessage {...messages.statusLabel} />
         </label>
         <select
+          id="status-select"
           className="mr-text-white mr-select mr-w-48"
           onChange={event => this.props.filterChange('status', event.target.value)}
           value={currentFilters.status ? currentFilters.status : 'all'}
@@ -74,10 +76,11 @@ export default class AdjustFiltersOverlay extends Component {
 
     const priorityFilter =
       <div className="mr-mt-4">
-        <label className="mr-w-32 mr-inline-block">
+        <label htmlFor="priority-select" className="mr-w-32 mr-inline-block">
           <FormattedMessage {...messages.priorityLabel} />
         </label>
         <select
+          id="priority-label" 
           className="mr-text-white mr-select mr-w-48"
           onChange={event => this.props.filterChange('priority', event.target.value)}
           value={currentFilters.priority ? currentFilters.priority : 'all'}
@@ -97,10 +100,11 @@ export default class AdjustFiltersOverlay extends Component {
 
     const challengeFilter =
       <div className="mr-mt-4">
-        <label className="mr-w-32 mr-inline-block">
+        <label htmlFor="challenge-label" className="mr-w-32 mr-inline-block">
           <FormattedMessage {...messages.challengeLabel} />
         </label>
-        <input type="text"
+        <input id="mapper-label" 
+               type="text"
                className="mr-text-white mr-input mr-w-64"
                value={currentFilters.challenge || ""}
                onChange={event => this.props.filterChange('challenge', event.target.value)}/>
@@ -130,10 +134,11 @@ export default class AdjustFiltersOverlay extends Component {
 
     const mapperFilter =
       <div className="mr-mt-4">
-        <label className="mr-w-32 mr-inline-block">
+        <label htmlFor="mapper-label" className="mr-w-32 mr-inline-block">
           <FormattedMessage {...messages.mapperLabel} />
         </label>
-        <input type="text"
+        <input id="mapper-label" 
+               type="text"
                className="mr-text-white mr-input mr-w-64"
                value={currentFilters.reviewRequestedBy}
                onChange={event => this.props.filterChange('reviewRequestedBy', event.target.value)}/>

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -280,13 +280,14 @@ export class TaskConfirmationModal extends Component {
                     this.props.user.settings.needsReview !== needsReviewType.mandatory &&
                       <div className="form mr-flex mr-items-baseline">
                         <input
+                          id="review-input"
                           type="checkbox"
                           className="mr-mr-2"
                           checked={this.props.needsReview}
                           onClick={this.props.toggleNeedsReview}
                           onChange={_noop}
                         />
-                        <label className="mr-text-white-50">
+                        <label htmlFor="review-input" className="mr-text-white-50">
                           <FormattedMessage {...messages.reviewLabel} />
                         </label>
                       </div>
@@ -315,6 +316,7 @@ export class TaskConfirmationModal extends Component {
                           <FormattedMessage {...messages.loadByLabel} />
                         </span>
                         <input
+                          id="load-method-random-input"
                           type="radio"
                           name="randomnessPreference"
                           className="mr-radio mr-mr-1"
@@ -322,11 +324,12 @@ export class TaskConfirmationModal extends Component {
                           onClick={() => this.props.chooseLoadBy(TaskLoadMethod.random)}
                           onChange={_noop}
                         />
-                        <label className="mr-ml-1 mr-mr-4">
+                        <label htmlFor="load-method-random-input" className="mr-ml-1 mr-mr-4">
                           <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.random]} />
                         </label>
 
                         <input
+                          id="load-method-proximity-input"
                           type="radio"
                           name="randomnessPreference"
                           className="mr-radio mr-mr-1"
@@ -334,7 +337,7 @@ export class TaskConfirmationModal extends Component {
                           onClick={() => this.props.chooseLoadBy(TaskLoadMethod.proximity)}
                           onChange={_noop}
                         />
-                        <label className="mr-ml-1">
+                        <label htmlFor="load-method-proximity-input" className="mr-ml-1">
                           <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />
                         </label>
                       </div>
@@ -430,10 +433,11 @@ export class TaskConfirmationModal extends Component {
                         onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.inbox)}
                         onChange={_noop}
                       />
-                      <label className="mr-mr-4">
+                      <label htmlFor="review-load-method-input" className="mr-mr-4">
                         <FormattedMessage {...messagesByReviewLoadMethod[TaskReviewLoadMethod.inbox]} />
                       </label>
                       <input
+                        id="review-load-method-input"
                         type="radio"
                         name="loadReviewPreference"
                         className="mr-mr-2"

--- a/src/components/TaskFilters/TaskPriorityFilter.js
+++ b/src/components/TaskFilters/TaskPriorityFilter.js
@@ -27,8 +27,9 @@ export default class TaskPriorityFilter extends Component {
           filters={
             _reverse(_map(TaskPriority, priority => (
               <li key={priority}>
-                <label className="mr-flex mr-items-center">
+                <label htmlFor={priority} className="mr-flex mr-items-center">
                   <input
+                    id={priority}
                     className="mr-checkbox-toggle mr-mr-2"
                     type="checkbox"
                     checked={this.props.includeTaskPriorities[priority]}

--- a/src/components/TaskFilters/TaskReviewStatusFilter.js
+++ b/src/components/TaskFilters/TaskReviewStatusFilter.js
@@ -44,14 +44,14 @@ export default class TaskReviewStatusFilter extends Component {
         secondaryFilters:
           _map(TaskMetaReviewStatusWithUnset, status => (
             <li key={`meta-${status}`}>
-              <label className="mr-flex mr-items-center">
+              <label htmlFor={`meta-${status}`} className="mr-flex mr-items-center">
                 <input
+                  id={`meta-${status}`}
                   className="mr-checkbox-toggle mr-mr-2"
                   type="checkbox"
                   checked={this.props.includeMetaReviewStatuses[status]}
                   onChange={(e) =>
-                    this.props.toggleIncludedMetaReviewStatus(status,
-                                                              e.nativeEvent.shiftKey)
+                    this.props.toggleIncludedMetaReviewStatus(status, e.nativeEvent.shiftKey)
                   } />
                 <FormattedMessage {...messagesByMetaReviewStatus[status]} />
               </label>
@@ -67,14 +67,14 @@ export default class TaskReviewStatusFilter extends Component {
           filters={
             _map(TaskReviewStatusWithUnset, status => (
               <li key={status} className='mr-w-76'>
-                <label className="mr-flex mr-items-center">
+                <label htmlFor={status} className="mr-flex mr-items-center">
                   <input
+                    id={status}
                     className="mr-checkbox-toggle mr-mr-2"
                     type="checkbox"
                     checked={this.props.includeTaskReviewStatuses[status]}
                     onChange={(e) =>
-                      this.props.toggleIncludedTaskReviewStatus(status,
-                                                                e.nativeEvent.shiftKey)
+                      this.props.toggleIncludedTaskReviewStatus(status, e.nativeEvent.shiftKey)
                     } />
                   <FormattedMessage {...messagesByReviewStatus[status]} />
                 </label>

--- a/src/components/TaskFilters/TaskStatusFilter.js
+++ b/src/components/TaskFilters/TaskStatusFilter.js
@@ -37,14 +37,14 @@ export default class TaskStatusFilter extends Component {
           filters={
             _map(taskStatusOptions, status => (
               <li key={status}>
-                <label className="mr-flex mr-items-center">
+                <label htmlFor={status} className="mr-flex mr-items-center">
                   <input
+                    id={status}
                     className="mr-checkbox-toggle mr-mr-2"
                     type="checkbox"
                     checked={this.props.includeTaskStatuses[status]}
                     onChange={(e) =>
-                      this.props.toggleIncludedTaskStatus(status,
-                                                          e.nativeEvent.shiftKey)
+                      this.props.toggleIncludedTaskStatus(status, e.nativeEvent.shiftKey)
                     } />
                   <FormattedMessage {...messagesByStatus[status]} />
                 </label>

--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -298,6 +298,7 @@ export class TaskHistoryList extends Component {
       <div className="mr-text-right mr-text-xs mr-mb-2">
         <span>
           <input
+            id="by-time-input"
             type="radio"
             name="showByTime"
             className="mr-radio mr-mr-1"
@@ -305,12 +306,13 @@ export class TaskHistoryList extends Component {
             onClick={() => this.setState({listType: TIME_TOGGLE})}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="by-time-input" className="mr-ml-1 mr-mr-4">
             <FormattedMessage {...messages.listByTime}/>
           </label>
         </span>
         <span>
           <input
+            id="by-user-input"
             type="radio"
             name="showByReviewers"
             className="mr-radio mr-mr-1"
@@ -318,7 +320,7 @@ export class TaskHistoryList extends Component {
             onClick={() => this.setState({listType: USER_TOGGLE})}
             onChange={_noop}
           />
-          <label className="mr-ml-1 mr-mr-4">
+          <label htmlFor="by-user-input" className="mr-ml-1 mr-mr-4">
             <FormattedMessage {...messages.listByUser}/>
           </label>
         </span>

--- a/src/components/TaskPane/TaskRandomnessControl/TaskRandomnessControl.js
+++ b/src/components/TaskPane/TaskRandomnessControl/TaskRandomnessControl.js
@@ -34,18 +34,24 @@ export default class TaskRandomnessControl extends Component {
           </div>
 
           <div className="task-randomness-control__options">
-            <label className="radio">
-              <input type="radio" name="randomnessPreference"
-                    className="task-randomness-control__random-option"
-                    checked={this.props.taskLoadBy === TaskLoadMethod.random}
-                    onChange={() => this.loadBy(TaskLoadMethod.random)} />
+            <label htmlFor="load-method-random-label" className="radio">
+              <input 
+                type="radio" 
+                id="load-method-random-label"
+                name="randomnessPreference"
+                className="task-randomness-control__random-option"
+                checked={this.props.taskLoadBy === TaskLoadMethod.random}
+                onChange={() => this.loadBy(TaskLoadMethod.random)} />
               <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.random]} />
             </label>
-            <label className="radio">
-              <input type="radio" name="randomnessPreference"
-                    className="task-randomness-control__proximity-option"
-                    checked={this.props.taskLoadBy === TaskLoadMethod.proximity}
-                    onChange={() => this.loadBy(TaskLoadMethod.proximity)} />
+            <label htmlFor="load-method-proximity-label" className="radio">
+              <input 
+                type="radio" 
+                id="load-method-proximity-label"
+                name="randomnessPreference"
+                className="task-randomness-control__proximity-option"
+                checked={this.props.taskLoadBy === TaskLoadMethod.proximity}
+                onChange={() => this.loadBy(TaskLoadMethod.proximity)} />
               <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />
             </label>
           </div>

--- a/src/components/TaskPane/TaskTrackControls/TaskTrackControls.js
+++ b/src/components/TaskPane/TaskTrackControls/TaskTrackControls.js
@@ -35,12 +35,13 @@ export default class TaskTrackControls extends Component {
       <div>
         <div onClick={this.toggleSaved}>
           <input
+            id="task-track-checkbox"
             type="checkbox"
             className="mr-mr-2"
             onChange={() => _noop}
             checked={this.taskIsTracked()}
           />
-          <label>
+          <label htmlFor="task-track-checkbox">
             <FormattedMessage {...messages.trackLabel } />
           </label>
         </div>

--- a/src/components/Widgets/TaskMapWidget/RapidEditor/EditSwitch.js
+++ b/src/components/Widgets/TaskMapWidget/RapidEditor/EditSwitch.js
@@ -22,8 +22,13 @@ export class EditSwitch extends Component {
     return (
       <div className="mr-flex mr-justify-center">
         {!disableRapid && (
-          <label className="switch-container mr-mr-2">
-            <input type="checkbox" checked={editModeOn} onChange={this.toggleVisible} />
+          <label htmlFor="edit-mode-checkbox" className="switch-container mr-mr-2">
+            <input 
+              type="checkbox" 
+              id="edit-mode-checkbox"
+              checked={editModeOn} 
+              onChange={this.toggleVisible} 
+            />
             <span className="slider round"></span>
           </label>
         )}

--- a/src/pages/Inbox/HeaderNotifications.js
+++ b/src/pages/Inbox/HeaderNotifications.js
@@ -18,7 +18,6 @@ class HeaderNotifications extends Component {
               <li className="mr-text-white">
                 <input
                   type="checkbox"
-
                   className="mr-checkbox-toggle mr-mr-1"
                   checked={this.props.groupByTask}
                   onChange={this.props.toggleGroupByTask}

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -471,20 +471,22 @@ export class TaskReviewTable extends Component {
           <div className="field favorites-only-switch mr-mt-2 mr-mr-4" onClick={() => this.toggleShowFavorites()}>
             <input
               type="checkbox"
+              id="only-saved-challenges-checkbox"
               className="mr-checkbox-toggle mr-mr-px"
               checked={!!this.props.reviewCriteria.savedChallengesOnly}
               onChange={() => null}
             />
-            <label> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
+            <label htmlFor="only-saved-challenges-checkbox"> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
           </div>
           <div className="field favorites-only-switch mr-mt-2" onClick={() => this.toggleExcludeOthers()}>
             <input
               type="checkbox"
+              id="exclude-other-reviewers-checkbox"
               className="mr-checkbox-toggle mr-mr-px"
               checked={!!this.props.reviewCriteria.excludeOtherReviewers}
               onChange={() => null}
             />
-            <label> {this.props.intl.formatMessage(messages.excludeOtherReviewers)}</label>
+            <label htmlFor="exclude-other-reviewers-checkbox"> {this.props.intl.formatMessage(messages.excludeOtherReviewers)}</label>
           </div>
         </div>
       )

--- a/src/services/Templating/Handlers/CheckboxFormHandler.js
+++ b/src/services/Templating/Handlers/CheckboxFormHandler.js
@@ -32,13 +32,14 @@ const CheckboxFormField = props => {
   return (
     <React.Fragment>
       <input
+        id="checkbox-label"
         type="checkbox"
         className="checkbox"
         defaultChecked={isChecked}
         disabled={props.disableTemplate}
         onChange={() => props.setCompletionResponse(props.propertyName, !isChecked)}
       />
-      <label className="mr-pl-2">{props.label}</label>
+      <label htmlFor="checkbox-label" className="mr-pl-2">{props.label}</label>
     </React.Fragment>
   )
 }

--- a/src/services/Templating/Handlers/SelectFormHandler.js
+++ b/src/services/Templating/Handlers/SelectFormHandler.js
@@ -43,6 +43,7 @@ const SelectFormField = props => {
   return (
     <React.Fragment>
       <select
+        id="select-label" 
         onChange={e => props.setCompletionResponse(props.propertyName, e.target.value)}
         className="select mr-text-black mr-text-xs"
         defaultValue={currentValue}
@@ -51,7 +52,7 @@ const SelectFormField = props => {
         <option key="0" value=""></option>
         {_map(props.values, (value, i) => <option key={i} value={value}>{value}</option>)}
       </select>
-      <label className="mr-pl-2">{props.label}</label>
+      <label htmlFor="select-label" className="mr-pl-2">{props.label}</label>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Main feature improvement of this pr: Accessibility: Associating labels with form elements using htmlFor ensures that screen readers can correctly announce the label when a user interacts with the form field. This improves accessibility for users who rely on screen readers or other assistive technologies to navigate the web.

A secondary focus of this pr is to attempt to resolve some of the suggestions in warnings displayed in devtools. 
<img width="523" alt="Screenshot 2024-02-21 at 6 30 30 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/8698e071-aca2-4214-bc64-040c19d185dd">

Moving forward with fixing the labels and input error, the structure of mapped element needs to include a unique id whenever a form is include, and the schemas in forms, whenever using a "ui:widget: 'radio' " pattern will need to be fixed as they are causing the "Page Errors"

Example of a radio format is the yes/no option selectors in forms.
<img width="403" alt="Screenshot 2024-02-21 at 7 33 36 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/ead91505-d319-4cc8-931f-8ac014c7730f">
