### PR TITLE
fix infinite loop for users without a widget layout

### DIFF
--- a/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
+++ b/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
@@ -38,23 +38,6 @@ export const WithWidgetWorkspacesInternal = function(WrappedComponent,
   return class extends Component {
     state = {
       currentConfigurationId: null,
-      currentConfiguration: {}
-    }
-
-    componentDidMount() {
-      if(this.props.user){
-        const configurations = this.workspaceConfigurations()
-        const currentConfiguration = this.currentConfiguration(configurations)
-        this.setState({currentConfiguration})
-      }
-    }
-
-    componentDidUpdate(prevProps) {
-      if(this.props.user && this.props.user.id !== prevProps.user?.id) {
-        const configurations = this.workspaceConfigurations()
-        const currentConfiguration = this.currentConfiguration(configurations)
-        this.setState({currentConfiguration})
-      }
     }
 
     /**
@@ -385,7 +368,7 @@ export const WithWidgetWorkspacesInternal = function(WrappedComponent,
       }
 
       const configurations = this.workspaceConfigurations()
-      const currentConfiguration = this.state.currentConfiguration
+      const currentConfiguration = this.currentConfiguration(configurations)
       const remainingConfigurations = currentConfiguration ?
                                       _omit(configurations, [currentConfiguration.id]) :
                                       configurations

--- a/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
+++ b/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
@@ -38,6 +38,7 @@ export const WithWidgetWorkspacesInternal = function(WrappedComponent,
   return class extends Component {
     state = {
       currentConfigurationId: null,
+      defaultWorkspace: null
     }
 
     /**
@@ -313,18 +314,20 @@ export const WithWidgetWorkspacesInternal = function(WrappedComponent,
     currentConfiguration = configurations => {
       let currentWorkspace =
         configurations[this.state.currentConfigurationId] ||
-        _find(configurations, config => config.active && !config.isBroken) ||
-        _find(configurations, config => !config.isBroken)
+        _find(configurations, ({ active, isBroken }) => active && !isBroken) ||
+        _find(configurations, ({ isBroken }) => !isBroken) ||
+        this.state.defaultWorkspace
     
-      // If no working workspace is found, create and save a fresh default
       if (!currentWorkspace) {
-        currentWorkspace = this.setupWorkspace(defaultConfiguration)
-        this.saveWorkspaceConfiguration(currentWorkspace)
+        const defaultWorkspace = this.setupWorkspace(defaultConfiguration)
+        this.saveWorkspaceConfiguration(defaultWorkspace)
+        this.setState({ defaultWorkspace })
+        currentWorkspace = defaultWorkspace
       }
     
-      return this.completeWorkspaceConfiguration(currentWorkspace)
+      return currentWorkspace ? this.completeWorkspaceConfiguration(currentWorkspace) : null
     }
-
+    
     /**
      * Add a new, default workspace configuration
      */


### PR DESCRIPTION
This fix addresses an infinite loop that occurs when the user doesn't have a configured widget layout. The solution creates a default widget layout if no other layouts are found and uses it to handle this one-time edge case for users without an existing configuration.