### PR TITLE
add global toggle to find challenge page

### DIFF
--- a/src/components/ChallengePane/ChallengePane.jsx
+++ b/src/components/ChallengePane/ChallengePane.jsx
@@ -46,7 +46,7 @@ const ShowChallengeListTogglesInternal = (props) => {
       <input
         type="checkbox"
         className="mr-checkbox-toggle mr-mr-1 mr-mb-6 mr-ml-4"
-        checked={!props.filteringGlobal}
+        checked={props.filteringGlobal}
         onChange={() => {
           props.setSearchFilters({ filterGlobal: !props.filteringGlobal })
         }}
@@ -127,7 +127,7 @@ export class ChallengePane extends Component {
 
   render() {
     const showingArchived = this.props.history.location.search.includes("archived=true");
-    const filteringGlobal = this.props.history.location.search.includes("filterGlobal") ? this.props.history.location.search.includes("filterGlobal=true") : true;
+    const filteringGlobal = this.props.history.location.search.includes("filterGlobal=true")
     const challengeStatus = [ChallengeStatus.ready,
                              ChallengeStatus.partiallyLoaded,
                              ChallengeStatus.none,

--- a/src/components/ChallengePane/ChallengePane.jsx
+++ b/src/components/ChallengePane/ChallengePane.jsx
@@ -31,7 +31,7 @@ import TaskChallengeMarkerContent from './TaskChallengeMarkerContent'
 import StartVirtualChallenge from './StartVirtualChallenge/StartVirtualChallenge'
 import messages from './Messages'
 
-const ShowArchivedToggleInternal = (props) => {
+const ShowChallengeListTogglesInternal = (props) => {
   return (
     <div className="mr-flex">
       <input
@@ -43,11 +43,20 @@ const ShowArchivedToggleInternal = (props) => {
         }}
       />
       <div className="mr-text-sm mr-mx-1"><FormattedMessage {...messages.showArchivedLabel} /></div>
+      <input
+        type="checkbox"
+        className="mr-checkbox-toggle mr-mr-1 mr-mb-6 mr-ml-4"
+        checked={!props.filteringGlobal}
+        onChange={() => {
+          props.setSearchFilters({ filterGlobal: !props.filteringGlobal })
+        }}
+      />
+      <div className="mr-text-sm mr-mx-1"><FormattedMessage {...messages.showGlobalLabel} /></div>
     </div>
   )
 }
 
-const ShowArchivedToggle = WithChallengeSearch(ShowArchivedToggleInternal);
+const ShowChallengeListToggles = WithChallengeSearch(ShowChallengeListTogglesInternal);
 
 // Setup child components with necessary HOCs
 const ChallengeResults = WithStatus(ChallengeResultList)
@@ -118,6 +127,7 @@ export class ChallengePane extends Component {
 
   render() {
     const showingArchived = this.props.history.location.search.includes("archived=true");
+    const filteringGlobal = this.props.history.location.search.includes("filterGlobal") ? this.props.history.location.search.includes("filterGlobal=true") : true;
     const challengeStatus = [ChallengeStatus.ready,
                              ChallengeStatus.partiallyLoaded,
                              ChallengeStatus.none,
@@ -156,7 +166,7 @@ export class ChallengePane extends Component {
         <div className="mr-p-6 lg:mr-flex mr-cards-inverse">
           <div className="mr-flex-0">
             <LocationFilter {...this.props} />
-            <ShowArchivedToggle showingArchived={showingArchived} {...this.props} />
+            <ShowChallengeListToggles showingArchived={showingArchived} filteringGlobal={filteringGlobal} {...this.props} />
             <ChallengeResults {...this.props} />
           </div>
           <div className="mr-flex-1">

--- a/src/components/ChallengePane/ChallengePane.jsx
+++ b/src/components/ChallengePane/ChallengePane.jsx
@@ -46,9 +46,9 @@ const ShowChallengeListTogglesInternal = (props) => {
       <input
         type="checkbox"
         className="mr-checkbox-toggle mr-mr-1 mr-mb-6 mr-ml-4"
-        checked={props.filteringGlobal}
+        checked={props.showingGlobal}
         onChange={() => {
-          props.setSearchFilters({ filterGlobal: !props.filteringGlobal })
+          props.setSearchFilters({ global: !props.showingGlobal })
         }}
       />
       <div className="mr-text-sm mr-mx-1"><FormattedMessage {...messages.showGlobalLabel} /></div>
@@ -127,7 +127,7 @@ export class ChallengePane extends Component {
 
   render() {
     const showingArchived = this.props.history.location.search.includes("archived=true");
-    const filteringGlobal = this.props.history.location.search.includes("filterGlobal=true")
+    const showingGlobal = this.props.history.location.search.includes("global=true")
     const challengeStatus = [ChallengeStatus.ready,
                              ChallengeStatus.partiallyLoaded,
                              ChallengeStatus.none,
@@ -166,7 +166,7 @@ export class ChallengePane extends Component {
         <div className="mr-p-6 lg:mr-flex mr-cards-inverse">
           <div className="mr-flex-0">
             <LocationFilter {...this.props} />
-            <ShowChallengeListToggles showingArchived={showingArchived} filteringGlobal={filteringGlobal} {...this.props} />
+            <ShowChallengeListToggles showingArchived={showingArchived} showingGlobal={showingGlobal} {...this.props} />
             <ChallengeResults {...this.props} />
           </div>
           <div className="mr-flex-1">

--- a/src/components/ChallengePane/Messages.js
+++ b/src/components/ChallengePane/Messages.js
@@ -37,5 +37,10 @@ export default defineMessages({
   showArchivedLabel: {
     id: "ChallengePane.controls.showArchived.label",
     defaultMessage: "Show Archived"
+  },
+
+  showGlobalLabel: {
+    id: "ChallengePane.controls.showGlobal.label",
+    defaultMessage: "Show Global Challenges"
   }
 })

--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
@@ -13,13 +13,11 @@ import { challengePassesLocationFilter }
        from '../../../services/Challenge/ChallengeLocation/ChallengeLocation'
 import { challengePassesGlobalFilter }
        from '../../../services/Challenge/ChallengeGlobal/ChallengeGlobal'
-import { challengePassesArchivedFilter }
-       from '../../../services/Challenge/ChallengeArchived/ChallengeArchived'
 import { challengePassesProjectFilter }
        from '../../../services/Challenge/ChallengeProject/ChallengeProject'
 
 const allFilters = [
-  challengePassesGlobalFilter,challengePassesArchivedFilter,
+  challengePassesGlobalFilter,
   challengePassesDifficultyFilter,
   challengePassesKeywordFilter,
   challengePassesCategorizationKeywordsFilter,

--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
@@ -11,13 +11,15 @@ import { challengePassesCategorizationKeywordsFilter }
        from '../../../services/Challenge/ChallengeCategorizationKeywords/ChallengeCategorizationKeywords';
 import { challengePassesLocationFilter }
        from '../../../services/Challenge/ChallengeLocation/ChallengeLocation'
+import { challengePassesGlobalFilter }
+       from '../../../services/Challenge/ChallengeGlobal/ChallengeGlobal'
 import { challengePassesArchivedFilter }
        from '../../../services/Challenge/ChallengeArchived/ChallengeArchived'
 import { challengePassesProjectFilter }
        from '../../../services/Challenge/ChallengeProject/ChallengeProject'
 
 const allFilters = [
-  challengePassesArchivedFilter,
+  challengePassesGlobalFilter,challengePassesArchivedFilter,
   challengePassesDifficultyFilter,
   challengePassesKeywordFilter,
   challengePassesCategorizationKeywordsFilter,

--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.jsx
@@ -11,12 +11,15 @@ import { challengePassesCategorizationKeywordsFilter }
        from '../../../services/Challenge/ChallengeCategorizationKeywords/ChallengeCategorizationKeywords';
 import { challengePassesLocationFilter }
        from '../../../services/Challenge/ChallengeLocation/ChallengeLocation'
+import { challengePassesArchivedFilter }
+       from '../../../services/Challenge/ChallengeArchived/ChallengeArchived'
 import { challengePassesGlobalFilter }
        from '../../../services/Challenge/ChallengeGlobal/ChallengeGlobal'
 import { challengePassesProjectFilter }
        from '../../../services/Challenge/ChallengeProject/ChallengeProject'
 
 const allFilters = [
+  challengePassesArchivedFilter,
   challengePassesGlobalFilter,
   challengePassesDifficultyFilter,
   challengePassesKeywordFilter,

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
@@ -37,7 +37,8 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
        project: param => this.props.setSearchFilters({project: param, searchType: SEARCH_TYPE_PROJECT}),
        query: param => this.props.setSearch(param),
        challengeSearch: param => this.props.setChallengeSearchMapBounds(toLatLngBounds(param), true),
-       archived: param => this.props.setSearchFilters({ archived: param === "true" })
+       archived: param => this.props.setSearchFilters({ archived: param === "true" }),
+       filterGlobal: param => this.props.setSearchFilters({ filterGlobal: param === "true" })
     }
 
     state = {

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
@@ -38,7 +38,7 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
        query: param => this.props.setSearch(param),
        challengeSearch: param => this.props.setChallengeSearchMapBounds(toLatLngBounds(param), true),
        archived: param => this.props.setSearchFilters({ archived: param === "true" }),
-       filterGlobal: param => this.props.setSearchFilters({ filterGlobal: param === "true" })
+       global: param => this.props.setSearchFilters({ global: param === "true" })
     }
 
     state = {

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -443,6 +443,10 @@ export const extendedFind = function (criteria, limit = RESULTS_PER_PAGE, admin 
       queryParams.ca = filters.archived;
     }
 
+    if (filters.filterGlobal) {
+      queryParams.fg = filters.filterGlobal;
+    }
+
     // Keywords/tags can come from both the the query and the filter, so we need to
     // combine them into a single keywords array.
     const keywords = queryParts.tagTokens.concat(

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -443,8 +443,8 @@ export const extendedFind = function (criteria, limit = RESULTS_PER_PAGE, admin 
       queryParams.ca = filters.archived;
     }
 
-    if (filters.filterGlobal) {
-      queryParams.fg = filters.filterGlobal;
+    if (filters.global) {
+      queryParams.cg = filters.global;
     }
 
     // Keywords/tags can come from both the the query and the filter, so we need to

--- a/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
+++ b/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
@@ -1,7 +1,0 @@
-export const challengePassesArchivedFilter = function(filter, challenge) {
-  if (!filter.archived) {
-    return challenge.isArchived === false
-  }
-
-  return true
-}

--- a/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
+++ b/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
@@ -1,0 +1,7 @@
+export const challengePassesArchivedFilter = function(filter, challenge) {
+  if (!filter.archived) {
+    return challenge.isArchived === false
+  }
+
+  return true
+}

--- a/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
+++ b/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
@@ -1,7 +1,7 @@
 export const challengePassesArchivedFilter = function(filter, challenge) {
-    if (!filter.archived) {
-      return challenge.isArchived === false
-    }
-  
-    return true
+  if (!filter.archived) {
+    return challenge.isArchived === false
   }
+
+  return true
+}

--- a/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
+++ b/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
@@ -1,0 +1,7 @@
+export const challengePassesGlobalFilter = function(filter, challenge) {
+  if (filter.filterGlobal) {
+    return challenge.isGlobal === false
+  }
+
+  return true
+}

--- a/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
+++ b/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
@@ -1,5 +1,5 @@
 export const challengePassesGlobalFilter = function(filter, challenge) {
-  if (filter.global) {
+  if (!filter.global) {
     return challenge.isGlobal === false
   }
 

--- a/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
+++ b/src/services/Challenge/ChallengeGlobal/ChallengeGlobal.js
@@ -1,5 +1,5 @@
 export const challengePassesGlobalFilter = function(filter, challenge) {
-  if (filter.filterGlobal) {
+  if (filter.global) {
     return challenge.isGlobal === false
   }
 

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -95,7 +95,8 @@ export const PARAMS_MAP = {
   difficulty: 'cd',
   tags: 'tt',
   excludeTasks: 'tExcl',
-  archived: "ca"
+  archived: "ca",
+  filterGlobal: "fg"
 }
 
 
@@ -157,6 +158,9 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
 
   if (filters.archived) {
     searchParameters[PARAMS_MAP.archived] = filters.archived;
+  }
+  if (filters.filterGlobal) {
+    searchParameters[PARAMS_MAP.filterGlobal] = filters.filterGlobal;
   }
   if (filters.reviewRequestedBy) {
     searchParameters[PARAMS_MAP.reviewRequestedBy] = filters.reviewRequestedBy

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -96,7 +96,7 @@ export const PARAMS_MAP = {
   tags: 'tt',
   excludeTasks: 'tExcl',
   archived: "ca",
-  filterGlobal: "fg"
+  global: "cg"
 }
 
 
@@ -159,8 +159,8 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
   if (filters.archived) {
     searchParameters[PARAMS_MAP.archived] = filters.archived;
   }
-  if (filters.filterGlobal) {
-    searchParameters[PARAMS_MAP.filterGlobal] = filters.filterGlobal;
+  if (filters.global) {
+    searchParameters[PARAMS_MAP.global] = filters.global;
   }
   if (filters.reviewRequestedBy) {
     searchParameters[PARAMS_MAP.reviewRequestedBy] = filters.reviewRequestedBy


### PR DESCRIPTION
Backend: https://github.com/maproulette/maproulette-backend/pull/1136

Resolves: https://github.com/maproulette/maproulette3/issues/2373 & https://github.com/maproulette/maproulette3/issues/2350

<img width="1680" alt="Screenshot 2024-07-15 at 1 52 54 PM" src="https://github.com/user-attachments/assets/6414ef6a-c408-48e2-84c3-497b2deb1cf5">

This PR introduces a new "Show Global" filter on the find challenges page. When unchecked, this filter excludes all challenges not classified as global. The global classification is determined by backend conditions, currently defined as challenges whose tasks span over 180 degrees horizontally or 90 degrees vertically on the map.