### PR TITLE
fix errors related to map unmounting

### DIFF
--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
@@ -30,6 +30,8 @@ import { MAX_ZOOM, UNCLUSTER_THRESHOLD } from '../../TaskClusterMap/TaskClusterM
 export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=false,
   showClusters=true, ignoreLocked=true, skipInitialFetch=false) {
   return class extends Component {
+    _isMounted = false
+
     state = {
       loading: false,
       fetchId: null,
@@ -151,6 +153,8 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
     }
 
     componentDidMount() {
+      this._isMounted = true
+
       if (!skipInitialFetch) {
         this.debouncedFetchClusters(this.state.showAsClusters)
       }
@@ -163,8 +167,12 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
       }
     }
 
+    componentWillUnmount() {
+      this._isMounted = false
+    }
+
     debouncedFetchClusters =
-      _debounce((showAsClusters) => this.fetchUpdatedClusters(showAsClusters), 800)
+      _debounce((showAsClusters) => {if(this._isMounted)this.fetchUpdatedClusters(showAsClusters), 800})
 
     componentDidUpdate(prevProps) {
       if (!_isEqual(_get(prevProps.criteria, 'searchQuery'), _get(this.props.criteria, 'searchQuery'))) {

--- a/src/components/TaskClusterMap/MapMarkers.js
+++ b/src/components/TaskClusterMap/MapMarkers.js
@@ -87,6 +87,12 @@ const Markers = (props) => {
   });
 
   useEffect(() => {
+    return () => {
+      clearTimeout(timerRef.current);
+    };
+  }, [map]);
+
+  useEffect(() => {
     if (!props.taskMarkers || props.delayMapLoad || !_isEqual(props.taskMarkers, prevProps.current.taskMarkers) || props.selectedClusters !== prevProps.current.selectedClusters) {
       refreshSpidered();
       generateMarkers();

--- a/src/components/TaskClusterMap/MapMarkers.js
+++ b/src/components/TaskClusterMap/MapMarkers.js
@@ -90,7 +90,7 @@ const Markers = (props) => {
     return () => {
       clearTimeout(timerRef.current);
     };
-  }, [map]);
+  }, []);
 
   useEffect(() => {
     if (!props.taskMarkers || props.delayMapLoad || !_isEqual(props.taskMarkers, prevProps.current.taskMarkers) || props.selectedClusters !== prevProps.current.selectedClusters) {


### PR DESCRIPTION
These errors typically occur when a user quickly navigates away from a page after interacting with the map. The issue arises because a either a setTimeout or debounce function is scheduled to execute shortly after a map move event. If the user navigates away from the map before this timeout completes, one of these errors will be thrown because the map no longer exists.

Related to the task marker view that uses setTimeout:
<img width="465" alt="Screenshot 2024-08-07 at 11 09 11 AM" src="https://github.com/user-attachments/assets/abf9eb3b-0c16-46e0-b35f-e7090a7af13c">
Related to the task cluster view that uses debounce:
<img width="471" alt="Screenshot 2024-08-07 at 11 10 11 AM" src="https://github.com/user-attachments/assets/d2d27b54-1a5d-4ce9-a4fa-a4a8b3e033a4">
