### PR TITLE
fix undefined prop bug in task editor

### DIFF
--- a/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
+++ b/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
@@ -65,7 +65,9 @@ export class EditTask extends Component {
     }
     else {
       const challengeState = _cloneDeep(this.challengeState)
-      challengeState.refreshAfterSave = true
+      if (challengeState) {
+        challengeState.refreshAfterSave = true
+      }
 
       this.props.history.push({
         pathname:`/admin/project/${this.props.projectId}/` +


### PR DESCRIPTION
Issue: Whenever you go directly to the task edit page, the finish editing button doesn't work.