### PR TITLE
Fix zoom and panning issues in maps

### DIFF
--- a/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
+++ b/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
@@ -70,7 +70,6 @@ const SourcedTileLayer = (props) => {
 
   return (
     <TileLayer
-      noWrap={true} 
       key={normalizedLayer.id}
       {...normalizedLayer}
       attribution={attribution(normalizedLayer)}

--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { GeoJSON, useMap } from 'react-leaflet'
-import L, { FeatureGroup } from 'leaflet'
+import L from 'leaflet'
 import { injectIntl } from 'react-intl'
 import { featureCollection } from '@turf/helpers'
 import _isFunction from 'lodash/isFunction'
@@ -103,23 +103,6 @@ const TaskFeatureLayer = props => {
       />
     )
   }, [features.length])
-
-  useEffect(() => {
-    if(numberOfFeatures !== features.length) {
-      const geoJSONFeatures = new FeatureGroup()
-
-      map.eachLayer(layer => {
-        if (layer.feature && layer.feature.type === "Feature") {
-          geoJSONFeatures.addLayer(layer)
-        }
-      })
-
-      if (geoJSONFeatures.getLayers().length !== 0) {
-        map.fitBounds(geoJSONFeatures.getBounds().pad(0.2))
-      }
-      setNumberOfFeatures(features.length)
-    }
-  }, [layer])
 
   return layer
 }

--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
@@ -28,7 +28,6 @@ const HIGHLIGHT_SIMPLESTYLE = {
  */
 const TaskFeatureLayer = props => {
   const [layer, setLayer] = useState(null)
-  const [numberOfFeatures, setNumberOfFeatures] = useState(0)
   const map = useMap()
 
   const propertyList = (featureProperties, onBack) => {

--- a/src/components/TaskClusterMap/MapMarkers.js
+++ b/src/components/TaskClusterMap/MapMarkers.js
@@ -7,6 +7,7 @@ import _filter from 'lodash/filter';
 import _reject from 'lodash/reject';
 import _compact from 'lodash/compact';
 import _isEmpty from 'lodash/isEmpty';
+import _isFinite from 'lodash/isFinite';
 import _omit from 'lodash/omit';
 import _cloneDeep from 'lodash/cloneDeep';
 import _isObject from 'lodash/isObject';
@@ -102,28 +103,13 @@ const Markers = (props) => {
   }, [props.currentZoom]);
 
   useEffect(() => {
-    // Fit bounds to initial tasks when they are loaded
-    if (!initialLoadComplete && mapMarkers && mapMarkers.length > 0) {
-      const bounds = props.centerBounds || toLatLngBounds(
-        bbox({
-          type: 'FeatureCollection',
-          features: _map(mapMarkers, cluster =>
-            ({
-              type: 'Feature',
-              geometry: {
-                type: 'Point',
-                coordinates: [cluster.props.position[1], cluster.props.position[0]]
-              }
-            })
-          )
-        })
-      );
-
-      map.fitBounds(bounds.pad(0.2));
-      props.setCurrentBounds(bounds.pad(0.2));
+    if (props.taskMarkers && !initialLoadComplete && props.initialBounds && _isFinite(props.initialBounds.getNorth())) {
       setInitialLoadComplete(true);
+      map.fitBounds(props.initialBounds)
+    } else if (props.taskCenter && !props.taskCenter.equals(prevProps.current.taskCenter)) {
+      map.panTo(props.taskCenter)
     }
-  }, [mapMarkers, initialLoadComplete]);
+  }, [props]);
 
   const refreshSpidered = () => {
     if (spidered.size === 0) {

--- a/src/components/TaskClusterMap/MapMarkers.js
+++ b/src/components/TaskClusterMap/MapMarkers.js
@@ -7,7 +7,6 @@ import _filter from 'lodash/filter';
 import _reject from 'lodash/reject';
 import _compact from 'lodash/compact';
 import _isEmpty from 'lodash/isEmpty';
-import _isFinite from 'lodash/isFinite';
 import _omit from 'lodash/omit';
 import _cloneDeep from 'lodash/cloneDeep';
 import _isObject from 'lodash/isObject';

--- a/src/components/TaskClusterMap/MapMarkers.js
+++ b/src/components/TaskClusterMap/MapMarkers.js
@@ -103,13 +103,30 @@ const Markers = (props) => {
   }, [props.currentZoom]);
 
   useEffect(() => {
-    if (props.taskMarkers && !initialLoadComplete && props.initialBounds && _isFinite(props.initialBounds.getNorth())) {
-      setInitialLoadComplete(true);
-      map.fitBounds(props.initialBounds)
-    } else if (props.taskCenter && !props.taskCenter.equals(prevProps.current.taskCenter)) {
+ // Fit bounds to initial tasks when they are loaded
+    if (!initialLoadComplete && mapMarkers && mapMarkers.length > 0) {
+      const bounds = props.centerBounds || toLatLngBounds(
+        bbox({
+          type: 'FeatureCollection',
+          features: _map(mapMarkers, cluster =>
+            ({
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [cluster.props.position[1], cluster.props.position[0]]
+              }
+            })
+          )
+        })
+      );
+
+      map.fitBounds(bounds.pad(0.2));
+      props.setCurrentBounds(bounds.pad(0.2));
+    } 
+    else if (props.taskCenter && !props.taskCenter.equals(prevProps.current.taskCenter)) {
       map.panTo(props.taskCenter)
     }
-  }, [props]);
+  }, [props, mapMarkers, initialLoadComplete]);
 
   const refreshSpidered = () => {
     if (spidered.size === 0) {

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -539,7 +539,7 @@ const TaskMap = (props) => {
         zoom={DEFAULT_ZOOM}
         zoomControl={false}
         minZoom={2}
-        maxZoom={20}
+        maxZoom={MAX_ZOOM}
         attributionControl={false}
         maxBounds={[[-90, -180], [90, 180]]} 
       >

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -304,7 +304,7 @@ export const TaskMapContainer = (props) => {
       );
       map.fitBounds(layerGroup.getBounds().pad(0.2));
     }
-  }, [features, map]);
+  }, [features.length]);
 
   const mapillaryImageMarkers = () => {
     return {

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -304,7 +304,7 @@ export const TaskMapContainer = (props) => {
       );
       map.fitBounds(layerGroup.getBounds().pad(0.2));
     }
-  }, [features.length]);
+  }, [props.taskBundle, props.taskId]);
 
   const mapillaryImageMarkers = () => {
     return {


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2376

After completing a task, the map bounds of both the task map widget and work on multiple tasks widget wasn't updating causing it to appear as if there was not data in the next task.

The main issue described was fixed here:
```
useEffect(() => {
  if (features.length !== 0) {
    const layerGroup = L.featureGroup(
      features.map(feature => L.geoJSON(feature))
    );
    map.fitBounds(layerGroup.getBounds().pad(0.2));
  }
}, [props.taskBundle, props.taskId]);
```
This re fits the bounds to display the new task in view using the props.taskBundle and props.taskId variables as listeners.

Other modification included in this pr is removing the nowrap attribute from cluster maps.