### PR TITLE
include the show archived filter in the challenge result list

### DIFF
--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
@@ -11,10 +11,13 @@ import { challengePassesCategorizationKeywordsFilter }
        from '../../../services/Challenge/ChallengeCategorizationKeywords/ChallengeCategorizationKeywords';
 import { challengePassesLocationFilter }
        from '../../../services/Challenge/ChallengeLocation/ChallengeLocation'
+import { challengePassesArchivedFilter }
+       from '../../../services/Challenge/ChallengeArchived/ChallengeArchived'
 import { challengePassesProjectFilter }
        from '../../../services/Challenge/ChallengeProject/ChallengeProject'
 
 const allFilters = [
+  challengePassesArchivedFilter,
   challengePassesDifficultyFilter,
   challengePassesKeywordFilter,
   challengePassesCategorizationKeywordsFilter,

--- a/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
+++ b/src/services/Challenge/ChallengeArchived/ChallengeArchived.js
@@ -1,0 +1,7 @@
+export const challengePassesArchivedFilter = function(filter, challenge) {
+    if (!filter.archived) {
+      return challenge.isArchived === false
+    }
+  
+    return true
+  }


### PR DESCRIPTION
This pr includes the archived filter to the challenge result list. (Previously the archived filter would only filter markers on the map, not the challenges that were displayed in the list)