### PR TITLE
refresh challenge on rebuild

### DIFF
--- a/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
@@ -40,20 +40,27 @@ export class RebuildTasksControl extends Component {
     })
   }
 
-  proceed = () => {
-    const removeUnmatched = this.state.removeUnmatchedTasks
-    const updatedFile = this.state.localFile ? this.state.localFile.file : null
+  proceed = async () => {
+    const { removeUnmatchedTasks, localFile, dataOriginDate } = this.state
+    const { challenge, recordSnapshot, deleteIncompleteTasks, rebuildChallenge, refreshChallenge } = this.props
+  
+    const updatedFile = localFile ? localFile.file : null
+  
     this.resetState()
-
-    this.props.recordSnapshot(this.props.challenge.id)
-
-    const deleteStepIfRequested = removeUnmatched ?
-                                  this.props.deleteIncompleteTasks(this.props.challenge) :
-                                  Promise.resolve()
-
-    deleteStepIfRequested.then(() => {
-      this.props.rebuildChallenge(this.props.challenge, updatedFile, this.state.dataOriginDate)
-    })
+    recordSnapshot(challenge.id)
+  
+    try {
+      if (removeUnmatchedTasks) {
+        await deleteIncompleteTasks(challenge)
+      }
+  
+      await rebuildChallenge(challenge, updatedFile, dataOriginDate)
+  
+    } catch (error) {
+      console.error('Error during proceed:', error)
+    }
+  
+    refreshChallenge()
   }
 
   render() {

--- a/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
@@ -23,6 +23,7 @@ export class RebuildTasksControl extends Component {
     removeUnmatchedTasks: false,
     localFilename: null,
     localFile: null,
+    dataOriginDate: null,
   }
 
   initiateConfirmation = () => this.setState({ confirming: true })
@@ -37,6 +38,7 @@ export class RebuildTasksControl extends Component {
       removeUnmatchedTasks: false,
       localFilename: null,
       localFile: null,
+      dataOriginDate: null,
     })
   }
 
@@ -45,6 +47,7 @@ export class RebuildTasksControl extends Component {
     const { challenge, recordSnapshot, deleteIncompleteTasks, rebuildChallenge, refreshChallenge } = this.props
   
     const updatedFile = localFile ? localFile.file : null
+    const originDate = dataOriginDate || challenge.dataOriginDate
   
     this.resetState()
     recordSnapshot(challenge.id)
@@ -54,7 +57,7 @@ export class RebuildTasksControl extends Component {
         await deleteIncompleteTasks(challenge)
       }
   
-      await rebuildChallenge(challenge, updatedFile, dataOriginDate)
+      await rebuildChallenge(challenge, updatedFile, originDate)
   
     } catch (error) {
       console.error('Error during proceed:', error)
@@ -64,14 +67,12 @@ export class RebuildTasksControl extends Component {
   }
 
   render() {
-    if (!this.props.challenge) {
-      return null
-    }
+    const { challenge, intl } = this.props
 
-    const challenge = AsManageableChallenge(this.props.challenge)
+    const manageableChallenge = AsManageableChallenge(challenge)
 
     let fileUploadArea = null
-    if (challenge.dataSource() === 'local') {
+    if (manageableChallenge.dataSource() === 'local') {
       const uploadContext = {}
       fileUploadArea = DropzoneTextUpload({
         id: 'geojson',
@@ -79,7 +80,7 @@ export class RebuildTasksControl extends Component {
         readonly: false,
         formContext: uploadContext,
         dropAreaClassName: "mr-text-green-white mr-border-matisse-blue mr-border-2 mr-rounded mr-text-sm mr-p-4 mr-cursor-pointer",
-        onChange: filename => {
+        onChange: (filename) => {
           this.setState({
             localFilename: filename,
             localFile: uploadContext.geojson,
@@ -91,7 +92,7 @@ export class RebuildTasksControl extends Component {
     let originDateField = null
     // Only offer an option to change the source origin date if it's a local file
     // we are uploading.
-    if (challenge.dataSource() === 'local') {
+    if (manageableChallenge.dataSource() === 'local') {
       originDateField = (
         <div>
           <label htmlFor="data-origin-date-input" className="mr-text-orange mr-mr-2">
@@ -131,14 +132,12 @@ export class RebuildTasksControl extends Component {
               <div className="mr-text-white">
                 <div>
                   <p>
-                    <FormattedMessage {...messages[challenge.dataSource()]} />
+                    <FormattedMessage {...messages[manageableChallenge.dataSource()]} />
                   </p>
 
                   <div>
                     <MarkdownContent
-                      markdown={this.props.intl.formatMessage(
-                        messages.explanation
-                      )}
+                      markdown={intl.formatMessage(messages.explanation)}
                     />
                   </div>
 
@@ -200,7 +199,7 @@ export class RebuildTasksControl extends Component {
 
                   <button
                     className="mr-button mr-button--danger"
-                    onClick={this.proceed}
+                    onClick={() => this.proceed()}
                   >
                     <FormattedMessage {...messages.proceed} />
                   </button>
@@ -217,6 +216,11 @@ export class RebuildTasksControl extends Component {
 RebuildTasksControl.propTypes = {
   challenge: PropTypes.object.isRequired,
   rebuildChallenge: PropTypes.func.isRequired,
+  recordSnapshot: PropTypes.func.isRequired,
+  deleteIncompleteTasks: PropTypes.func.isRequired,
+  refreshChallenge: PropTypes.func.isRequired,
+  controlClassName: PropTypes.string,
+  intl: PropTypes.object.isRequired,
 }
 
 export default injectIntl(RebuildTasksControl)

--- a/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.test.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.test.js
@@ -1,0 +1,162 @@
+import React from 'react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import { RebuildTasksControl } from './RebuildTasksControl'
+import { act } from 'react-dom/test-utils'
+
+jest.mock('../../../../interactions/Challenge/AsManageableChallenge', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation((challenge) => ({
+    ...challenge,
+    dataSource: () => 'local',
+  })),
+}))
+
+describe('RebuildTasksControl', () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      challenge: {
+        id: 1,
+        dataOriginDate: '2024-01-01',
+      },
+      recordSnapshot: jest.fn(),
+      deleteIncompleteTasks: jest.fn(),
+      rebuildChallenge: jest.fn(),
+      refreshChallenge: jest.fn(),
+      intl: {
+        formatMessage: jest.fn().mockImplementation(({ id }) => id),
+        formatDate: jest.fn(),
+      },
+    }
+  })
+
+  const renderComponent = (additionalProps = {}) => {
+    return render(
+      <IntlProvider locale="en">
+        <RebuildTasksControl {...props} {...additionalProps} />
+        <div>Test Passes</div>
+      </IntlProvider>
+    )
+  }
+
+  it("doesn't break if only required props are provided", () => {
+    renderComponent()
+    expect(screen.getByText("Test Passes")).toBeInTheDocument()
+  })
+
+  it('shows the modal when the control is clicked', () => {
+    renderComponent()
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+    expect(screen.getByText(/Rebuild Challenge Tasks/i)).toBeInTheDocument()
+  })
+
+  it('hides the modal when cancel button is clicked', async () => {
+    renderComponent()
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+    fireEvent.click(screen.getByText(/Cancel/i))
+    await waitFor(() => {
+      expect(screen.queryByText(/Rebuild Challenge Tasks/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('handles file upload correctly', async () => {
+    const { container } = renderComponent()
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+
+    await act(async () => {
+      const fileInput = container.querySelector('input[type="file"]')
+      if (fileInput) {
+        const file = new File(['test content'], 'test.geojson', { type: 'application/geojson' })
+        Object.defineProperty(fileInput, 'files', {
+          value: [file],
+          configurable: true,
+        })
+        fireEvent.change(fileInput)
+      }
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('test.geojson')).toBeInTheDocument()
+    })
+  })
+
+  it('handles checkbox change correctly and calls proceed function when checked', async () => {
+    const { rebuildChallenge, deleteIncompleteTasks, recordSnapshot, refreshChallenge } = props
+    renderComponent()
+
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+    const checkbox = screen.getByLabelText(/First remove incomplete tasks/i)
+    expect(checkbox.checked).toBe(false)
+
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Proceed/i))
+    })
+
+    await waitFor(() => {
+      expect(recordSnapshot).toHaveBeenCalledWith(props.challenge.id)
+      expect(rebuildChallenge).toHaveBeenCalledWith(props.challenge, null, '2024-01-01')
+      expect(deleteIncompleteTasks).toHaveBeenCalledWith(props.challenge)
+      expect(refreshChallenge).toHaveBeenCalled()
+    })
+  })
+
+  it('handles checkbox change correctly and calls proceed function when not checked', async () => {
+    const { rebuildChallenge, deleteIncompleteTasks, recordSnapshot, refreshChallenge } = props
+    renderComponent()
+
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+    const checkbox = screen.getByLabelText(/First remove incomplete tasks/i)
+    expect(checkbox.checked).toBe(false)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Proceed/i))
+    })
+
+    await waitFor(() => {
+      expect(recordSnapshot).toHaveBeenCalledWith(props.challenge.id)
+      expect(rebuildChallenge).toHaveBeenCalledWith(props.challenge, null, '2024-01-01')
+      expect(deleteIncompleteTasks).not.toHaveBeenCalled()
+      expect(refreshChallenge).toHaveBeenCalled()
+    })
+  })
+
+  it('logs an error during proceed if an error occurs', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    props.rebuildChallenge = jest.fn().mockImplementation(() => {
+      throw new Error('Simulated error')
+    })
+
+    renderComponent()
+
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Proceed/i))
+    })
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Error during proceed:', expect.any(Error))
+    })
+
+    consoleError.mockRestore()
+  })
+
+  it('updates state when input value changes', async () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByText(/Rebuild Tasks/i))
+
+    const inputField = screen.getByLabelText(/Date data was sourced/i)
+
+    fireEvent.change(inputField, { target: { value: '2024-12-31' } })
+
+    await screen.findByDisplayValue('2024-12-31')
+
+    expect(inputField.value).toBe('2024-12-31')
+  })
+})


### PR DESCRIPTION
Issue: When a user rebuilds a challenge, the application does not display a loading screen. As a result, users see the previous state of the challenge until they manually refresh the page to view the rebuilt challenge.

Solution: This pull request refreshes the challenge on rebuild so that the loading screen appears while the challenge is being rebuilt. Additionally, it ensures that the challenge is automatically refreshed once the rebuild process is complete, providing users with an immediate view of the updated challenge.

Extra: This pull request adds some jest unit tests and sets the default for dataOriginDate as the current challenges dataOriginDate