### PR TITLE
fix map recentering issue

### DIFF
--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -698,7 +698,7 @@ export class TaskClusterMap extends Component {
     else if (this.props.initialBounds) {
       this.currentBounds = this.props.initialBounds
     }
-
+    const currentCenterpoint = AsMappableTask(this.props.task).calculateCenterPoint()
     let selectionKit = this.props.hideLasso === true ? null : (
       <>
         {this.props.showSelectMarkersInView && (
@@ -737,7 +737,7 @@ export class TaskClusterMap extends Component {
       <EnhancedMap
         ref={this.mapRef}
         className="mr-z-0"
-        center={latLng(0, 0)}
+        center={currentCenterpoint}
         zoom={this.currentZoom} minZoom={MIN_ZOOM} maxZoom={MAX_ZOOM}
         setInitialBounds={false}
         initialBounds = {this.currentBounds}

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { ZoomControl, ScaleControl, Marker, LayerGroup, Rectangle, Polyline, Pane, Tooltip }
        from 'react-leaflet'
-import { latLng } from 'leaflet'
 import bbox from '@turf/bbox'
 import bboxPolygon from '@turf/bbox-polygon'
 import distance from '@turf/distance'


### PR DESCRIPTION
With the fix of the map jumping bug, a new issue was created where when the user goes between tasks, the map bounds isn't updated to the current tasks map bounds, so the user sees no tasks. This pr fixes that.