### PR TITLE
add condition that checks that projects display name exists

### DIFF
--- a/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.js
+++ b/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.js
@@ -70,15 +70,14 @@ const CandidateProjectList = function(props) {
     }
 
     let index = 0
-    if (searchQuery) {
+    if (searchQuery && project.displayName) {
       const displayNameLower = project.displayName.toLowerCase()
       const searchQueryLower = searchQuery.toLowerCase()
       if (displayNameLower.startsWith(searchQueryLower)) {
         index = 3
       } else if (displayNameLower.includes(searchQueryLower)) {
         index = 2
-      }
-       else {
+      } else {
         const similarity = levenshtein(searchQueryLower, displayNameLower)
         if (similarity > 0 && similarity < 4) {
           index = 1 


### PR DESCRIPTION
Some older projects don't have a display name, so when the project list was filtered in the "Move challenges" project modal, it would throw an error because you cannot run ".toLowercase()" on an undefined variable.