### PR TITLE
Connect to new endpoint for fetching specifically task markers

### DIFF
--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
@@ -111,10 +111,11 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
         // Fetch up to threshold+1 individual tasks (eg. 1001 tasks)
         this.props.fetchBoundedTaskMarkers(searchCriteria, UNCLUSTER_THRESHOLD + 1, !storeTasks, ignoreLocked).then(results => {
           if (currentFetchId >= this.state.fetchId) {
+            const totalCount = results.length
             // If we retrieved 1001 tasks then there might be more tasks and
             // they should be clustered. So fetch as clusters
             // (unless we are zoomed all the way in already)
-            if (results.totalCount > UNCLUSTER_THRESHOLD &&
+            if (totalCount > UNCLUSTER_THRESHOLD &&
                 _get(this.props, 'criteria.zoom', 0) < MAX_ZOOM) {
               this.props.fetchTaskClusters(challengeId, searchCriteria, 25, overrideDisable
               ).then(results => {
@@ -127,8 +128,8 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
               })
             }
             else {
-              this.setState({clusters: results.tasks, loading: false,
-                             taskCount: results.totalCount})
+              this.setState({clusters: results, loading: false,
+                             taskCount: totalCount})
             }
           }
         }).catch(error => {

--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
@@ -17,7 +17,7 @@ import { fromLatLngBounds, boundsWithinAllowedMaxDegrees }
        from '../../../services/MapBounds/MapBounds'
 import { fetchTaskClusters, clearTaskClusters }
        from '../../../services/Task/TaskClusters'
-import { fetchBoundedTasks, clearBoundedTasks }
+import { fetchBoundedTaskMarkers, fetchBoundedTasks, clearBoundedTasks }
        from '../../../services/Task/BoundedTask'
 import { MAX_ZOOM, UNCLUSTER_THRESHOLD } from '../../TaskClusterMap/TaskClusterMap'
 
@@ -109,7 +109,7 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
         searchCriteria.page = 0
 
         // Fetch up to threshold+1 individual tasks (eg. 1001 tasks)
-        this.props.fetchBoundedTasks(searchCriteria, UNCLUSTER_THRESHOLD + 1, !storeTasks, ignoreLocked, true).then(results => {
+        this.props.fetchBoundedTaskMarkers(searchCriteria, UNCLUSTER_THRESHOLD + 1, !storeTasks, ignoreLocked).then(results => {
           if (currentFetchId >= this.state.fetchId) {
             // If we retrieved 1001 tasks then there might be more tasks and
             // they should be clustered. So fetch as clusters
@@ -256,7 +256,7 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
 
 export const mapDispatchToProps = dispatch => Object.assign(
   {},
-  bindActionCreators({ fetchTaskClusters, fetchBoundedTasks }, dispatch),
+  bindActionCreators({ fetchTaskClusters, fetchBoundedTaskMarkers, fetchBoundedTasks }, dispatch),
   {
     clearTasksAndClusters: () => {
       dispatch(clearBoundedTasks())

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -34,7 +34,7 @@ export const MIN_ZOOM = 2
  * An uncluster option will be offered if no more than number of tasks
  * will be shown.
  */
-export const UNCLUSTER_THRESHOLD = 1000 // max number of tasks
+export const UNCLUSTER_THRESHOLD = 500 // max number of tasks
 
 /**
  * The number of clusters to show.

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -34,7 +34,7 @@ export const MIN_ZOOM = 2
  * An uncluster option will be offered if no more than number of tasks
  * will be shown.
  */
-export const UNCLUSTER_THRESHOLD = 500 // max number of tasks
+export const UNCLUSTER_THRESHOLD = 1000 // max number of tasks
 
 /**
  * The number of clusters to show.

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -105,6 +105,7 @@ const apiRoutes = (factory) => {
     tasks: {
       random: factory.get("/tasks/random", { noCache: true }),
       withinBounds: factory.put("/tasks/box/:left/:bottom/:right/:top"),
+      markersWithinBounds: factory.put("/markers/box/:left/:bottom/:right/:top"),
       bulkUpdate: factory.put("/tasks"),
       bulkStatusChange: factory.put("/tasks/changeStatus"),
       review: factory.get("/tasks/review"),

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -126,9 +126,8 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
         } : null,
       }
     ).execute().then(normalizedResults => {
-      const totalCount = normalizedResults.result.total
-
-      let tasks = _values(_get(normalizedResults, 'entities.tasks', {}))
+      let tasks = _values(_get(normalizedResults, 'result', {}))
+      const totalCount = tasks.length
       tasks = _map(tasks, task =>
         Object.assign(task, {}, task.pointReview)
       )

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -43,7 +43,109 @@ export const receiveBoundedTasks = function(tasks,
   }
 }
 
-// async action creators
+/**
+ * Retrieve all task markers (up to the given limit) matching the given search
+ * criteria, which should at least include a boundingBox field, and may
+ * optionally include a filters field with additional constraints
+ */
+export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispatch = false, ignoreLocked = true, withGeometries) {
+  return function(dispatch) {
+    if (!skipDispatch) {
+      // The map is either showing task clusters or bounded tasks so we shouldn't
+      // have both in redux.
+      // (ChallengeLocation needs to know which challenge tasks pass the location)
+      dispatch(clearTaskClusters())
+    }
+
+    const normalizedBounds = toLatLngBounds(criteria.boundingBox)
+    if (!normalizedBounds) {
+      return null
+    }
+
+    const filters = _get(criteria, 'filters', {})
+    const searchParameters = generateSearchParametersString(
+      filters,
+      null,
+      _get(criteria, 'savedChallengesOnly'),
+      null,
+      null,
+      _get(criteria, 'invertFields')
+    )
+
+    if (!filters.challengeId) {
+      const onlyEnabled = _isUndefined(criteria.onlyEnabled) ?
+        true :
+        criteria.onlyEnabled
+      const challengeStatus = criteria.challengeStatus
+      if (challengeStatus) {
+        searchParameters.cStatus = challengeStatus.join(',')
+      }
+
+      // ce: limit to enabled challenges
+      // pe: limit to enabled projects
+      searchParameters.ce = onlyEnabled ? 'true' : 'false'
+      searchParameters.pe = onlyEnabled ? 'true' : 'false'
+
+      // if we are restricting to onlyEnabled challenges then let's
+      // not show 'local' challenges either.
+      searchParameters.cLocal = onlyEnabled ? CHALLENGE_EXCLUDE_LOCAL :
+        CHALLENGE_INCLUDE_LOCAL
+    }
+
+    // If we are searching within map bounds we need to ensure the parent
+    // challenge is also within those bounds
+    if (filters.location === CHALLENGE_LOCATION_WITHIN_MAPBOUNDS) {
+      if (_isArray(criteria.boundingBox)) {
+        searchParameters.bb = criteria.boundingBox.join(',')
+      } else {
+        searchParameters.bb = criteria.boundingBox
+      }
+    }
+
+    const fetchId = uuidv1()
+    !skipDispatch && dispatch(receiveBoundedTasks(null, RequestStatus.inProgress, fetchId))
+
+    return new Endpoint(
+      api.tasks.markersWithinBounds, {
+        schema: {
+          tasks: [taskSchema()]
+        },
+        variables: {
+          left: normalizedBounds.getWest(),
+          bottom: normalizedBounds.getSouth(),
+          right: normalizedBounds.getEast(),
+          top: normalizedBounds.getNorth(),
+        },
+        params: {
+          limit,
+          excludeLocked: ignoreLocked,
+          ...searchParameters,
+        },
+        json: filters.taskPropertySearch ? {
+          taskPropertySearch: filters.taskPropertySearch
+        } : null,
+      }
+    ).execute().then(normalizedResults => {
+      const totalCount = normalizedResults.result.total
+
+      let tasks = _values(_get(normalizedResults, 'entities.tasks', {}))
+      tasks = _map(tasks, task =>
+        Object.assign(task, {}, task.pointReview)
+      )
+
+      !skipDispatch && dispatch(receiveBoundedTasks(tasks, RequestStatus.success, fetchId, totalCount))
+
+      return {
+        tasks,
+        totalCount
+      }
+    }).catch(error => {
+      dispatch(receiveBoundedTasks([], RequestStatus.error, fetchId))
+      dispatch(addError(AppErrors.boundedTask.fetchFailure))
+      console.log(error.response || error)
+    })
+  }
+}
 
 /**
  * Retrieve all tasks (up to the given limit) matching the given search

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -48,7 +48,7 @@ export const receiveBoundedTasks = function(tasks,
  * criteria, which should at least include a boundingBox field, and may
  * optionally include a filters field with additional constraints
  */
-export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispatch = false, ignoreLocked = true, withGeometries) {
+export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispatch = false, ignoreLocked = true) {
   return function(dispatch) {
     if (!skipDispatch) {
       // The map is either showing task clusters or bounded tasks so we shouldn't

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -62,7 +62,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
       return null
     }
 
-    const filters = _get(criteria, 'filters', {})
+    const filters = criteria.filters ?? {};
     const searchParameters = generateSearchParametersString(
       filters,
       null,

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -69,7 +69,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
       criteria.savedChallengesOnly,
       null,
       null,
-      _get(criteria, 'invertFields')
+      criteria.invertFields
     )
 
     if (!filters.challengeId) {

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -73,9 +73,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
     )
 
     if (!filters.challengeId) {
-      const onlyEnabled = _isUndefined(criteria.onlyEnabled) ?
-        true :
-        criteria.onlyEnabled
+      const onlyEnabled = criteria.onlyEnabled ?? true;
       const challengeStatus = criteria.challengeStatus
       if (challengeStatus) {
         searchParameters.cStatus = challengeStatus.join(',')

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -123,8 +123,8 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
           taskPropertySearch: filters.taskPropertySearch
         } : null,
       }
-    ).execute().then(normalizedResults => {
-      let tasks = _values(_get(normalizedResults, 'result', {}))
+    ).execute().then(({ result }) => {
+      let tasks = result ? Object.values(result) : [];
       const totalCount = tasks.length
       tasks = _map(tasks, task =>
         Object.assign(task, {}, task.pointReview)

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -124,17 +124,13 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
       }
     ).execute().then(({ result }) => {
       let tasks = result ? Object.values(result) : [];
-      const totalCount = tasks.length
       tasks = tasks.map(task => Object.assign(task, task.pointReview))
 
       if (!skipDispatch) {
-        dispatch(receiveBoundedTasks(tasks, RequestStatus.success, fetchId, totalCount))
+        dispatch(receiveBoundedTasks(tasks, RequestStatus.success, fetchId, tasks.length))
       }
 
-      return {
-        tasks,
-        totalCount
-      }
+      return tasks
     }).catch(error => {
       dispatch(receiveBoundedTasks([], RequestStatus.error, fetchId))
       dispatch(addError(AppErrors.boundedTask.fetchFailure))

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -47,7 +47,7 @@ export const receiveBoundedTasks = function(tasks,
  * criteria, which should at least include a boundingBox field, and may
  * optionally include a filters field with additional constraints
  */
-export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispatch = false, ignoreLocked = true) {
+export function fetchBoundedTaskMarkers(criteria, limit = 50, skipDispatch = false, ignoreLocked = true) {
   return function(dispatch) {
     if (!skipDispatch) {
       // The map is either showing task clusters or bounded tasks so we shouldn't
@@ -144,7 +144,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
  * criteria, which should at least include a boundingBox field, and may
  * optionally include a filters field with additional constraints
  */
-export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false, ignoreLocked=true, withGeometries) {
+export function fetchBoundedTasks(criteria, limit=50, skipDispatch=false, ignoreLocked=true, withGeometries) {
   return function(dispatch) {
     if (!skipDispatch) {
       // The map is either showing task clusters or bounded tasks so we shouldn't

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -126,11 +126,11 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
     ).execute().then(({ result }) => {
       let tasks = result ? Object.values(result) : [];
       const totalCount = tasks.length
-      tasks = _map(tasks, task =>
-        Object.assign(task, {}, task.pointReview)
-      )
+      tasks = tasks.map(task => Object.assign(task, task.pointReview))
 
-      !skipDispatch && dispatch(receiveBoundedTasks(tasks, RequestStatus.success, fetchId, totalCount))
+      if (!skipDispatch) {
+        dispatch(receiveBoundedTasks(tasks, RequestStatus.success, fetchId, totalCount))
+      }
 
       return {
         tasks,

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -66,7 +66,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
     const searchParameters = generateSearchParametersString(
       filters,
       null,
-      _get(criteria, 'savedChallengesOnly'),
+      criteria.savedChallengesOnly,
       null,
       null,
       _get(criteria, 'invertFields')

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -9,7 +9,6 @@ import { addError } from '../Error/Error'
 import AppErrors from '../Error/AppErrors'
 import _get from 'lodash/get'
 import _values from 'lodash/values'
-import _isArray from 'lodash/isArray'
 import _isUndefined from 'lodash/isUndefined'
 import _map from 'lodash/map'
 import { generateSearchParametersString } from '../Search/Search'
@@ -93,7 +92,7 @@ export const fetchBoundedTaskMarkers = function(criteria, limit = 50, skipDispat
     // If we are searching within map bounds we need to ensure the parent
     // challenge is also within those bounds
     if (filters.location === CHALLENGE_LOCATION_WITHIN_MAPBOUNDS) {
-      if (_isArray(criteria.boundingBox)) {
+      if (Array.isArray(criteria.boundingBox)) {
         searchParameters.bb = criteria.boundingBox.join(',')
       } else {
         searchParameters.bb = criteria.boundingBox
@@ -200,7 +199,7 @@ export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false
     // If we are searching within map bounds we need to ensure the parent
     // challenge is also within those bounds
     if (filters.location === CHALLENGE_LOCATION_WITHIN_MAPBOUNDS) {
-      if (_isArray(criteria.boundingBox)) {
+      if (Array.isArray(criteria.boundingBox)) {
         searchParameters.bb = criteria.boundingBox.join(',')
       }
       else {
@@ -276,7 +275,7 @@ export const currentBoundedTasks = function(state={}, action) {
           updatedTasks.loading = true
         }
         else {
-          updatedTasks.tasks = _isArray(action.tasks) ? action.tasks : []
+          updatedTasks.tasks = Array.isArray(action.tasks) ? action.tasks : []
           updatedTasks.loading = false
           updatedTasks.totalCount = action.totalCount
         }


### PR DESCRIPTION
resolves: https://github.com/maproulette/maproulette3/issues/2354
Paired with and dependent on: https://github.com/maproulette/maproulette-backend/pull/1130

Issue: The old endpoint used for fetching task markers was needlessly complex and slow. 

This PR connect to the simpler endpoint used to fetch specifically marker data.