### PR TITLE
fix initial zoom on tasks

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -393,6 +393,7 @@ export class EnhancedMap extends ReactLeafletMap {
       this.noInitialBoundsSet = false
       this.leafletElement.fitBounds(this.props.initialBounds)
     } else if (!this.props.center.equals(prevProps.center)) {
+      this.fitBoundsToLayer()
       this.leafletElement.panTo(this.props.center)
     }
 


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2243
Issue: Whenever a users completes transitions from one task to another, the zoom levels do not change. An example where this is an issue is when the user is working on a small road, they are zoomed in really far to see the entire feature, but if they were to go to the next task and its a massive road, they would be zoomed in way too far, and sometimes this would result in them seeing no data if the road curved around the center point.
Solution: Whenever the center point changes ( This only happens whenever the task changes ), the initial zoom will be reset to cover all the features in the task.