### PR TITLE
add view challenge button in task read only modes completion widget

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { FormattedMessage, injectIntl } from 'react-intl'
+import { Link } from "react-router-dom";
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import _pick from 'lodash/pick'
@@ -425,8 +426,15 @@ export class ActiveTaskControls extends Component {
           />
 
           {this.props.taskReadOnly ?
-           <div className="mr-mt-4 mr-text-lg mr-text-pink-light">
-            <FormattedMessage {...messages.readOnly} />
+           <div>
+             <div className="mr-mt-4 mr-text-lg mr-text-pink-light">
+               <FormattedMessage {...messages.readOnly} />
+             </div>
+             <Link to={`/browse/challenges/${this.props.challengeId}`}>
+               <button className="mr-mt-4 mr-button">
+                 <FormattedMessage {...messages.browseChallenge} />
+               </button>
+             </Link>
            </div> :
            <React.Fragment>
              {AsCooperativeWork(this.props.task).isTagType() && (!isFinal || needsRevised) && this.props.user.settings.seeTagFixSuggestions &&

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
@@ -24,6 +24,11 @@ export default defineMessages({
     defaultMessage: "Previewing task in read-only mode",
   },
 
+  browseChallenge: {
+    id: 'Task.browseChallenge.message',
+    defaultMessage: "View Challenge",
+  },
+
   viewChangesetLabel: {
     id: "Task.controls.viewChangeset.label",
     defaultMessage: "View Changeset",


### PR DESCRIPTION
Add view challenge button to read only mode. Because that widget is used for navigation by users frequently, it always throws me off whenever i don't see an option to navigate, so i added this view challenge button when the user is in read only mode. This also helps with testing allowing for faster navigation, and makes it easier for developers to understand what status that widget is in based on the conditions for that button being visible.

<img width="512" alt="Screenshot 2024-02-29 at 9 25 05 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/2d73cb49-ff75-4471-b5d5-b22d9d2e348a">
