### PR TITLE
fix looping issue with leaderboard fetching

### DIFF
--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
@@ -100,6 +100,12 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
             this.setState({leaderboard})
 
             const userId = _get(this.props, 'user.id')
+            // The reason for using _get is that the structure of the props may vary
+            // depending on where this component is used, and accessing the user's score
+            // directly through `this.props.user.score` may result in runtime errors if
+            // the `user` object or the `score` property is not available in certain contexts.
+            // By using `_get`, we safely handle cases where the expected property may be missing
+            // or nested within a deeper structure. 
             const userScore = _get(this.props, 'user.score')
             if (userScore && userId && !options.ignoreUser && userType !== USER_TYPE_REVIEWER) {
               this.props.fetchLeaderboardForUser(userId, 1,

--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
@@ -100,7 +100,8 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
             this.setState({leaderboard})
 
             const userId = _get(this.props, 'user.id')
-            if (userId && !options.ignoreUser && userType !== USER_TYPE_REVIEWER) {
+            const userScore = _get(this.props, 'user.score')
+            if (userScore && userId && !options.ignoreUser && userType !== USER_TYPE_REVIEWER) {
               this.props.fetchLeaderboardForUser(userId, 1,
                 ...this.leaderboardParams(numberMonths, countryCode),
                 startDate, endDate).then(userLeaderboard => {

--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -132,7 +132,7 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if (prevProps[userProp] !== this.props[userProp]) {
+      if (prevProps[userProp].score !== this.props[userProp].score) {
         this.updateAllMetrics(this.props)
       }
 

--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -126,44 +126,46 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
     }
 
     componentDidMount() {
-      if (this.props[userProp]) {
+      if (this.props[userProp]?.score) {
         this.updateAllMetrics(this.props)
       }
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if (prevProps[userProp].score !== this.props[userProp].score) {
-        this.updateAllMetrics(this.props)
-      }
+      if(prevProps[userProp]?.score){
+        if (prevProps[userProp]?.score !== this.props[userProp]?.score) {
+          this.updateAllMetrics(this.props)
+        }
 
-      else if (prevState.tasksReviewedMonthsPast !== this.state.tasksReviewedMonthsPast &&
-               this.state.tasksReviewedMonthsPast !== CUSTOM_RANGE) {
-        this.updateUserMetrics(this.props)
-      }
+        else if (prevState.tasksReviewedMonthsPast !== this.state.tasksReviewedMonthsPast &&
+                this.state.tasksReviewedMonthsPast !== CUSTOM_RANGE) {
+          this.updateUserMetrics(this.props)
+        }
 
-      else if (prevState.tasksReviewerMonthsPast !== this.state.tasksReviewerMonthsPast &&
-               this.state.tasksReviewerMonthsPast !== CUSTOM_RANGE) {
-        this.updateUserMetrics(this.props)
-      }
+        else if (prevState.tasksReviewerMonthsPast !== this.state.tasksReviewerMonthsPast &&
+                this.state.tasksReviewerMonthsPast !== CUSTOM_RANGE) {
+          this.updateUserMetrics(this.props)
+        }
 
-      else if (prevState.tasksCompletedMonthsPast !== this.state.tasksCompletedMonthsPast &&
-               this.state.tasksCompletedMonthsPast !== CUSTOM_RANGE) {
-        this.updateUserMetrics(this.props)
-      }
+        else if (prevState.tasksCompletedMonthsPast !== this.state.tasksCompletedMonthsPast &&
+                this.state.tasksCompletedMonthsPast !== CUSTOM_RANGE) {
+          this.updateUserMetrics(this.props)
+        }
 
-      else if (this.state.tasksCompletedMonthsPast === CUSTOM_RANGE &&
-               prevState.tasksCompletedDateRange !== this.state.tasksCompletedDateRange) {
-        this.updateUserMetrics(this.props)
-      }
+        else if (this.state.tasksCompletedMonthsPast === CUSTOM_RANGE &&
+                prevState.tasksCompletedDateRange !== this.state.tasksCompletedDateRange) {
+          this.updateUserMetrics(this.props)
+        }
 
-      else if (this.state.tasksReviewedMonthsPast === CUSTOM_RANGE &&
-               prevState.tasksReviewedDateRange !== this.state.tasksReviewedDateRange) {
-        this.updateUserMetrics(this.props)
-      }
+        else if (this.state.tasksReviewedMonthsPast === CUSTOM_RANGE &&
+                prevState.tasksReviewedDateRange !== this.state.tasksReviewedDateRange) {
+          this.updateUserMetrics(this.props)
+        }
 
-      else if (this.state.tasksReviewerMonthsPast === CUSTOM_RANGE &&
-               prevState.tasksReviewerDateRange !== this.state.tasksReviewerDateRange) {
-        this.updateUserMetrics(this.props)
+        else if (this.state.tasksReviewerMonthsPast === CUSTOM_RANGE &&
+                prevState.tasksReviewerDateRange !== this.state.tasksReviewerDateRange) {
+          this.updateUserMetrics(this.props)
+        }
       }
     }
 

--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -132,38 +132,26 @@ export const WithUserMetrics = function(WrappedComponent, userProp) {
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if(prevProps[userProp]?.score){
-        if (prevProps[userProp]?.score !== this.props[userProp]?.score) {
+      const { userProp } = this.props
+    
+      if (prevProps[userProp]?.score) {
+        const scoreChanged = prevProps[userProp]?.score !== this.props[userProp]?.score
+        const { tasksCompletedMonthsPast, tasksReviewedMonthsPast, tasksReviewerMonthsPast,
+          tasksCompletedDateRange, tasksReviewedDateRange, tasksReviewerDateRange } = this.state
+    
+        if (scoreChanged) {
           this.updateAllMetrics(this.props)
-        }
-
-        else if (prevState.tasksReviewedMonthsPast !== this.state.tasksReviewedMonthsPast &&
-                this.state.tasksReviewedMonthsPast !== CUSTOM_RANGE) {
+        } else if (tasksReviewedMonthsPast !== CUSTOM_RANGE && (
+            prevState.tasksCompletedMonthsPast !== tasksCompletedMonthsPast ||
+            prevState.tasksReviewedMonthsPast !== tasksReviewedMonthsPast ||
+            prevState.tasksReviewerMonthsPast !== tasksReviewerMonthsPast
+          )) {
           this.updateUserMetrics(this.props)
-        }
-
-        else if (prevState.tasksReviewerMonthsPast !== this.state.tasksReviewerMonthsPast &&
-                this.state.tasksReviewerMonthsPast !== CUSTOM_RANGE) {
-          this.updateUserMetrics(this.props)
-        }
-
-        else if (prevState.tasksCompletedMonthsPast !== this.state.tasksCompletedMonthsPast &&
-                this.state.tasksCompletedMonthsPast !== CUSTOM_RANGE) {
-          this.updateUserMetrics(this.props)
-        }
-
-        else if (this.state.tasksCompletedMonthsPast === CUSTOM_RANGE &&
-                prevState.tasksCompletedDateRange !== this.state.tasksCompletedDateRange) {
-          this.updateUserMetrics(this.props)
-        }
-
-        else if (this.state.tasksReviewedMonthsPast === CUSTOM_RANGE &&
-                prevState.tasksReviewedDateRange !== this.state.tasksReviewedDateRange) {
-          this.updateUserMetrics(this.props)
-        }
-
-        else if (this.state.tasksReviewerMonthsPast === CUSTOM_RANGE &&
-                prevState.tasksReviewerDateRange !== this.state.tasksReviewerDateRange) {
+        } else if (tasksCompletedMonthsPast === CUSTOM_RANGE && (
+            prevState.tasksCompletedDateRange !== tasksCompletedDateRange ||
+            prevState.tasksReviewedDateRange !== tasksReviewedDateRange ||
+            prevState.tasksReviewerDateRange !== tasksReviewerDateRange
+          )) {
           this.updateUserMetrics(this.props)
         }
       }


### PR DESCRIPTION
Issue: Whenever a user navigates to the dashboard or user metrics page, the leaderboard gets fetched every time something in the page renders. On the default dashboard layout, this happens 12 times.

Solution: Remove the condition that was true every time, and replace it with a condition checking if a users points exist, and that they have changed since the previous render so that we don't fetch user metrics for users with no metrics, and also dont continue to fetch metrics over and over again for users that do have points.