### PR TITLE
disable TopChallenges, and Leaderboard relate features that are broken

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,10 @@ import Profile from './pages/Profile/Profile'
 import Metrics from './pages/Metrics/Metrics'
 import Dashboard from './pages/Dashboard/Dashboard.js'
 import Leaderboard from './pages/Leaderboard/Leaderboard'
-import ChallengeLeaderboard from './pages/Leaderboard/ChallengeLeaderboard'
-import ProjectLeaderboard from './pages/Leaderboard/ProjectLeaderboard'
-import CountryLeaderboard from './pages/Leaderboard/CountryLeaderboard'
+// Disable Pages till leaderboards support unique queries
+// import ChallengeLeaderboard from './pages/Leaderboard/ChallengeLeaderboard'
+// import ProjectLeaderboard from './pages/Leaderboard/ProjectLeaderboard'
+// import CountryLeaderboard from './pages/Leaderboard/CountryLeaderboard'
 import ChallengePane from './components/ChallengePane/ChallengePane'
 import ChallengeDetail from './components/ChallengeDetail/ChallengeDetail'
 import ProjectDetail from './components/ProjectDetail/ProjectDetail'
@@ -136,9 +137,10 @@ export class App extends Component {
             <CachedRoute path='/teams' component={Teams} />
             <CachedRoute path='/social' component={Social} />
             <CachedRoute path='/activity' component={GlobalActivity} />
-            <CachedRoute path='/challenge/:challengeId/leaderboard' component={ChallengeLeaderboard} />
+            {/* Disable Pages till leaderboards support unique queries */}
+            {/* <CachedRoute path='/challenge/:challengeId/leaderboard' component={ChallengeLeaderboard} />
             <CachedRoute path='/project/:projectId/leaderboard' component={ProjectLeaderboard} />
-            <CachedRoute path='/country/:countryCode/leaderboard' component={CountryLeaderboard} />
+            <CachedRoute path='/country/:countryCode/leaderboard' component={CountryLeaderboard} /> */}
             <CachedRoute path='/challenge/:challengeId/task/:taskId/inspect' component={InspectTask} />
             <CachedRoute path='/challenge/:challengeId/task/:taskId/review' component={CurrentReviewTaskPane} />
             <CachedRoute path='/challenge/:challengeId/task/:taskId/meta-review' component={CurrentMetaReviewTaskPane}/>

--- a/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard.js
+++ b/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard.js
@@ -12,11 +12,16 @@ import messages from './Messages'
 
 export default class ChallengeOwnerLeaderboard extends Component {
   render() {
+    const userType = this.props.userType
+
+    if(userType === "mapper") return (
+      <div className="mr-mt-8 mr-text-red"> <FormattedMessage {...messages.challengeOwnerLeaderboardDisabled}/></div>
+   )
+
     if (!this.props.leaderboard) {
       return null
     }
 
-    const userType = this.props.userType
 
     const showNumberTasks = this.props.leaderboard.length > 0 ?
       this.props.leaderboard[0].completedTasks > 0 : false

--- a/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/Messages.js
+++ b/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/Messages.js
@@ -14,6 +14,11 @@ export default defineMessages({
     defaultMessage: "# Tasks",
   },
 
+  challengeOwnerLeaderboardDisabled: {
+    id: "ChallengeOwnerLeaderboard.challengeOwnerLeaderboardDisabled.label",
+    defaultMessage: "Sorry, mapper results for this leaderboard are currently disabled.",
+  },
+
   reviewsCompletedLabel: {
     id: "ChallengeOwnerLeaderboard.reviewsCompleted.label",
     defaultMessage: "# Reviews",

--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -9,9 +9,9 @@ import ChallengeOwnerLeaderboard
        from '../../ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard'
 import PastDurationSelector
        from '../../../../PastDurationSelector/PastDurationSelector'
-//CURRENT_MONTH, and CUSTOM_RANGE removed untill endpoint can handle unique params
-// import { CURRENT_MONTH, CUSTOM_RANGE }
-//        from '../../../../PastDurationSelector/PastDurationSelector'
+// CURRENT_MONTH removed untill endpoint can handle unique params
+import { CUSTOM_RANGE }
+       from '../../../../PastDurationSelector/PastDurationSelector'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
 import { USER_TYPE_MAPPER, USER_TYPE_REVIEWER }
        from '../../../../../services/Leaderboard/Leaderboard'

--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -9,8 +9,9 @@ import ChallengeOwnerLeaderboard
        from '../../ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard'
 import PastDurationSelector
        from '../../../../PastDurationSelector/PastDurationSelector'
-import { CURRENT_MONTH, CUSTOM_RANGE }
-       from '../../../../PastDurationSelector/PastDurationSelector'
+//CURRENT_MONTH, and CUSTOM_RANGE removed untill endpoint can handle unique params
+// import { CURRENT_MONTH, CUSTOM_RANGE }
+//        from '../../../../PastDurationSelector/PastDurationSelector'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
 import { USER_TYPE_MAPPER, USER_TYPE_REVIEWER }
        from '../../../../../services/Leaderboard/Leaderboard'
@@ -84,7 +85,8 @@ export default class LeaderboardWidget extends Component {
     const selector =
       <PastDurationSelector
         className="mr-button mr-button--green-lighter mr-button--small mr-dropdown--right"
-        pastMonthsOptions={[CURRENT_MONTH, 1, 3, 6, 12, CUSTOM_RANGE]}
+        // CURRENT_MONTH, and CUSTOM_RANGE removed untill endpoint can handle unique params
+        pastMonthsOptions={[1, 3, 6, 12]}
         currentMonthsPast={monthsPast}
         selectDuration={this.setMonthsPast}
         selectCustomRange={this.setDateRange}

--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -10,7 +10,7 @@ import ChallengeOwnerLeaderboard
 import PastDurationSelector
        from '../../../../PastDurationSelector/PastDurationSelector'
 // CURRENT_MONTH removed untill endpoint can handle unique params
-import { CUSTOM_RANGE }
+import { CUSTOM_RANGE } 
        from '../../../../PastDurationSelector/PastDurationSelector'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
 import { USER_TYPE_MAPPER, USER_TYPE_REVIEWER }

--- a/src/components/CardChallenge/CardChallenge.js
+++ b/src/components/CardChallenge/CardChallenge.js
@@ -140,14 +140,15 @@ export class CardChallenge extends Component {
                   year='numeric' month='long' day='2-digit'
                 />
               </li>
-              <li>
+              {/* Disable Link tell project leaderboard page is reimplemented */}
+              {/* <li>
                 <Link
                   className="mr-text-green-lighter hover:mr-text-white"
                   to={`/challenge/${this.props.challenge.id}/leaderboard`}
                 >
                   <FormattedMessage {...messages.viewLeaderboard} />
                 </Link>
-              </li>
+              </li> */}
             </ol>
            }
 

--- a/src/components/CardProject/CardProject.js
+++ b/src/components/CardProject/CardProject.js
@@ -43,7 +43,8 @@ export class CardProject extends Component {
 
         {this.props.isExpanded &&
          <div className="mr-card-project__content">
-           <ol className="mr-card-project__meta">
+           {/* Disable Link tell project leaderboard page is reimplemented */}
+           {/* <ol className="mr-card-project__meta">
              <li>
                <Link
                  className="mr-text-green-lighter hover:mr-text-white"
@@ -52,7 +53,7 @@ export class CardProject extends Component {
                  <FormattedMessage {...messages.viewLeaderboard} />
                </Link>
              </li>
-           </ol>
+           </ol> */}
 
            <div className="mr-card-project__description">
              <MarkdownContent markdown={this.props.project.description} />

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -569,14 +569,15 @@ export class ChallengeDetail extends Component {
                           day="2-digit"
                         />
                       </li>
-                      <li>
+                      {/* Disable Link tell project leaderboard page is reimplemented */}
+                      {/* <li>
                         <Link
                           className="mr-text-green-lighter hover:mr-text-white"
                           to={`/challenge/${challenge.id}/leaderboard`}
                         >
                           <FormattedMessage {...messages.viewLeaderboard} />
                         </Link>
-                      </li>
+                      </li> */}
                       <div className="mr-mb-3" />
                       {this.renderDetailTabs()}
                     </ol>

--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { FormattedMessage, FormattedDate, injectIntl } from 'react-intl'
+//reimplement when DurationButtons are reimplemented
+//FormattedDate
+import { FormattedMessage, injectIntl } from 'react-intl'
 import _map from 'lodash/map'
 import Dropdown from '../Dropdown/Dropdown'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'

--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -125,16 +125,18 @@ const DurationButton = function(props) {
           {props.currentMonthsPast > CURRENT_MONTH &&
             <FormattedMessage {...messages.pastMonthsOption}
                               values={{months: props.currentMonthsPast}} />}
-          {props.currentMonthsPast === CURRENT_MONTH &&
-            <FormattedMessage {...messages.currentMonthOption} />}
+          {/* Disable until the leaderboard can handle unique params */}
+          {/* {props.currentMonthsPast === CURRENT_MONTH &&
+            <FormattedMessage {...messages.currentMonthOption} />} */}
           {props.currentMonthsPast === ALL_TIME &&
             <FormattedMessage {...messages.allTimeOption} />}
-          {props.currentMonthsPast <= CUSTOM_RANGE &&
+          {/* Disable until the leaderboard can handle unique params */}
+          {/* {props.currentMonthsPast <= CUSTOM_RANGE &&
             <React.Fragment>
               <FormattedDate value={props.customStartDate} /> -
               <FormattedDate value={props.customEndDate} />
             </React.Fragment>
-          }
+          } */}
         </span>
         <SvgSymbol
           sym="icon-cheveron-down"
@@ -151,9 +153,11 @@ const ListDurationItems = function(props) {
     <li key={months}>
       <a onClick={() => props.pickDuration(months, props.closeDropdown)}>
         {months > CURRENT_MONTH  && <FormattedMessage {...messages.pastMonthsOption} values={{months}} />}
-        {months === CURRENT_MONTH  && <FormattedMessage {...messages.currentMonthOption} />}
+        {/* Disable until the leaderboard can handle unique params */}
+        {/* {months === CURRENT_MONTH  && <FormattedMessage {...messages.currentMonthOption} />} */}
         {months === ALL_TIME  && <FormattedMessage {...messages.allTimeOption} />}
-        {months <= CUSTOM_RANGE  && <FormattedMessage {...messages.customRangeOption} />}
+        {/* Disable until the leaderboard can handle unique params */}
+        {/* {months <= CUSTOM_RANGE  && <FormattedMessage {...messages.customRangeOption} />} */}
       </a>
     </li>
   ))

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -113,7 +113,8 @@ export class ProjectDetail extends Component {
                       <FormattedDate value={parse(project.modified)}
                                       year='numeric' month='long' day='2-digit' />
                     </li>
-                    {_get(this.props, 'challenges.length', 0) > 0 &&
+                    {/* Disable Link tell project leaderboard page is reimplemented */}
+                    {/* {_get(this.props, 'challenges.length', 0) > 0 &&
                       <li>
                         <Link
                           className="mr-text-green-lighter hover:mr-text-white"
@@ -122,7 +123,7 @@ export class ProjectDetail extends Component {
                           <FormattedMessage {...messages.viewLeaderboard} />
                         </Link>
                       </li>
-                    }
+                    } */}
                   </ol>
 
                   <div className="mr-card-challenge__description">

--- a/src/components/TopUserChallenges/Messages.js
+++ b/src/components/TopUserChallenges/Messages.js
@@ -14,6 +14,11 @@ export default defineMessages({
     defaultMessage: "Your Top Challenges",
   },
 
+  topChallengesDisabled: {
+    id: "TopUserChallenges.topChallengesDisabled.label",
+    defaultMessage: "Results for Top Challenges widget are currently disabled",
+  },
+
   noChallenges: {
     id: "TopUserChallenges.widget.noChallenges",
     defaultMessage: "No Challenges",

--- a/src/components/TopUserChallenges/TopUserChallengesWidget.js
+++ b/src/components/TopUserChallenges/TopUserChallengesWidget.js
@@ -28,29 +28,32 @@ const descriptor = {
 }
 
 export class TopUserChallengesWidget extends Component {
-  updateChallenges = monthsPast => {
-    this.props.fetchTopChallenges(
-      this.props.user.id,
-      subMonths(new Date(), monthsPast)
-    )
-  }
+  // Disable till related endpoint allows for unique values
 
-  currentMonthsPast = () => {
-    return this.props.widgetConfiguration.monthsPast || 1
-  }
 
-  setMonthsPast = monthsPast => {
-    if (this.props.widgetConfiguration.monthsPast !== monthsPast) {
-      this.props.updateWidgetConfiguration({monthsPast})
-      this.updateChallenges(monthsPast)
-    }
-  }
+  // updateChallenges = monthsPast => {
+  //   this.props.fetchTopChallenges(
+  //     this.props.user.id,
+  //     subMonths(new Date(), monthsPast)
+  //   )
+  // }
 
-  componentDidMount() {
-    if (this.props.user) {
-      this.updateChallenges(this.currentMonthsPast())
-    }
-  }
+  // currentMonthsPast = () => {
+  //   return this.props.widgetConfiguration.monthsPast || 1
+  // }
+
+  // setMonthsPast = monthsPast => {
+  //   if (this.props.widgetConfiguration.monthsPast !== monthsPast) {
+  //     this.props.updateWidgetConfiguration({monthsPast})
+  //     this.updateChallenges(monthsPast)
+  //   }
+  // }
+
+  // componentDidMount() {
+  //   if (this.props.user) {
+  //     this.updateChallenges(this.currentMonthsPast())
+  //   }
+  // }
 
   render() {
     return (
@@ -58,17 +61,18 @@ export class TopUserChallengesWidget extends Component {
         {...this.props}
         className="top-user-challenges-widget"
         widgetTitle={<FormattedMessage {...messages.header} />}
-        rightHeaderControls={
-          <PastDurationSelector
-            className={classNames(
-              "mr-button mr-button--small",
-              this.props.lightMode ? "mr-button--green" : "mr-button--green-lighter"
-            )}
-            pastMonthsOptions={[1, 3, 6, 12]}
-            currentMonthsPast={this.currentMonthsPast()}
-            selectDuration={this.setMonthsPast}
-          />
-        }
+        // Disable till related endpoint allows for unique values
+        // rightHeaderControls={
+        //   <PastDurationSelector
+        //     className={classNames(
+        //       "mr-button mr-button--small",
+        //       this.props.lightMode ? "mr-button--green" : "mr-button--green-lighter"
+        //     )}
+        //     pastMonthsOptions={[1, 3, 6, 12]}
+        //     currentMonthsPast={this.currentMonthsPast()}
+        //     selectDuration={this.setMonthsPast}
+        //   />
+        // }
       >
         <TopChallengeList {...this.props} />
       </QuickWidget>

--- a/src/components/TopUserChallenges/TopUserChallengesWidget.js
+++ b/src/components/TopUserChallenges/TopUserChallengesWidget.js
@@ -2,12 +2,12 @@ import React, { Component } from 'react'
   // Disable till TopUserChallengesWidget is reimplemented
 // import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
-import _map from 'lodash/map'
-import _get from 'lodash/get'
-import _compact from 'lodash/compact'
-import _isFinite from 'lodash/isFinite'
-import _isPlainObject from 'lodash/isPlainObject'
-import { Link } from 'react-router-dom'
+// import _map from 'lodash/map'
+// import _get from 'lodash/get'
+// import _compact from 'lodash/compact'
+// import _isFinite from 'lodash/isFinite'
+// import _isPlainObject from 'lodash/isPlainObject'
+// import { Link } from 'react-router-dom'
   // Disable till TopUserChallengesWidget is reimplemented
 // import subMonths from 'date-fns/sub_months'
 import { WidgetDataTarget, registerWidgetType }
@@ -77,7 +77,10 @@ export class TopUserChallengesWidget extends Component {
         //   />
         // }
       >
-        <TopChallengeList {...this.props} />
+        <div className="mr-text-red"> 
+          <FormattedMessage {...messages.topChallengesDisabled}/>
+        </div>
+        {/* <TopChallengeList {...this.props} /> */}
       </QuickWidget>
     )
   }
@@ -87,43 +90,43 @@ TopUserChallengesWidget.defaultProps = {
   lightMode: false,
 }
 
-const TopChallengeList = function(props) {
-  const challengeItems =
-    _compact(_map(_get(props, 'user.topChallenges', []), challenge => {
-      if (!_isFinite(_get(challenge, 'id'))) {
-        return null
-      }
+// const TopChallengeList = function(props) {
+//   const challengeItems =
+//     _compact(_map(_get(props, 'user.topChallenges', []), challenge => {
+//       if (!_isFinite(_get(challenge, 'id'))) {
+//         return null
+//       }
 
-      return (
-        <li key={challenge.id} className="mr-py-2">
-          <Link to={`/browse/challenges/${challenge.id}`}>
-            {challenge.name}
-          </Link>
-          {_isPlainObject(challenge.parent) && // virtual challenges don't have projects
-            <div className="mr-links-grey-light">
-              <Link
-                onClick={e => {e.stopPropagation()}}
-                to={`/browse/projects/${challenge.parent.id}`}
-              >
-                {challenge.parent.displayName || challenge.parent.name}
-              </Link>
-            </div>
-          }
-        </li>
-      )
-    }
-  ))
+//       return (
+//         <li key={challenge.id} className="mr-py-2">
+//           <Link to={`/browse/challenges/${challenge.id}`}>
+//             {challenge.name}
+//           </Link>
+//           {_isPlainObject(challenge.parent) && // virtual challenges don't have projects
+//             <div className="mr-links-grey-light">
+//               <Link
+//                 onClick={e => {e.stopPropagation()}}
+//                 to={`/browse/projects/${challenge.parent.id}`}
+//               >
+//                 {challenge.parent.displayName || challenge.parent.name}
+//               </Link>
+//             </div>
+//           }
+//         </li>
+//       )
+//     }
+//   ))
 
-  return (
-    challengeItems.length > 0 ?
-    <ol className="mr-list-reset mr-links-green-lighter">
-      {challengeItems}
-    </ol> :
-    <div className="mr-text-grey-lighter">
-      <FormattedMessage {...messages.noChallenges} />
-    </div>
-  )
-}
+//   return (
+//     challengeItems.length > 0 ?
+//     <ol className="mr-list-reset mr-links-green-lighter">
+//       {challengeItems}
+//     </ol> :
+//     <div className="mr-text-grey-lighter">
+//       <FormattedMessage {...messages.noChallenges} />
+//     </div>
+//   )
+// }
 
 registerWidgetType(TopUserChallengesWidget, descriptor)
 

--- a/src/components/TopUserChallenges/TopUserChallengesWidget.js
+++ b/src/components/TopUserChallenges/TopUserChallengesWidget.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import classNames from 'classnames'
+  // Disable till TopUserChallengesWidget is reimplemented
+// import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import _map from 'lodash/map'
 import _get from 'lodash/get'
@@ -7,12 +8,14 @@ import _compact from 'lodash/compact'
 import _isFinite from 'lodash/isFinite'
 import _isPlainObject from 'lodash/isPlainObject'
 import { Link } from 'react-router-dom'
-import subMonths from 'date-fns/sub_months'
+  // Disable till TopUserChallengesWidget is reimplemented
+// import subMonths from 'date-fns/sub_months'
 import { WidgetDataTarget, registerWidgetType }
        from '../../services/Widget/Widget'
 import QuickWidget from '../QuickWidget/QuickWidget'
-import PastDurationSelector
-       from '../PastDurationSelector/PastDurationSelector'
+  // Disable till TopUserChallengesWidget is reimplemented
+// import PastDurationSelector
+//        from '../PastDurationSelector/PastDurationSelector'
 import messages from './Messages'
 
 const descriptor = {

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -64,7 +64,10 @@ export const fetchLeaderboard = (numberMonths=null, onlyEnabled=true,
       return results
     } catch (error) {
       console.error('Error fetching leaderboard:', error)
-      dispatch(addError(AppErrors.leaderboard.fetchFailure))
+       //Prevent error modals on leaderboard widgets, and retain error modal on leaderboard page
+      if(!forProjects && !forChallenges){
+        dispatch(addError(AppErrors.leaderboard.fetchFailure))
+      }
       return []
     }
   }

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -425,56 +425,59 @@ export const fetchSavedChallenges = function(userId, limit=50) {
  * month is used.
  */
 export const fetchTopChallenges = function(userId, startDate, limit=5) {
-  return function(dispatch) {
-    // If no startDate given, default to past month.
-    const params = {
-      start: (startDate ? startOfDay(startDate) : startOfDay(subMonths(new Date(), 1))).toISOString(),
-      limit,
-    }
+  // Prevent endpont from being called till it can handle unique queries.
+  return
 
-    const variables = { userId }
+  // return function(dispatch) {
+  //   // If no startDate given, default to past month.
+  //   const params = {
+  //     start: (startDate ? startOfDay(startDate) : startOfDay(subMonths(new Date(), 1))).toISOString(),
+  //     limit,
+  //   }
 
-    const cachedTopChallenges = userCache.get(variables, params, USER_TOP_CHALLENGES);
+  //   const variables = { userId }
 
-    if (cachedTopChallenges) {
-      dispatch(receiveChallenges(cachedTopChallenges.challenges))
-      dispatch(receiveUsers(cachedTopChallenges.user))
+  //   const cachedTopChallenges = userCache.get(variables, params, USER_TOP_CHALLENGES);
 
-      return cachedTopChallenges.challenges
-    }
+  //   if (cachedTopChallenges) {
+  //     dispatch(receiveChallenges(cachedTopChallenges.challenges))
+  //     dispatch(receiveUsers(cachedTopChallenges.user))
 
-    return new Endpoint(
-      api.user.topChallenges, {
-        schema: [ challengeSchema() ],
-        variables,
-        params,
-      }
-    ).execute().then(normalizedChallenges => {
-      const challenges = _get(normalizedChallenges, 'entities.challenges')
-      const user = {id: userId, topChallenges: []}
+  //     return cachedTopChallenges.challenges
+  //   }
 
-      // Store the top challenge ids in order, sorted by user activity (descending)
-      if (_isObject(challenges)) {
-        user.topChallenges = _map(
-          _reverse(_sortBy(_toPairs(challenges), idAndChallenge => idAndChallenge[1].activity)),
-          idAndChallenge => parseInt(idAndChallenge[0], 10)
-        )
-      }
+  //   return new Endpoint(
+  //     api.user.topChallenges, {
+  //       schema: [ challengeSchema() ],
+  //       variables,
+  //       params,
+  //     }
+  //   ).execute().then(normalizedChallenges => {
+  //     const challenges = _get(normalizedChallenges, 'entities.challenges')
+  //     const user = {id: userId, topChallenges: []}
 
-      // Remove the user-specific activity score before adding this challenge
-      // to the general redux store.
-      _each(challenges, challenge => {
-        delete challenge.activity
-      })
+  //     // Store the top challenge ids in order, sorted by user activity (descending)
+  //     if (_isObject(challenges)) {
+  //       user.topChallenges = _map(
+  //         _reverse(_sortBy(_toPairs(challenges), idAndChallenge => idAndChallenge[1].activity)),
+  //         idAndChallenge => parseInt(idAndChallenge[0], 10)
+  //       )
+  //     }
 
-      userCache.set(variables, params, { challenges: normalizedChallenges.entities, user }, USER_TOP_CHALLENGES)
+  //     // Remove the user-specific activity score before adding this challenge
+  //     // to the general redux store.
+  //     _each(challenges, challenge => {
+  //       delete challenge.activity
+  //     })
 
-      dispatch(receiveChallenges(normalizedChallenges.entities))
-      dispatch(receiveUsers(simulatedEntities(user)))
+  //     userCache.set(variables, params, { challenges: normalizedChallenges.entities, user }, USER_TOP_CHALLENGES)
 
-      return normalizedChallenges
-    })
-  }
+  //     dispatch(receiveChallenges(normalizedChallenges.entities))
+  //     dispatch(receiveUsers(simulatedEntities(user)))
+
+  //     return normalizedChallenges
+  //   })
+  // }
 }
 
 /**


### PR DESCRIPTION
At the time of this pr, dynamic queries are disabled, which has led to many "broken" features. To limit the amount of errors users run into, this pull request will remove these broken features. Specifically, it involves disabling the following functionalities: the 'Top Challenges' widget, the fetch for top challenges on the user metrics page, the challenge leaderboard page, the project leaderboard page, custom ranges in dropdown menus, current month ranges in dropdown menus, and removing the error modals on leaderboard widgets.