### PR TITLE
add documentation links to mr tag features

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -243,7 +243,7 @@ export default defineMessages({
     id: "Admin.EditChallenge.form.preferredTags.description",
     defaultMessage:
       "You can optionally provide a list of " +
-      "preferred tags that you want the user to use when completing a task.",
+      "preferred tags that you want the user to use when completing a task. [Learn More](https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/)",
   },
 
   preferredReviewTagsLabel: {
@@ -255,7 +255,7 @@ export default defineMessages({
     id: "Admin.EditChallenge.form.preferredReviewTags.description",
     defaultMessage:
       "You can optionally provide a list of " +
-      "preferred tags that you want the reviewer to use when reviewing a task.",
+      "preferred tags that you want the reviewer to use when reviewing a task. [Learn More](https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/)",
   },
 
   limitTagsDescription: {

--- a/src/components/TaskTags/TaskTags.js
+++ b/src/components/TaskTags/TaskTags.js
@@ -77,13 +77,13 @@ export class TaskTags extends Component {
                 <FormattedMessage {...messages.modifyTags} />
               </h3>
               <a target="_blank" rel="noreferrer" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-2">
-              <SvgSymbol
-                  sym="info-icon"
-                  viewBox="0 0 20 20"
-                  className="mr-fill-white mr-w-4 mr-h-4"
-                />
-              </a>
-            </div>
+                <SvgSymbol
+                    sym="info-icon"
+                    viewBox="0 0 20 20"
+                    className="mr-fill-white mr-w-4 mr-h-4"
+                  />
+                </a>
+              </div>
               <div className="mr-mt-2 mr-w-full">
                 <KeywordAutosuggestInput
                   handleChangeTags={this.handleChangeTags}
@@ -130,13 +130,13 @@ export class TaskTags extends Component {
               <FormattedMessage {...messages.updateTags} />
             </a>
             <a target="_blank" rel="noreferrer" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="">
-            <SvgSymbol
-                sym="info-icon"
-                viewBox="0 0 20 20"
-                className="mr-fill-white mr-w-3 mr-h-3"
-              />
-            </a>
-          </div> : null
+              <SvgSymbol
+                  sym="info-icon"
+                  viewBox="0 0 20 20"
+                  className="mr-fill-white mr-w-3 mr-h-3"
+                />
+              </a>
+            </div> : null
           }
         </div>
       )

--- a/src/components/TaskTags/TaskTags.js
+++ b/src/components/TaskTags/TaskTags.js
@@ -76,7 +76,7 @@ export class TaskTags extends Component {
               <h3 className="mr-text-yellow mr-text-3xl mr-mb-4">
                 <FormattedMessage {...messages.modifyTags} />
               </h3>
-              <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-2">
+              <a target="_blank" rel="noreferrer" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-2">
               <SvgSymbol
                   sym="info-icon"
                   viewBox="0 0 20 20"
@@ -129,7 +129,7 @@ export class TaskTags extends Component {
             <a onClick={() => this.setState({ edit: true })} className="mr-inline-block mr-mr-2">
               <FormattedMessage {...messages.updateTags} />
             </a>
-            <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="">
+            <a target="_blank" rel="noreferrer" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="">
             <SvgSymbol
                 sym="info-icon"
                 viewBox="0 0 20 20"
@@ -147,7 +147,7 @@ export class TaskTags extends Component {
           <a onClick={() => this.setState({edit: true})}>
             <FormattedMessage {...messages.addTags} />
           </a>
-          <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-1">
+          <a target="_blank" rel="noreferrer" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-1">
             <SvgSymbol
               sym="info-icon"
               viewBox="0 0 20 20"

--- a/src/components/TaskTags/TaskTags.js
+++ b/src/components/TaskTags/TaskTags.js
@@ -10,6 +10,7 @@ import KeywordAutosuggestInput
 import External from '../External/External'
 import Modal from '../Modal/Modal'
 import messages from './Messages'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
 
 export class TaskTags extends Component {
   state = {
@@ -71,9 +72,18 @@ export class TaskTags extends Component {
         <External>
           <Modal isActive onClose={() => this.setState({edit: false})} allowOverflow>
             <div className="mr-w-full">
-              <h2 className="mr-text-yellow mr-text-4xl mr-mb-4">
+              <div className="mr-flex">
+              <h3 className="mr-text-yellow mr-text-3xl mr-mb-4">
                 <FormattedMessage {...messages.modifyTags} />
-              </h2>
+              </h3>
+              <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-2">
+              <SvgSymbol
+                  sym="info-icon"
+                  viewBox="0 0 20 20"
+                  className="mr-fill-white mr-w-4 mr-h-4"
+                />
+              </a>
+            </div>
               <div className="mr-mt-2 mr-w-full">
                 <KeywordAutosuggestInput
                   handleChangeTags={this.handleChangeTags}
@@ -115,20 +125,34 @@ export class TaskTags extends Component {
           </div>
 
           {!disableEditTags ?
-           <div className="mr-links-green-lighter mr-flex-grow-0">
-             <a onClick={() => this.setState({edit: true})}>
-               <FormattedMessage {...messages.updateTags} />
-             </a>
-           </div> : null
+            <div className="mr-links-green-lighter mr-flex-grow-0 mr-flex">
+            <a onClick={() => this.setState({ edit: true })} className="mr-inline-block mr-mr-2">
+              <FormattedMessage {...messages.updateTags} />
+            </a>
+            <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="">
+            <SvgSymbol
+                sym="info-icon"
+                viewBox="0 0 20 20"
+                className="mr-fill-white mr-w-3 mr-h-3"
+              />
+            </a>
+          </div> : null
           }
         </div>
       )
     }
     else if (!disableEditTags) {
       return (
-        <div className="mr-links-green-lighter">
+        <div className="mr-links-green-lighter mr-flex">
           <a onClick={() => this.setState({edit: true})}>
             <FormattedMessage {...messages.addTags} />
+          </a>
+          <a target="_blank" href="https://learn.maproulette.org/en-us/documentation/using-maproulette-tags/" title="Learn more about Maproulette tags" className="mr-ml-1">
+            <SvgSymbol
+              sym="info-icon"
+              viewBox="0 0 20 20"
+              className="mr-fill-white mr-w-3 mr-h-3"
+            />
           </a>
         </div>
       )


### PR DESCRIPTION
Partially resolves issue found here about difficulty understanding mr tags: https://github.com/maproulette/maproulette3/issues/2067
Implemented to make it easier and quicker to find documentation on MR Tags.
This PR will be implemented around the same time the relevant documentation page is updated. Updates the the documentation page located here: https://github.com/maproulette/docs/pull/43
<img width="1035" alt="Screenshot 2024-07-17 at 7 44 34 PM" src="https://github.com/user-attachments/assets/794e1940-a377-4266-970a-efec8b3d2bd0">
<img width="593" alt="Screenshot 2024-07-17 at 7 44 23 PM" src="https://github.com/user-attachments/assets/231be445-a3c1-4136-95d8-59604785d062">
<img width="479" alt="Screenshot 2024-07-17 at 7 44 10 PM" src="https://github.com/user-attachments/assets/96c5f88a-e02e-4c92-a4e3-4941907d6f2d">
<img width="736" alt="Screenshot 2024-07-17 at 7 43 38 PM" src="https://github.com/user-attachments/assets/98afbb6c-b7d5-49dc-a411-c10f83c5d798">

