### PR TITLE
unlock unbundled tasks on updated bundle submittion

### DIFF
--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -66,6 +66,7 @@ export function WithTaskBundle(WrappedComponent) {
         } else if ((prevTaskBundle && prevInitialBundle) && prevTaskBundle !== prevInitialBundle && prevState.completingTask) {
           const tasksToUnlock = prevInitialBundle.taskIds.filter(taskId => !prevTaskBundle.taskIds.includes(taskId))
           tasksToUnlock.map(taskId => {
+            debugger
             this.props.releaseTask(taskId).then(() => {
               // wait for lock to be cleared in db and provide some leeway 
               // time with setTimeout before triggering storage event
@@ -129,6 +130,7 @@ export function WithTaskBundle(WrappedComponent) {
           (taskId) => !this.state.taskBundle.taskIds.includes(taskId)
         )
         tasksToUnlock.map((taskId) => {
+          debugger
           this.props.releaseTask(taskId).then(() => {
             // wait for lock to be cleared in db and provide some leeway 
             // time with setTimeout before triggering storage event
@@ -247,6 +249,7 @@ export const mapDispatchToProps = dispatch => bindActionCreators({
   resetTaskBundle,
   removeTaskFromBundle,
   fetchTaskBundle,
+  releaseTask
 }, dispatch)
 
 export default WrappedComponent =>

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -85,10 +85,15 @@ export function WithTaskBundle(WrappedComponent) {
 
     setBundlingConditions = () => {
       const { task, taskReadOnly, workspace, user, name } = this.props
-      const inReview = task?.reviewStatus === TaskReviewStatus.needed || task?.reviewStatus === TaskReviewStatus.disputed
-      const invalidWorkspace = workspace?.name === "taskReview" || name === "taskReview"
-      const completeStatus = (!inReview && ![0, 2].includes(task?.reviewStatus)) && ![0, 3, 6].includes(task?.status)
-      const bundleEditsDisabled = taskReadOnly || ( completeStatus || ((!user.isSuperUser) && ((task.completedBy && user.id !== task.completedBy) || invalidWorkspace)))
+      const isCompletionWorkspace = workspace?.name === "taskCompletion" || name === "taskCompletion"
+      const isReviewWorkspace = workspace?.name === "taskReview" || name === "taskReview"
+      
+      const completionStatus = isCompletionWorkspace && ([2].includes(task?.reviewStatus) || [0, 3, 6].includes(task?.status))
+      
+      const enableMapperEdits = (!task?.completedBy || user.id === task.completedBy) && completionStatus && !isReviewWorkspace
+      const enableSuperUserEdits = user.isSuperUser && (completionStatus || isReviewWorkspace)
+      
+      const bundleEditsDisabled = taskReadOnly || (!enableMapperEdits && !enableSuperUserEdits)
 
       this.setState({ bundleEditsDisabled })
     }

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -5,7 +5,6 @@ import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
 import { bundleTasks, deleteTaskBundle, resetTaskBundle, removeTaskFromBundle, fetchTaskBundle } from '../../../services/Task/Task'
-import { TaskReviewStatus } from '../../../services/Task/TaskReview/TaskReviewStatus'
 import { releaseTask } from '../../../services/Task/Task'
 
 /**

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -66,7 +66,6 @@ export function WithTaskBundle(WrappedComponent) {
         } else if ((prevTaskBundle && prevInitialBundle) && prevTaskBundle !== prevInitialBundle && prevState.completingTask) {
           const tasksToUnlock = prevInitialBundle.taskIds.filter(taskId => !prevTaskBundle.taskIds.includes(taskId))
           tasksToUnlock.map(taskId => {
-            debugger
             this.props.releaseTask(taskId).then(() => {
               // wait for lock to be cleared in db and provide some leeway 
               // time with setTimeout before triggering storage event
@@ -130,7 +129,6 @@ export function WithTaskBundle(WrappedComponent) {
           (taskId) => !this.state.taskBundle.taskIds.includes(taskId)
         )
         tasksToUnlock.map((taskId) => {
-          debugger
           this.props.releaseTask(taskId).then(() => {
             // wait for lock to be cleared in db and provide some leeway 
             // time with setTimeout before triggering storage event

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.js
@@ -145,19 +145,21 @@ export function WithTaskBundle(WrappedComponent) {
       const { task, workspace, history, fetchTaskBundle } = this.props
       this.setState({ loading: true })
       fetchTaskBundle(bundleId, !this.state.bundleEditsDisabled).then(taskBundle => {
-        if (!task.isBundlePrimary) {
-          const challengeId = task?.parent?.id
-          const primaryTask = taskBundle.tasks.find(task => task.isBundlePrimary)
-          const isMetaReview = history?.location?.pathname?.includes("meta-review")
-          const location = workspace?.name === "taskReview" ? (isMetaReview ? "/meta-review" : "/review") : ""
-          if (primaryTask) {
-            history.push(`/challenge/${challengeId}/task/${primaryTask.id}${location}`)
-          } else {
-            console.error("Primary task not found in task bundle.")
+        if(taskBundle) {
+          if (!task.isBundlePrimary) {
+            const primaryTask = taskBundle.tasks.find(task => task.isBundlePrimary)
+            const isMetaReview = history?.location?.pathname?.includes("meta-review")
+            const location = workspace?.name === "taskReview" ? (isMetaReview ? "/meta-review" : "/review") : ""
+            if (primaryTask) {
+              history.push(`/challenge/${primaryTask.parent}/task/${primaryTask.id}${location}`)
+            } else {
+              console.error("Primary task not found in task bundle.")
+            }
           }
         }
-        this.setState({ initialBundle: taskBundle, selectedTasks: taskBundle?.taskIds, taskBundle, loading: false })
+        this.setState({ initialBundle: taskBundle, selectedTasks: taskBundle?.taskIds, taskBundle })
       })
+      this.setState({ loading: false })
     }
 
     createTaskBundle = (taskIds, bundleTypeMismatch, name) => {


### PR DESCRIPTION
This PR fixes some of the conditions that disable bundling edits, handles undefined props on bundle fetch, and adds functionality to unlock tasks that were unbundled after submission.