### PR TITLE
add challenge filtering on browse projects page

### DIFF
--- a/src/components/CardChallenge/CardChallenge.js
+++ b/src/components/CardChallenge/CardChallenge.js
@@ -19,6 +19,7 @@ import Taxonomy from '../Taxonomy/Taxonomy'
 import ChallengeProgress from '../ChallengeProgress/ChallengeProgress'
 import BusySpinner from '../BusySpinner/BusySpinner'
 import messages from './Messages'
+import { isUsableChallengeStatus } from '../../services/Challenge/ChallengeStatus/ChallengeStatus'
 
 export class CardChallenge extends Component {
   render() {
@@ -55,7 +56,7 @@ export class CardChallenge extends Component {
       <article
         ref={node => this.node = node}
         className={classNames(
-          "mr-card-challenge",
+          `${isUsableChallengeStatus(this.props.challenge?.status) ? "mr-card-challenge" : "mr-card-challenge mr-bg-white-10"}`,
           this.props.className,
           {'is-active': this.props.isExpanded}
         )}
@@ -120,7 +121,7 @@ export class CardChallenge extends Component {
             }
           </div>
         </header>
-
+        {this.props.challenge?.status === 5 ? <FormattedMessage {...messages.completedChallengeLabel} /> : null}
         {this.props.isExpanded &&
          <div className="mr-card-challenge__content">
            {!this.props.challenge.isVirtual &&

--- a/src/components/CardChallenge/Messages.js
+++ b/src/components/CardChallenge/Messages.js
@@ -19,6 +19,11 @@ export default defineMessages({
     defaultMessage: "View Leaderboard",
   },
 
+  completedChallengeLabel: {
+    id: "Challenge.fields.completed.label",
+    defaultMessage: "Completed"
+  },
+
   vpListLabel: {
     id: "Challenge.fields.vpList.label",
     defaultMessage: "Also in matching virtual {count,plural, one{project} other{projects}}:"

--- a/src/components/ChallengePane/ChallengeFilterSubnav/ProjectFilterSubnav.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/ProjectFilterSubnav.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react'
+import { FormattedMessage, injectIntl } from 'react-intl'
+import WithChallengeSearch from '../../HOCs/WithSearch/WithChallengeSearch'
+import FilterByDifficulty from './FilterByDifficulty'
+import FilterByKeyword from './FilterByKeyword'
+import FilterByCategorizationKeywords from './FilterByCategorizationKeywords'
+import ClearFiltersControl from './ClearFiltersControl'
+import SortChallengesSelector from './SortChallengesSelector'
+import './ChallengeFilterSubnav.scss'
+import messages from './Messages'
+
+/**
+ * ProjectilterSubnav presents a navigation bar that contains options
+ * for filtering MapRoulette challenges within the project browse view.
+ *
+ * @see See FilterByDifficulty
+ * @see See FilterByKeyword
+ * @see See FilterByCategorizationKeywords
+ *
+ */
+export class ProjectilterSubnav extends Component {
+  clearFilters = () => {
+    this.props.clearSearchFilters()
+    this.props.clearSearch()
+  }
+
+  render() {
+    const filtersActive =
+      this.props.unfilteredChallenges?.length > this.props.challenges?.length
+
+    return (
+      <header className="mr-bg-black-10 mr-shadow mr-py-4 lg:mr-py-0 mr-px-6 mr-hidden lg:mr-flex mr-items-center mr-justify-between">
+        <div className="mr-flex-grow mr-flex mr-items-center mr-justify-between lg:mr-justify-start">
+          <h1 className="mr-hidden xl:mr-flex mr-text-3xl mr-leading-tight mr-font-normal mr-mr-6">
+            <FormattedMessage {...messages.header} />
+          </h1>
+
+          <div className="mr-flex mr-items-center">
+            <SortChallengesSelector {...this.props} />
+            <FilterByKeyword {...this.props} />
+            <FilterByDifficulty {...this.props} />
+            <FilterByCategorizationKeywords {...this.props} />
+          </div>
+
+          {filtersActive && (
+            <ClearFiltersControl clearFilters={this.clearFilters} />
+          )}
+        </div>
+      </header>
+    )
+  }
+}
+
+export default WithChallengeSearch(injectIntl(ProjectilterSubnav))

--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -110,13 +110,9 @@ export class ChallengeResultList extends Component {
         ? limitUserResults(challengeResultsUnbound)
         : challengeResultsUnbound;
   
-    const challengeResults = this.props.project?.id ? _filter(allChallenges, (challenge) => {
+    const challengeResults = this.props.project?.id && this.props.remainingChallengeOnly ? _filter(allChallenges, (challenge) => {
         return (isUsableChallengeStatus(challenge.status))
       }) : allChallenges
-  
-    const finishedChallengeResults = this.props.project?.id ? _filter(allChallenges, (challenge) => {
-        return (!isUsableChallengeStatus(challenge.status))
-      }) : []
   
     const uniqueParents = new Set();
 
@@ -281,7 +277,7 @@ export class ChallengeResultList extends Component {
     }
     
     let results = null
-    if (challengeResults.length === 0 && finishedChallengeResults.length == 0) {
+    if (challengeResults.length === 0) {
       if (!isFetching) {
         results = (
           <div className="mr-text-white mr-text-lg mr-pt-4">
@@ -306,32 +302,6 @@ export class ChallengeResultList extends Component {
           );
         }
       }))
-      if(finishedChallengeResults?.length > 0){
-        results.push(
-          <div className="mr-text-sm mr-text-yellow mr-uppercase mr-mb-4">
-          <FormattedMessage
-            {...messages.completedChallengeCount}
-            values={{
-              count: finishedChallengeResults.length,
-            }}
-          />
-        </div>,
-          ..._compact(_map(finishedChallengeResults, (result) => {
-            if (result.parent) {
-              return (
-                <ChallengeResultItem
-                  key={`challenge_${result.id}`}
-                  {...this.props}
-                  className="mr-mb-4"
-                  challenge={result}
-                  listRef={this.listRef}
-                  sort={search?.sort}
-                />
-              )
-            }
-          }))
-        )
-      }
     } else if (!this.props.excludeProjectResults && searchType === "projects" && projectResults) {
       results = _compact(_map(projectResults, (result) => {
           return (

--- a/src/components/ProjectDetail/Messages.js
+++ b/src/components/ProjectDetail/Messages.js
@@ -24,6 +24,16 @@ export default defineMessages({
     defaultMessage: "Manage",
   },
 
+  showRemaining: {
+    id: "ProjectDetails.management.controls.showRemaining.label",
+    defaultMessage: "Display Remaining Challenges",
+  },
+
+  showAll: {
+    id: "ProjectDetails.management.controls.showAll.label",
+    defaultMessage: "Display All Challenges",
+  },
+
   startLabel: {
     id: "ProjectDetails.management.controls.start.label",
     defaultMessage: "Start",

--- a/src/components/ProjectDetail/Messages.js
+++ b/src/components/ProjectDetail/Messages.js
@@ -24,11 +24,6 @@ export default defineMessages({
     defaultMessage: "Manage",
   },
 
-  showRemaining: {
-    id: "ProjectDetails.management.controls.showRemaining.label",
-    defaultMessage: "Display Remaining Challenges",
-  },
-
   showAll: {
     id: "ProjectDetails.management.controls.showAll.label",
     defaultMessage: "Display All Challenges",

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -33,6 +33,10 @@ const ProjectProgress = WithComputedMetrics(ChallengeProgress)
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
 export class ProjectDetail extends Component {
+  state = {
+    remainingChallengeOnly: true
+  }
+
   render() {
     const project = this.props.project
     if (!_isObject(project)) {
@@ -72,11 +76,15 @@ export class ProjectDetail extends Component {
                     isVirtual: this.props.project.isVirtual
                   }}
                 />
+              <button  className="mr-button mr-button--small mr-button--green-lighter mr-ml-4" onClick={() => this.setState({ remainingChallengeOnly: !this.state.remainingChallengeOnly })}>
+                { this.state.remainingChallengeOnly ? <FormattedMessage {...messages.showAll} /> : <FormattedMessage {...messages.showRemaining} />  }
+              </button>
               </div>
               <ChallengeResultList
                 unfilteredChallenges={this.props.challenges}
                 excludeProjectResults
                 excludeProjectId={this.props.project.id}
+                remainingChallengeOnly={this.state.remainingChallengeOnly}
                 {...this.props}
               />
             </div>

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -16,6 +16,9 @@ import WithStartChallenge from '../HOCs/WithStartChallenge/WithStartChallenge'
 import WithBrowsedChallenge from '../HOCs/WithBrowsedChallenge/WithBrowsedChallenge'
 import WithProject from '../HOCs/WithProject/WithProject'
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
+import ProjectFilterSubnav from '../ChallengePane/ChallengeFilterSubnav/ProjectFilterSubnav'
+import WithFilteredChallenges from '../HOCs/WithFilteredChallenges/WithFilteredChallenges'
+import WithChallengeSearch from '../HOCs/WithSearch/WithChallengeSearch'
 import WithComputedMetrics from '../AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics'
 import ChallengeResultList from '../ChallengePane/ChallengeResultList/ChallengeResultList'
 import { PROJECT_CHALLENGE_LIMIT } from '../../services/Project/Project'
@@ -56,104 +59,107 @@ export class ProjectDetail extends Component {
     )
 
     return (
-      <div className="mr-bg-gradient-r-green-dark-blue mr-text-white lg:mr-flex">
-        {!this.props.loadingChallenges &&
-          <div className="mr-pt-8 mr-pl-8">
-            <div className="mr-text-sm mr-text-yellow mr-uppercase mr-mb-4">
-              <FormattedMessage
-                {...messages.challengeCount}
-                values={{
-                  count: challengeResults.length,
-                  isVirtual: this.props.project.isVirtual
-                }}
+      <div className="mr-bg-gradient-r-green-dark-blue mr-text-white">
+        <ProjectFilterSubnav {...this.props} />
+        <div className="mr-bg-gradient-r-green-dark-blue mr-text-white lg:mr-flex">
+          {!this.props.loadingChallenges &&
+            <div className="mr-pt-8 mr-pl-8">
+              <div className="mr-text-sm mr-text-yellow mr-uppercase mr-mb-4">
+                <FormattedMessage
+                  {...messages.challengeCount}
+                  values={{
+                    count: challengeResults.length,
+                    isVirtual: this.props.project.isVirtual
+                  }}
+                />
+              </div>
+              <ChallengeResultList
+                unfilteredChallenges={this.props.challenges}
+                excludeProjectResults
+                excludeProjectId={this.props.project.id}
+                {...this.props}
               />
             </div>
-            <ChallengeResultList
-              unfilteredChallenges={this.props.challenges}
-              excludeProjectResults
-              excludeProjectId={this.props.project.id}
-              {...this.props}
-            />
-          </div>
-        }
-        {this.props.loadingChallenges && <BusySpinner />}
-        <div className="mr-flex-1">
-          <div className="mr-h-content mr-overflow-auto">
-            <div className="mr-max-w-md mr-mx-auto">
-              <div className="mr-pt-6 mr-px-8">
-                <div className="mr-mb-4">
-                  <button
-                    className="mr-text-green-lighter mr-text-sm hover:mr-text-white"
-                    onClick={() => this.props.history.goBack()}
-                  >
-                    &larr; <FormattedMessage {...messages.goBack} />
-                  </button>
-                </div>
-
-                <h1 className="mr-card-challenge__title">{project.displayName}</h1>
-                <div className="mr-card-challenge__content">
-                  <ol className="mr-card-challenge__meta">
-                    <li>
-                      <strong className="mr-text-yellow">
-                        <FormattedMessage
-                          {...messages.createdOnLabel}
-                        />
-                        :
-                      </strong>{' '}
-                      <FormattedDate value={parse(project.created)}
-                                      year='numeric' month='long' day='2-digit' />
-                    </li>
-                    <li>
-                      <strong className="mr-text-yellow">
-                        <FormattedMessage
-                          {...messages.modifiedOnLabel}
-                        />
-                        :
-                      </strong>{' '}
-                      <FormattedDate value={parse(project.modified)}
-                                      year='numeric' month='long' day='2-digit' />
-                    </li>
-                    {/* Disable Link tell project leaderboard page is reimplemented */}
-                    {/* {_get(this.props, 'challenges.length', 0) > 0 &&
-                      <li>
-                        <Link
-                          className="mr-text-green-lighter hover:mr-text-white"
-                          to={`/project/${project.id}/leaderboard`}
-                        >
-                          <FormattedMessage {...messages.viewLeaderboard} />
-                        </Link>
-                      </li>
-                    } */}
-                  </ol>
-
-                  <div className="mr-card-challenge__description">
-                    <MarkdownContent
-                      markdown={project.description}
-                    />
+          }
+          {this.props.loadingChallenges && <BusySpinner />}
+          <div className="mr-flex-1">
+            <div className="mr-h-content mr-overflow-auto">
+              <div className="mr-max-w-md mr-mx-auto">
+                <div className="mr-pt-6 mr-px-8">
+                  <div className="mr-mb-4">
+                    <button
+                      className="mr-text-green-lighter mr-text-sm hover:mr-text-white"
+                      onClick={() => this.props.history.goBack()}
+                    >
+                      &larr; <FormattedMessage {...messages.goBack} />
+                    </button>
                   </div>
 
-                  {this.props.challenges?.length > PROJECT_CHALLENGE_LIMIT 
-                    ?  <div className="mr-text-red">
-                        Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.
-                      </div>
-                    :  <ProjectProgress className="mr-my-4" {...this.props} />}
-                 
+                  <h1 className="mr-card-challenge__title">{project.displayName}</h1>
+                  <div className="mr-card-challenge__content">
+                    <ol className="mr-card-challenge__meta">
+                      <li>
+                        <strong className="mr-text-yellow">
+                          <FormattedMessage
+                            {...messages.createdOnLabel}
+                          />
+                          :
+                        </strong>{' '}
+                        <FormattedDate value={parse(project.created)}
+                                        year='numeric' month='long' day='2-digit' />
+                      </li>
+                      <li>
+                        <strong className="mr-text-yellow">
+                          <FormattedMessage
+                            {...messages.modifiedOnLabel}
+                          />
+                          :
+                        </strong>{' '}
+                        <FormattedDate value={parse(project.modified)}
+                                        year='numeric' month='long' day='2-digit' />
+                      </li>
+                      {/* Disable Link tell project leaderboard page is reimplemented */}
+                      {/* {_get(this.props, 'challenges.length', 0) > 0 &&
+                        <li>
+                          <Link
+                            className="mr-text-green-lighter hover:mr-text-white"
+                            to={`/project/${project.id}/leaderboard`}
+                          >
+                            <FormattedMessage {...messages.viewLeaderboard} />
+                          </Link>
+                        </li>
+                      } */}
+                    </ol>
 
-                  <ul className="mr-card-challenge__actions mr-mt-4 mr-leading-none mr-text-base">
-                    <li>
-                      {_get(this.props.user, 'settings.isReviewer') &&
-                        <Link
-                          className={classNames(
-                            "mr-text-green-lighter hover:mr-text-white mr-mr-4",
-                            {"mr-border-r-2 mr-border-white-10 mr-pr-4 mr-mr-4": manageControl})}
-                          to={`/review?projectId=${project.id}&projectName=${project.displayName}`}
-                        >
-                          <FormattedMessage {...messages.viewReviews} />
-                        </Link>
-                      }
-                      {manageControl}
-                    </li>
-                  </ul>
+                    <div className="mr-card-challenge__description">
+                      <MarkdownContent
+                        markdown={project.description}
+                      />
+                    </div>
+
+                    {this.props.challenges?.length > PROJECT_CHALLENGE_LIMIT 
+                      ?  <div className="mr-text-red">
+                          Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.
+                        </div>
+                      :  <ProjectProgress className="mr-my-4" {...this.props} />}
+                  
+
+                    <ul className="mr-card-challenge__actions mr-mt-4 mr-leading-none mr-text-base">
+                      <li>
+                        {_get(this.props.user, 'settings.isReviewer') &&
+                          <Link
+                            className={classNames(
+                              "mr-text-green-lighter hover:mr-text-white mr-mr-4",
+                              {"mr-border-r-2 mr-border-white-10 mr-pr-4 mr-mr-4": manageControl})}
+                            to={`/review?projectId=${project.id}&projectName=${project.displayName}`}
+                          >
+                            <FormattedMessage {...messages.viewReviews} />
+                          </Link>
+                        }
+                        {manageControl}
+                      </li>
+                    </ul>
+                  </div>
                 </div>
               </div>
             </div>
@@ -166,9 +172,13 @@ export class ProjectDetail extends Component {
 
 export default WithCurrentUser(
   WithProject(
-    WithStartChallenge(
-      WithBrowsedChallenge(
-        injectIntl(ProjectDetail)
+    WithChallengeSearch(
+      WithFilteredChallenges(
+        WithStartChallenge(
+          WithBrowsedChallenge(
+            injectIntl(ProjectDetail)
+          )
+        )
       )
     ), {includeChallenges: true}
   )

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -68,17 +68,25 @@ export class ProjectDetail extends Component {
         <div className="mr-bg-gradient-r-green-dark-blue mr-text-white lg:mr-flex">
           {!this.props.loadingChallenges &&
             <div className="mr-pt-8 mr-pl-8">
-              <div className="mr-text-sm mr-text-yellow mr-uppercase mr-mb-4">
-                <FormattedMessage
-                  {...messages.challengeCount}
-                  values={{
-                    count: challengeResults.length,
-                    isVirtual: this.props.project.isVirtual
-                  }}
-                />
-              <button  className="mr-button mr-button--small mr-button--green-lighter mr-ml-4" onClick={() => this.setState({ remainingChallengeOnly: !this.state.remainingChallengeOnly })}>
-                { this.state.remainingChallengeOnly ? <FormattedMessage {...messages.showAll} /> : <FormattedMessage {...messages.showRemaining} />  }
-              </button>
+              <div className="mr-flex mr-mb-4">
+                <div className="mr-text-sm mr-text-yellow mr-uppercase mr-my-auto">
+                  <FormattedMessage
+                    {...messages.challengeCount}
+                    values={{
+                      count: challengeResults.length,
+                      isVirtual: this.props.project.isVirtual
+                    }}
+                  />
+                </div>
+                <div className="mr-my-auto">
+                  <input
+                    type="checkbox"
+                    className="mr-checkbox-toggle mr-ml-4"
+                    checked={!this.state.remainingChallengeOnly}
+                    onChange={() => this.setState({ remainingChallengeOnly: !this.state.remainingChallengeOnly })}
+                  />
+                  <label className="mr-text-white mr-ml-1 mr-text-sm"><FormattedMessage {...messages.showAll} /></label>
+                </div>
               </div>
               <ChallengeResultList
                 unfilteredChallenges={this.props.challenges}


### PR DESCRIPTION
<img width="1672" alt="Screenshot 2024-05-20 at 12 23 01 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/642bee6d-4e73-4c36-ae26-108141644066">
Resolves feature request to add sorting and filtering to the challenges in the browse projects page.