### PR TITLE
add links to task ids in work on multiple tasks widget

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -346,6 +346,18 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     id: 'id',
     Header: props.intl.formatMessage(messages.idLabel),
     accessor: t => {
+      const taskLink = (
+        <div className="row-controls-column mr-links-green-lighter">
+          <Link 
+            to={`/challenge/${props.challenge?.id}/task/${t.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t.id}
+          </Link>
+        </div>
+      )
+      
       if (t.isBundlePrimary && t.id === props.task?.id) {
         return (
           <span className="mr-flex mr-items-center">
@@ -355,7 +367,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
               className="mr-fill-current mr-w-3 mr-h-3 mr-absolute mr-left-0 mr--ml-2"
               title={props.intl.formatMessage(messages.multipleTasksTooltip)}
             />
-            {t.id}
+            {taskLink}
           </span>
         )
       }
@@ -368,12 +380,12 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
               className="mr-fill-current mr-w-4 mr-h-4 mr-absolute mr-left-0 mr--ml-2"
               title={props.intl.formatMessage(messages.bundleMemberTooltip)}
             />
-            {t.id}
+            {taskLink}
           </span>
         )
       }
       else {
-        return <span>{t.id}</span>
+        return <span>{taskLink}</span>
       }
     },
     exportable: t => t.id,

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { Link } from 'react-router-dom'
 import { messagesByStatus } from '../../../services/Task/TaskStatus/TaskStatus'
 import { messagesByPriority } from '../../../services/Task/TaskPriority/TaskPriority'
 import AsCooperativeWork from '../../../interactions/Task/AsCooperativeWork'
@@ -33,19 +34,49 @@ class TaskMarkerContent extends Component {
     return (
       <div className="mr-flex mr-justify-center">
         <div className="mr-flex-col mr-w-full">
-          {[
-            ['nameLabel', this.props.marker.options.name],
-            ['taskIdLabel', taskId],
-            ['statusLabel', statusMessage && this.props.intl.formatMessage(statusMessage)],
-            ['priorityLabel', priorityMessage && this.props.intl.formatMessage(priorityMessage)],
-          ].map(([labelMessageId, content]) => (
-            <div key={labelMessageId} className="mr-flex">
-              <div className="mr-w-1/2 mr-mr-2 mr-text-right">
-                <FormattedMessage {...messages[labelMessageId]} />
-              </div>
-              <div className="mr-w-1/2 mr-text-left">{content}</div>
+          <div className="mr-flex">
+            <div className="mr-w-1/2 mr-mr-2 mr-text-right">
+              <FormattedMessage {...messages.nameLabel} />
             </div>
-          ))}
+            <div className="mr-w-1/2 mr-text-left">{this.props.marker.options.name || this.props.marker.options.geometries?.features[0]?.id}</div>
+          </div>
+
+          <div className="mr-flex">
+            <div className="mr-w-1/2 mr-mr-2 mr-text-right">
+              <FormattedMessage {...messages.taskIdLabel} />
+            </div>
+            <div className="mr-w-1/2 mr-text-left">
+              <Link 
+                to={`/challenge/${this.props.challenge?.id}/task/${this.props.marker.options.taskId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {this.props.marker.options.taskId}
+              </Link>
+            </div>
+          </div>
+
+          {statusMessage && (
+            <div className="mr-flex">
+              <div className="mr-w-1/2 mr-mr-2 mr-text-right">
+                <FormattedMessage {...messages.statusLabel} />
+              </div>
+              <div className="mr-w-1/2 mr-text-left">
+                {this.props.intl.formatMessage(statusMessage)}
+              </div>
+            </div>
+          )}
+
+          {priorityMessage && (
+            <div className="mr-flex">
+              <div className="mr-w-1/2 mr-mr-2 mr-text-right">
+                <FormattedMessage {...messages.priorityLabel} />
+              </div>
+              <div className="mr-w-1/2 mr-text-left">
+                {this.props.intl.formatMessage(priorityMessage)}
+              </div>
+            </div>
+          )}
 
           <div className="mr-flex mr-justify-center mr-mt-2">
             <label>


### PR DESCRIPTION
<img width="1046" alt="Screenshot 2024-07-04 at 4 42 58 PM" src="https://github.com/maproulette/maproulette3/assets/88843144/13c079b9-b764-4567-9e0b-bfd9c5541ab1">
Add links to task id in work on multiple tasks table and its marker popups.