### PR TITLE
fix empy mr tag bug

### DIFF
--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -47,7 +47,9 @@ export class ReviewTaskControls extends Component {
   setTags = tags => this.setState({tags})
 
   onConfirm = (alternateCriteria) => {
-    this.props.saveTaskTags(this.props.task, this.state.tags)
+    if(this.state.tags) {
+      this.props.saveTaskTags(this.props.task, this.state.tags)
+    }
     this.props.setCompletingTask(this.props.task.id)
 
     const history = _cloneDeep(this.props.history)
@@ -59,7 +61,7 @@ export class ReviewTaskControls extends Component {
     const errorTags = this.state.errorTags?.length ? this.state.errorTags : undefined
 
     this.props.updateTaskReviewStatus(this.props.task, this.state.reviewStatus,
-                                     this.state.comment, "",
+                                     this.state.comment, null,
                                      this.state.loadBy, history,
                                      this.props.taskBundle, requestedNextTask, null, errorTags)
     this.setState({ confirmingTask: false, comment: "", errorTags: [] })
@@ -102,8 +104,6 @@ export class ReviewTaskControls extends Component {
 
   /** Save Review Status */
   updateReviewStatus = (reviewStatus) => {
-    this.props.saveTaskTags(this.props.task, this.state.tags)
-
     this.setState({reviewStatus, confirmingTask: true})
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -150,14 +150,14 @@ export class ActiveTaskControls extends Component {
 
     if (!_isUndefined(this.state.submitRevision)) {
       this.props.updateTaskReviewStatus(this.props.task, this.state.submitRevision,
-                                        this.state.comment, "",
+                                        this.state.comment, null,
                                         this.state.revisionLoadBy, this.props.history,
                                         this.props.taskBundle, this.state.requestedNextTask,
                                         taskStatus)
     }
     else {
       this.props.completeTask(this.props.task, this.props.task.parent.id,
-                              taskStatus, this.state.comment, "",
+                              taskStatus, this.state.comment, null,
                               revisionSubmission ? null : this.props.taskLoadBy,
                               this.props.user.id,
                               revisionSubmission || this.state.needsReview,

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -143,7 +143,9 @@ export class ActiveTaskControls extends Component {
 
   /** Mark the task as complete with the given status */
   complete = taskStatus => {
-    this.props.saveTaskTags(this.props.task, this.state.tags)
+    if(this.state.tags) {
+      this.props.saveTaskTags(this.props.task, this.state.tags)
+    }
     this.props.setCompletingTask(this.props.task.id)
 
     const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected
@@ -153,7 +155,7 @@ export class ActiveTaskControls extends Component {
                                         this.state.comment, null,
                                         this.state.revisionLoadBy, this.props.history,
                                         this.props.taskBundle, this.state.requestedNextTask,
-                                        taskStatus)
+                                        taskStatus, null)
     }
     else {
       this.props.completeTask(this.props.task, this.props.task.parent.id,


### PR DESCRIPTION
Issue: An empty mr tag was being added on task completion whenever a task was submitted without any mr tags.

This pr solves that issue by preventing a null value from being passed the endpoint that saves tags.
Before fix:
<img width="709" alt="Screenshot 2024-08-15 at 6 00 18 PM" src="https://github.com/user-attachments/assets/59162ac9-b06a-4d84-9319-e40177624730">
After fix:
<img width="709" alt="Screenshot 2024-08-15 at 5 59 34 PM" src="https://github.com/user-attachments/assets/691d0a49-a5fe-4477-99e1-d48dbc88b5d2">
