### PR TITLE
fix comment overflow styles

### DIFF
--- a/src/components/ChallengeDetail/ChallengeCommentsPane.js
+++ b/src/components/ChallengeDetail/ChallengeCommentsPane.js
@@ -14,12 +14,7 @@ import defaultPic from "../../static/images/user_no_image.png";
 const calcHeight = (offset) => {
   const variableHeight = window.innerHeight - offset;
   const minHeight = 300;
-
-  if (variableHeight < minHeight) {
-    return minHeight;
-  }
-
-  return variableHeight;
+  return variableHeight < minHeight ? minHeight : variableHeight;
 };
 
 const renderCommentList = ({ osmId, comments, tasksOn, owner }) => {
@@ -41,6 +36,7 @@ const renderCommentList = ({ osmId, comments, tasksOn, owner }) => {
       >
         <div
           className={classNames("mr-flex", isUser ? "mr-flex-row-reverse" : "")}
+          style={{maxWidth: '100%'}}
         >
           <div className="mr-px-2 mr-flex-0">
             <div className="mr-w-9">
@@ -57,9 +53,10 @@ const renderCommentList = ({ osmId, comments, tasksOn, owner }) => {
           </div>
           <div
             className={classNames(
-              "mr-p-1 mr-rounded mr-p-2 mr-flex-1",
+              "mr-p-1 mr-rounded mr-p-2 mr-flex-1 mr-w-full",
               isUser ? "mr-bg-blue-light" : "mr-bg-green-dark"
             )}
+            style={{maxWidth: '80%'}}
           >
             <div>
               <div className="mr-text-sm">

--- a/src/styles/utilities/typography.css
+++ b/src/styles/utilities/typography.css
@@ -99,7 +99,7 @@ h4,
 }
 
 .mr-markdown {
-  @apply mr-text-sm;
+  @apply mr-text-sm mr-overflow-auto mr-break-words;
 
   h1,
   h2,


### PR DESCRIPTION
Before:
<img width="627" alt="Screenshot 2024-07-26 at 2 59 52 PM" src="https://github.com/user-attachments/assets/54a1ccf9-023e-49a6-9248-a811ff4daab7">
After:
<img width="623" alt="Screenshot 2024-07-26 at 3 00 24 PM" src="https://github.com/user-attachments/assets/3ab86c74-2f2c-4ca7-8fde-7e7f7b137493">
Before:
<img width="533" alt="Screenshot 2024-07-26 at 2 31 05 PM" src="https://github.com/user-attachments/assets/65c081ae-6129-4881-ac6f-c5fd1f13dc2e">
After:
<img width="529" alt="Screenshot 2024-07-26 at 2 31 30 PM" src="https://github.com/user-attachments/assets/98ae5128-536c-4863-af1c-bd5193b35df1">
