### PR TITLE
*make changset description mandatory and fix instruction length condition in challenge editor

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/OSMCommitSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/OSMCommitSchema.js
@@ -36,6 +36,7 @@ export const jsSchema = (
     $schema: "http://json-schema.org/draft-07/schema#",
     type: "object",
     properties,
+    required: ["checkinComment"],
   };
 
   // For new challenges, offer option to toggle #maproulette tag on commit comment.
@@ -75,13 +76,7 @@ export const uiSchema = (
   extraErrors,
   options = {}
 ) => {
-  const isCollapsed =
-    options.longForm && (options.collapsedGroups || []).indexOf(STEP_ID) === -1;
-  const toggleCollapsed =
-    options.longForm && options.toggleCollapsed
-      ? () => options.toggleCollapsed(STEP_ID)
-      : undefined;
-
+ 
   const uiSchemaFields = {
     "ui:order": [
       "checkinComment",
@@ -91,20 +86,16 @@ export const uiSchema = (
     checkinComment: {
       "ui:emptyValue": "",
       "ui:help": intl.formatMessage(messages.checkinCommentDescription),
-      "ui:collapsed": isCollapsed,
-      "ui:toggleCollapsed": toggleCollapsed,
       "ui:groupHeader": options.longForm
         ? intl.formatMessage(messages.osmCommitStepHeader)
         : undefined,
     },
     checkinSource: {
-      "ui:help": intl.formatMessage(messages.checkinSourceDescription),
-      "ui:collapsed": isCollapsed,
+      "ui:help": intl.formatMessage(messages.checkinSourceDescription)
     },
     includeCheckinHashtag: {
       "ui:field": "columnRadio",
-      "ui:help": intl.formatMessage(messages.includeCheckinHashtagDescription),
-      "ui:collapsed": isCollapsed,
+      "ui:help": intl.formatMessage(messages.includeCheckinHashtagDescription)
     }
   };
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/WorkflowSteps.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/WorkflowSteps.js
@@ -179,19 +179,22 @@ const newChallengeSteps = {
     previous: 'DataSource',
   }),
   'Instructions': Object.assign({}, instructionsStep, {
-    next: 'AutomatedEditsCodeAgreement',
+    next: 'OSMCommit',
     previous: 'Description',
+  }),
+  'OSMCommit': Object.assign({}, osmCommitStep, { 
+    next: 'AutomatedEditsCodeAgreement',
+    previous: 'Instructions',
   }),
   'AutomatedEditsCodeAgreement': Object.assign({}, automatedEditsCodeAgreementStep, {
     next: 'AdvancedOptions',
-    previous: 'Instructions'
+    previous: 'OSMCommit',
   }),
   'AdvancedOptions': Object.assign({}, advancedOptionsStep, {
     next: [
       'Discoverability',
       'Priorities',
       'Zoom',
-      'OSMCommit',
       'Basemap',
       'Properties',
       'Tags',
@@ -211,11 +214,6 @@ const newChallengeSteps = {
     canFinish: true,
   }),
   'Zoom': Object.assign({}, zoomStep, {
-    next: 'AdvancedOptions',
-    previous: 'AdvancedOptions',
-    canFinish: true,
-  }),
-  'OSMCommit': Object.assign({}, osmCommitStep, {
     next: 'AdvancedOptions',
     previous: 'AdvancedOptions',
     canFinish: true,
@@ -249,10 +247,10 @@ const editChallengeSteps = {
       'DataSource',
       'Description',
       'Instructions',
+      'OSMCommit',
       'Discoverability',
       'Priorities',
       'Zoom',
-      'OSMCommit',
       'Basemap',
       'Properties',
       'Tags',
@@ -276,6 +274,11 @@ const editChallengeSteps = {
     previous: 'AllOptions',
     canFinish: true,
   }),
+  'OSMCommit': Object.assign({}, osmCommitStep, {
+    next: 'AllOptions',
+    previous: 'AllOptions',
+    canFinish: true,
+  }),
   'Discoverability': Object.assign({}, discoverabilityStep, {
     next: 'AllOptions',
     previous: 'AllOptions',
@@ -287,11 +290,6 @@ const editChallengeSteps = {
     canFinish: true,
   }),
   'Zoom': Object.assign({}, zoomStep, {
-    next: 'AllOptions',
-    previous: 'AllOptions',
-    canFinish: true,
-  }),
-  'OSMCommit': Object.assign({}, osmCommitStep, {
     next: 'AllOptions',
     previous: 'AllOptions',
     canFinish: true,

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1041,10 +1041,12 @@ export const fetchChallenges = function (
       const {
         instruction,
         description,
-        name
+        name,
+        checkinComment
       } = challengeData;
 
       const instructionsMinLength = process.env.REACT_APP_CHALLENGE_INSTRUCTIONS_MIN_LENGTH || 150
+      debugger
       if (
         challengeData.parent != undefined && 
         (
@@ -1052,7 +1054,9 @@ export const fetchChallenges = function (
           instruction.length < instructionsMinLength ||
           !description?.trim()?.length ||
           !name ||
-          name.length <= 3
+          name.length <= 3 ||
+          !checkinComment ||
+          checkinComment === '#maproulette'
         )
       ) {
         let errorMessage = '';
@@ -1063,10 +1067,12 @@ export const fetchChallenges = function (
           errorMessage = AppErrors.challengeSaveFailure.saveDescriptionFailure;
         } else if (
           instruction === undefined ||
-          instruction.length < 150
+          instruction.length < instructionsMinLength
         ) {
           errorMessage = AppErrors.challengeSaveFailure.saveInstructionsFailure;
           errorMessage.values = { minLength: `${instructionsMinLength}` };
+        } else if (checkinComment === undefined || checkinComment === '' || checkinComment === '#maproulette') {
+          errorMessage = AppErrors.challengeSaveFailure.saveChangesetDescriptionFailure;
         } else {
           errorMessage = AppErrors.challengeSaveFailure.saveDetailsFailure;
         }

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1046,7 +1046,6 @@ export const fetchChallenges = function (
       } = challengeData;
 
       const instructionsMinLength = process.env.REACT_APP_CHALLENGE_INSTRUCTIONS_MIN_LENGTH || 150
-      debugger
       if (
         challengeData.parent != undefined && 
         (

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -89,6 +89,7 @@ export default {
     saveNameFailure: messages.challengeSaveNameFailure,
     saveDescriptionFailure: messages.challengeSaveDescriptionFailure,
     saveInstructionsFailure: messages.challengeSaveInstructionFailure,
+    saveChangesetDescriptionFailure: messages.challengeSaveChangesetDescriptionFailure,
     saveEditPolicyAgreementFailure: messages.challengeSaveEditPolicyAgreementFailure,
   },
 

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -209,6 +209,10 @@ export default defineMessages({
     id: "Errors.challengeSaveFailure.challengeSaveInstructionFailure",
     defaultMessage: "The 'DETAILED INSTRUCTIONS FOR MAPPERS' field must have more than {minLength} characters.",
   },
+  challengeSaveChangesetDescriptionFailure: {
+    id: "Errors.challengeSaveFailure.challengeSaveChangesetDescriptionFailure",
+    defaultMessage: "The 'CHANGESET DESCRIPTION' field is required.",
+  },
   challengeSaveEditPolicyAgreementFailure: {
     id: "Errors.challengeSaveFailure.challengeSaveEditPolicyAgreementFailure",
     defaultMessage: "You must check the box at the bottom of the page to indicate that you acknowledge OpenStreetMap's Automated Edits code of conduct."


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/1756

This PR makes the changeset description mandatory. Changeset fields are also farther up on the ui order in the challenge editor. And error message pops up if the field is empty
Also fixed an issue with instructions length conditions in the form validator.
![image](https://github.com/maproulette/maproulette3/assets/165847490/94b6a60f-128a-449b-8720-f13876c40852)
