### PR TITLE
fix bundle deletion on redirect bug

### DIFF
--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -116,6 +116,7 @@ const apiRoutes = (factory) => {
       fetchReviewClusters: factory.get("/taskCluster/review"),
       inCluster: factory.get("/tasksInCluster/:clusterId"),
       bundle: factory.post("/taskBundle"),
+      // resetBundle: factory.post("/taskBundle/reset"),
       deleteBundle: factory.delete("/taskBundle/:bundleId"),
       removeTaskFromBundle: factory.post("/taskBundle/:id/unbundle"),
       fetchBundle: factory.get("/taskBundle/:bundleId"),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -951,6 +951,27 @@ export const bundleTasks = function(taskIds, bundleTypeMismatch, bundleName="") 
     })
   }
 }
+// initialBundle, taskBundle props
+export const resetTaskBundle = function() {
+  return
+  // return function(dispatch) {
+  //   return new Endpoint(api.tasks.resetBundle, {
+  //     params: { initialBundle, taskBundle },
+  //   }).execute()
+  //     .then(results => {
+  //       return results
+  //     })
+  //     .catch(error => {
+  //       if (isSecurityError(error)) {
+  //         dispatch(ensureUserLoggedIn())
+  //           .then(() => dispatch(addError(AppErrors.user.unauthorized)))
+  //       } else {
+  //         dispatch(addError(AppErrors.task.bundleFailure))
+  //         console.log(error.response || error)
+  //       }
+  //     })
+  // }
+}
 
 export const deleteTaskBundle = function(bundleId, primaryTaskId) {
   return function(dispatch) {


### PR DESCRIPTION
Bug: Whenever a user redirected away from a task that was already bundled when the task started, the bundle would get destroyed.

Solution: Make it so the bundle can be initialized the componentDidMount, and reset the initial bundle on task id change so that bundles don't get deleted based on a previously looked at bundle.