### PR TITLE
Prevent "ghost widget" from appearing in workspace widget layout editor

### DIFF
--- a/src/components/WidgetGrid/WidgetGrid.js
+++ b/src/components/WidgetGrid/WidgetGrid.js
@@ -62,6 +62,14 @@ export class WidgetGrid extends Component {
           }
         }
 
+        const widgetStyle = {
+          "zIndex": widgetHidden ? 0 : (highestY - widgetLayout.y), // higher values towards top of page
+        }
+
+        // Prevent the editing layout from rendering an empty resizable elememnt for "permanent but conditionally shown" widgets 
+        // that are currently hidden.
+        if(widgetHidden && widgetPermanent && this.props.isEditing) widgetStyle["display"] = "none" 
+
         return (
           <div
             key={widgetLayout.i}
@@ -70,9 +78,7 @@ export class WidgetGrid extends Component {
                 'mr-card-widget--editing': this.props.isEditing,
                 'mr-card-widget--top-row': widgetLayout.y === 0,
               })}
-            style={{
-              "zIndex": widgetHidden ? 0 : (highestY - widgetLayout.y), // higher values towards top of page
-            }}
+            style={widgetStyle}
           >
             <WidgetComponent
               {...this.props}


### PR DESCRIPTION
This addresses #2268. The problem: 

If a widget is both "permanent" to a default workspace layout (can't be removed) but also "conditional", in that it is sometimes hidden based on certain conditions, the widget will not appear in a workspace but the layout editor will render an empty resize element that can't be moved or removed: 

![Screen Shot 2024-06-10 at 9 16 59 PM](https://github.com/maproulette/maproulette3/assets/45773707/6e35753d-b73f-42a2-a71f-9918808426d8)

In this case (and currently the only case), it is the Tag Diff widget that appears conditionally when a task is cooperative/Tag Fix task:

![Screen Shot 2024-06-10 at 9 15 24 PM](https://github.com/maproulette/maproulette3/assets/45773707/9463d28c-4846-4a9d-a743-7b4898790909)

The solution: 

Since the desired behavior is that certain widgets be permanent (can't be removed from) but only shown under certain conditions, an inline css style rule applied in this circumstance will prevent the empty resize element from appearing in the layout editor view. 