### PR TITLE
fix task unlock functionality in locked task widget

### DIFF
--- a/src/components/LockedTasks/LockedTasksWidget.js
+++ b/src/components/LockedTasks/LockedTasksWidget.js
@@ -65,7 +65,7 @@ const LockedTasks = (props) => {
 
   useEffect(() => {
     fetchLockedTasks();
-  }, [props.user]);
+  }, []);
 
   const LockedTasksList = () => {
     const sortedLockedTasks = [...lockedTasks].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt));


### PR DESCRIPTION
Issue: Whenever a user unlocked a task from this widget, the task unlocked would be immediatedly added back to the list of tasks that are locked.

This pr prevents the locked tasks from being refetched when a task is unlocked preventing this race condition from occurring.