### PR TITLE
fix bundle button for normal users and disable bundling functionality  in read only mode

### DIFF
--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -80,7 +80,7 @@ export function WithTaskBundle(WrappedComponent) {
       const inReview = task?.reviewStatus === TaskReviewStatus.needed || task?.reviewStatus === TaskReviewStatus.disputed
       const invalidWorkspace = workspace?.name === "taskReview" || name === "taskReview"
       const completeStatus = (!inReview && !task?.reviewStatus !== 0) && ![0, 3, 6].includes(task?.status)
-      const bundleEditsDisabled = taskReadOnly || ( completeStatus || ((!user.isSuperUser) && (user.id !== task.completedBy || invalidWorkspace)))
+      const bundleEditsDisabled = taskReadOnly || ( completeStatus || ((!user.isSuperUser) && ((task.completedBy && user.id !== task.completedBy) || invalidWorkspace)))
 
       this.setState({ bundleEditsDisabled })
     }

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -119,6 +119,11 @@ export default class TaskBundleWidget extends Component {
       return
     }
     
+    //Ignore if in read only mode
+    if (this.props.taskReadOnly) {
+      return
+    }
+
     const shortcuts = this.props.keyboardShortcutGroups.taskEditing
     if (event.key === shortcuts.completeTogether.key) {
       this.bundleTasks()
@@ -482,7 +487,7 @@ const BuildBundle = props => {
   }
 
   const totalTaskCount = _get(props, 'taskInfo.totalCount') || _get(props, 'taskInfo.tasks.length')
-  const bundleButton = props.selectedTaskCount(totalTaskCount) > 1 &&  !props.bundleEditsDisabled ? (
+  const bundleButton = !props.taskReadOnly && props.selectedTaskCount(totalTaskCount) > 1 && !props.bundleEditsDisabled ? (
       <button
         className="mr-button mr-button--green-lighter mr-button--small"
         onClick={props.bundleTasks}


### PR DESCRIPTION
Issue fixed: Normal users would not be able to see the bundle button; only super users could. Also, the button still showed up in read-only mode, and the hotkeys also worked.