### PR TITLE
Show a warning when clicking 'I fixed it' if embedded Rapid editor has unsaved changes

### DIFF
--- a/src/components/HOCs/WithEditor/WithEditor.js
+++ b/src/components/HOCs/WithEditor/WithEditor.js
@@ -11,7 +11,8 @@ import AppErrors from '../../../services/Error/AppErrors'
  * WithEditor provides an editor prop to its WrappedComponent that contains the
  * current open editor (if any) from the redux store and the user's currently
  * configured editor (or the system default editor if none is configured), as
- * well as functions for interacting with editors
+ * well as functions for interacting with editors. If the embedded Rapid Editor
+ * is running, it also provides access to the RapidContext.
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
@@ -25,6 +26,7 @@ export const mapStateToProps = state => {
   return ({
     editor: state.openEditor,
     configuredEditor: _get(userEntity, 'settings.defaultEditor', DEFAULT_EDITOR),
+    rapidContext: _get(state, 'rapidEditor.context'),
   })
 }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -183,12 +183,18 @@ export class ActiveTaskControls extends Component {
   }
 
   initiateCompletion = (taskStatus, submitRevision) => {
-    this.setState({
-      confirmingTask: this.props.task,
-      osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(this.props.task)}`,
-      confirmingStatus: taskStatus,
-      submitRevision,
-    })
+    const hasUnsavedRapidChanges = this.props.rapidContext?.systems.editor.hasChanges()
+    const intl = this.props.intl
+    const message = intl.formatMessage(messages.rapidDiscardUnsavedChanges)
+
+    if (!hasUnsavedRapidChanges || window.confirm(message)) {
+      this.setState({
+        confirmingTask: this.props.task,
+        osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(this.props.task)}`,
+        confirmingStatus: taskStatus,
+        submitRevision,
+      })
+    }
   }
 
   confirmCompletion = () => {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
@@ -33,4 +33,9 @@ export default defineMessages({
     id: "Task.controls.viewChangeset.label",
     defaultMessage: "View Changeset",
   },
+
+  rapidDiscardUnsavedChanges: {
+    id: "Widgets.TaskMapWidget.rapidDiscardUnsavedChanges",
+    defaultMessage: "You have unsaved changes in Rapid which will be discarded. Are you sure you want to proceed?",
+  },
 })

--- a/src/components/Widgets/TaskMapWidget/RapidEditor/RapidEditor.js
+++ b/src/components/Widgets/TaskMapWidget/RapidEditor/RapidEditor.js
@@ -138,7 +138,7 @@ const RapidEditor = ({
 }) => {
   const dispatch = useDispatch();
   const [rapidLoaded, setRapidLoaded] = useState(window.Rapid !== undefined);
-  const { context, dom } = useSelector((state) => state.rapidEditor.rapidContext);
+  const { context, dom } = useSelector((state) => state.rapidEditor);
   const windowInit = typeof window !== 'undefined';
 
   // This significantly reduces build time _and_ means different TM instances can share the same download of Rapid.

--- a/src/services/RapidEditor/RapidEditor.js
+++ b/src/services/RapidEditor/RapidEditor.js
@@ -1,15 +1,13 @@
 export const SET_RAPIDEDITOR = 'SET_RAPIDEDITOR';
 
-const initialState = {
-  rapidContext: { context: null, dom: null },
-};
+const initialState = { context: null, dom: null };
 
 export function rapidEditor(state = initialState, action) {
   switch (action.type) {
     case SET_RAPIDEDITOR: {
       return {
         ...state,
-        rapidContext: action.context,
+        ...action.context,
       };
     }
     default:


### PR DESCRIPTION
Fixes #2162

When completing a task (i.e. clicking "I fixed it", "Can't complete", etc, all of which would advance to the next task), a confirmation window will now be shown if there are unsaved changes in the embedded Rapid editor. The confirmation is very basic (I just used `window.confirm()`) but should help prevent users from accidentally advancing to the next task without uploading their changes. I considered trying to make a more complex/styleable modal but decided not to for now since with my limited experience with the codebase it would have taken longer and might not have matched the existing design language that I'm still getting familiar with.

https://github.com/user-attachments/assets/5b4175f0-8488-4418-8182-cbd5bb8f715e

Tested:
1. The confirmation window is shown if there are unsaved changes in Rapid and the user clicks any of the buttons in the completion widget.
2. The confirmation window is not shown if there are no unsaved changes in the Rapid editor. This includes the scenario where the user did not interact with the Rapid editor at all before clicking a button. **I was unable to test the scenario where the user saves their changes in Rapid**, because my dev environment throws an unspecific error when I try to save. Is this a configuration issue I should look into?
3. The confirmation window is not shown if the embedded Rapid editor is not running.





