### PR TITLE
prevent osm/external id updates in challenge edit forms

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -652,6 +652,11 @@ will not be able to make sense of it.
       "(https://learn.maproulette.org/documentation/setting-external-task-identifiers/).",
   },
 
+  disableOsmIdProperty: {
+    id: "Admin.EditChallenge.form.disableOsmIdProperty",
+    defaultMessage: "This ID cannot be edited after challenge creation, this is to prevent task duplication. [Learn more](https://learn.maproulette.org/documentation/setting-external-task-identifiers/)."
+  },
+
   customTaskStyleLabel: {
     id: "Admin.EditChallenge.form.customTaskStyles.label",
     defaultMessage: "Customize Task Property Styles",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
@@ -1,3 +1,4 @@
+import AsEditableChallenge from "../../../../../../interactions/Challenge/AsEditableChallenge";
 import messages from "../Messages";
 
 const STEP_ID = "Properties";
@@ -66,6 +67,7 @@ export const uiSchema = (
   extraErrors,
   options = {}
 ) => {
+  const sourceReadOnly = AsEditableChallenge(challengeData)
   const isCollapsed =
     options.longForm && (options.collapsedGroups || []).indexOf(STEP_ID) === -1;
   const toggleCollapsed =
@@ -91,6 +93,8 @@ export const uiSchema = (
       "ui:emptyValue": "",
       "ui:help": intl.formatMessage(messages.osmIdPropertyDescription),
       "ui:collapsed": isCollapsed,
+      "ui:description": intl.formatMessage(messages.disableOsmIdProperty),
+      "ui:readonly": sourceReadOnly,
     },
     customTaskStyles: {
       "ui:field": "configureCustomTaskStyles",


### PR DESCRIPTION
Partially resolves: https://github.com/maproulette/maproulette3/issues/1736

- [ ] need to still update documentation

<img width="644" alt="Screenshot 2024-08-29 at 7 05 05 PM" src="https://github.com/user-attachments/assets/be50a41d-4881-4055-a8f8-a48cb7777217">
