### PR TITLE
bump to v3.14.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on
 This project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.14.12] - 2023-2-29
+Released with [maproulette-backend_v4.4.15](https://github.com/maproulette/maproulette-backend/releases/tag/v4.4.15)
+
+## What's Changed
+* fix bundle deletion on redirect bug by @CollinBeczak in https://github.com/maproulette/maproulette3/pull/2288
+
+**Full Changelog**: https://github.com/maproulette/maproulette3/compare/v3.14.11...v3.14.12
+
 ## [v3.14.11] - 2023-2-28
 Released with [maproulette-backend_v4.4.15](https://github.com/maproulette/maproulette-backend/releases/tag/v4.4.15)
 
@@ -15,7 +23,6 @@ Released with [maproulette-backend_v4.4.15](https://github.com/maproulette/mapro
 * Fix handler looping issue with leaderboard fetching by @CollinBeczak in https://github.com/maproulette/maproulette3/pull/2284
 
 **Full Changelog**: https://github.com/maproulette/maproulette3/compare/v3.14.10...v3.14.11
-
 
 ## [v3.14.10] - 2023-2-19
 Released with [maproulette-backend_v4.4.14](https://github.com/maproulette/maproulette-backend/releases/tag/v4.4.14)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maproulette3",
-  "version": "3.14.11",
+  "version": "3.14.12",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.5.4",


### PR DESCRIPTION
## What's Changed
* fix bundle deletion on redirect bug by @CollinBeczak in https://github.com/maproulette/maproulette3/pull/2288

**Full Changelog**: https://github.com/maproulette/maproulette3/compare/v3.14.11...v3.14.12
Released with: [maproulette-backend_v4.4.15](https://github.com/maproulette/maproulette-backend/releases/tag/v4.4.15)

