### PR TITLE
fix preferred tags prop undefined error

### DIFF
--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.js
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.js
@@ -150,8 +150,11 @@ export default class AutosuggestTextBox extends Component {
 
     // Filter preferredResults based on user input
     const filteredPreferredResults = preferredResults.filter((result) => {
-      const resultName = result.name || result.displayName
-      return resultName.toLowerCase().includes(this.props.inputValue.toLowerCase())
+      const resultName = result.name || result.displayName || result
+      if (typeof resultName === 'string') {
+        return resultName.toLowerCase().includes(this.props.inputValue.toLowerCase())
+      }
+      return false
     })
 
     searchResults = searchResults.filter(result => result?.id !== -999)


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2334

Issue: The result parameter often has a differing structure depending on where it is being used in the ui. This results in errors whenever the filter is expecting a string, but receives an undefined value due to the objects that are checked for not being available.

Solution: Account for prefered tags object structure, and add a condition that the resultName variable must be a type of String.