### PR TITLE
Fix the editor overwrite bug.

### DIFF
--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -96,15 +96,15 @@ export const editTask = function (
 
       if (editor === ID) {
         editorWindowReference = window.open(
-          constructIdURI(task, mapBounds, options, taskBundle, replacedComment)
+          constructIdURI(task, mapBounds, options, taskBundle, replacedComment), '_blank', 'noopener,noreferrer'
         );
       } else if (editor === LEVEL0) {
         editorWindowReference = window.open(
-          constructLevel0URI(task, mapBounds, options, taskBundle, replacedComment)
+          constructLevel0URI(task, mapBounds, options, taskBundle, replacedComment), '_blank', 'noopener,noreferrer'
         );
       } else if (editor === RAPID) {
         editorWindowReference = window.open(
-          constructRapidURI(task, mapBounds, options, replacedComment)
+          constructRapidURI(task, mapBounds, options, replacedComment), '_blank', 'noopener,noreferrer'
         );
       }
 


### PR DESCRIPTION
When testing: https://github.com/maproulette/maproulette3/pull/2388, I discovered that when a new editor is opened in the same session that the previous one is overwritten and deleted. This PR adds the expected functionality so that when a new editor is opened, the previous one also remains open.
Before:
https://github.com/user-attachments/assets/f53e538f-63c8-4f24-968b-2eb593cdb5d1

After:
https://github.com/user-attachments/assets/4618cdba-3d16-457b-bda7-0c080e8ec381


