### PR TITLE
fix map jumping bug

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -42,6 +42,7 @@ export class EnhancedMap extends ReactLeafletMap {
   animationHandle = null
   mapBoundsFitToLayer = false
   mapMoved = false
+  noInitialBoundsSet = true
 
   /**
    * Invoked after the user is finished altering the map bounds, either by
@@ -388,10 +389,10 @@ export class EnhancedMap extends ReactLeafletMap {
       this.props.animator.setAnimationFunction(this.animateFeatures)
     }
 
-    if (this.props.initialBounds && _isFinite(this.props.initialBounds.getNorth())) {
+    if (this.props.taskMarkers && this.noInitialBoundsSet && this.props.initialBounds && _isFinite(this.props.initialBounds.getNorth())) {
+      this.noInitialBoundsSet = false
       this.leafletElement.fitBounds(this.props.initialBounds)
-    }
-    else if (!this.props.center.equals(prevProps.center)) {
+    } else if (!this.props.center.equals(prevProps.center)) {
       this.leafletElement.panTo(this.props.center)
     }
 

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -285,7 +285,7 @@ export class TaskClusterMap extends Component {
 
   closeSearch = () => this.setState({searchOpen: false})
 
-  debouncedUpdateBounds = _debounce(this.props.updateBounds, 800)
+  debouncedUpdateBounds = _debounce(this.props.updateBounds, 500)
 
   spiderIfNeeded = (marker, allMarkers) => {
     if (this.state.spidered.has(marker.options.taskId)) {
@@ -744,6 +744,7 @@ export class TaskClusterMap extends Component {
         zoomControl={false} animate={false} worldCopyJump={true}
         onBoundsChange={this.updateBounds}
         justFitFeatures
+        taskMarkers={this.props.taskMarkers}
         onClick={() => this.unspider()}
         onZoomOrMoveStart={this.debouncedUpdateBounds.cancel}
       >


### PR DESCRIPTION
Bug: Whenever a user is using any of the maps, if they are repositioning the screen too frequently, it would "bounce" the screen back to one of the previous positions after markers updated. This pr fixes that issue by changing the condition to reset set the bounds after the markers are fetched so that that the bounds are only fetched on the very first fetch of task markers. This is in order to maintain the initial map bounds displaying the primary task.