### PR TITLE
support user-friendly task identifier in search result markers

### DIFF
--- a/src/components/ChallengePane/Messages.js
+++ b/src/components/ChallengePane/Messages.js
@@ -4,9 +4,34 @@ import { defineMessages } from 'react-intl'
  * Internationalized messages for use with ChallengePane
  */
 export default defineMessages({
-  startChallengeLabel: {
-    id: "ChallengePane.controls.startChallenge.label",
-    defaultMessage: "Start Challenge"
+  taskInfoLabel: {
+    id: "ChallengePane.controls.taskInfo.label",
+    defaultMessage: "Task Info:"
+  },
+  
+  challengeNameLabel: {
+    id: "ChallengePane.controls.challengeName.label",
+    defaultMessage: "Challenge Name:"
+  },
+
+  challengeIdLabel: {
+    id: "ChallengePane.controls.challengeId.label",
+    defaultMessage: "Challenge Id:"
+  },
+
+  taskNameLabel: {
+    id: "ChallengePane.controls.taskName.label",
+    defaultMessage: "Task Name:"
+  },
+
+  taskIdLabel: {
+    id: "ChallengePane.controls.taskId.label",
+    defaultMessage: "Task Id:"
+  },
+
+  startTaskLabel: {
+    id: "ChallengePane.controls.startTask.label",
+    defaultMessage: "Start Task"
   },
 
   showArchivedLabel: {

--- a/src/components/ChallengePane/TaskChallengeMarkerContent.js
+++ b/src/components/ChallengePane/TaskChallengeMarkerContent.js
@@ -17,24 +17,31 @@ class TaskChallengeMarkerContent extends Component {
     }
 
     return (
-      <div className="marker-popup-content">
-        <h3>
-          <a onClick={() => this.props.history.push(
-            `/browse/challenges/${challengeId}`
-          )}>
-            {markerData.options.parentName || _get(this.props.task, 'parent.name')}
-          </a>
+      <div>
+        <h3 >
+          <div className="mr-text-left mr-text-grey">
+            <h4>{this.props.intl.formatMessage(messages.taskInfoLabel)}</h4>
+            <div className="mr-text-sm">
+      
+              {this.props.intl.formatMessage(messages.taskNameLabel)} {markerData.options.name || _get(this.props.task, 'name')}
+              <br />
+            {this.props.intl.formatMessage(messages.taskIdLabel)}   <a onClick={() => {
+              this.props.startChallengeWithTask(challengeId, false, markerData.options.taskId)
+            }}>{markerData.options.id || _get(this.props.task, 'id')}</a>
+              <br />
+              {this.props.intl.formatMessage(messages.challengeNameLabel)} {markerData.options.parentName || _get(this.props.task, 'parent.name')}
+              <br />
+              {this.props.intl.formatMessage(messages.challengeIdLabel)} <a onClick={() => this.props.history.push(`/browse/challenges/${challengeId}`)}>{markerData.options.parentId || _get(this.props.task, 'parent.id')}</a>
+            </div>
+          </div>
         </h3>
 
         <div className="marker-popup-content__links">
           <div>
             <a onClick={() => {
-              this.props.startChallengeWithTask(
-                challengeId,
-                false,
-                markerData.options.taskId)
+              this.props.startChallengeWithTask(challengeId, false, markerData.options.taskId)
             }}>
-              {this.props.intl.formatMessage(messages.startChallengeLabel)}
+              {this.props.intl.formatMessage(messages.startTaskLabel)} {markerData.options.id || _get(this.props.task, 'id')}
             </a>
           </div>
         </div>


### PR DESCRIPTION
resolves: https://github.com/maproulette/maproulette3/issues/951

example of what the change will look like.
<img width="503" alt="Screenshot 2024-04-17 at 4 59 46 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/de0a10e0-2cfb-4ced-928d-e2f8224b5add">

The task name will be the same as the value located in the feature id column in the task analysis tables. The value used in the column is the name property in the tasks object.

Examples of possible names:

<img width="399" alt="Screenshot 2024-04-17 at 5 03 18 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/4467957a-65a5-409b-859e-a8ac56e4a932">

<img width="431" alt="Screenshot 2024-04-17 at 5 04 33 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/11b9aae3-2649-4e68-8dd0-9dfb8a8aff1a">
