### PR TITLE
fix duplicate pane name errors

### DIFF
--- a/src/components/SupplementalMap/SupplementalMap.js
+++ b/src/components/SupplementalMap/SupplementalMap.js
@@ -92,7 +92,7 @@ const SupplementalMap = props => {
         {_map(overlayLayers, (layer, index) => (
           <Pane
             key={`pane-${renderId}-${index}`}
-            name={`pane-${index}`}
+            name={`pane-${renderId}-${index}`}
             style={{zIndex: 10 + index}}
             className="custom-pane"
           >

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -764,7 +764,7 @@ export class TaskClusterMap extends Component {
         {_map(overlayLayers, (layer, index) => (
           <Pane
             key={`pane-${renderId}-${index}`}
-            name={`pane-${index}`}
+            name={`pane-${renderId}-${index}`}
             style={{zIndex: 10 + index}}
             className="custom-pane"
           >

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -627,7 +627,7 @@ export class TaskMap extends Component {
           {_map(overlayLayers, (layer, index) => (
             <Pane
               key={`pane-${renderId}-${index}`}
-              name={`pane-${index}`}
+              name={`pane-${renderId}-${index}`}
               style={{zIndex: 10 + index}}
               className="custom-pane"
             >


### PR DESCRIPTION
Fix's these error. Solution was making the names of the pane's more unique. This error occurred whenever the task completion modal was opened.


<img width="521" alt="Screenshot 2024-02-21 at 8 02 05 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/078bfcf2-243b-438d-97b1-9f8278e357dc">
