### PR TITLE
Show owner name on challenge and project pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "react/jsx-no-duplicate-props": "warn",
     "react/jsx-no-target-blank": "warn",
     "react/no-unknown-property": "warn",
+    "react/jsx-no-target-blank": 0,
     "react/prop-types": 0
   },
   "overrides": [

--- a/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
+++ b/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
@@ -10,6 +10,7 @@ import { challengeDenormalizationSchema,
          fetchChallengeComments,
          fetchChallengeActivity,
          fetchChallengeActions } from '../../../../services/Challenge/Challenge'
+import { fetchBasicUser } from '../../../../services/User/User'
 import { addError } from '../../../../services/Error/Error'
 import AppErrors from '../../../../services/Error/AppErrors'
 import AsManageableChallenge
@@ -47,6 +48,7 @@ const WithCurrentChallenge = function(WrappedComponent) {
 
             if (this.props.user) {
               Promise.all([
+                this.props.fetchUser(challenge.owner),
                 this.props.fetchChallengeComments(challengeId),
                 this.props.fetchChallengeActivity(challengeId, new Date(challenge?.created)),
                 this.props.fetchChallengeActions(challengeId),
@@ -71,6 +73,7 @@ const WithCurrentChallenge = function(WrappedComponent) {
     render() {
       const challengeId = this.currentChallengeId()
       let challenge = null
+      let owner = null
       let clusteredTasks = null
 
       if (_isFinite(challengeId)) {
@@ -79,10 +82,13 @@ const WithCurrentChallenge = function(WrappedComponent) {
                       challengeDenormalizationSchema(),
                       this.props.entities)
         )
+        owner = Object.values(this.props.entities.users)
+          .find(user => user.osmProfile.id === challenge.owner);
       }
 
       return <WrappedComponent key={challengeId}
                                challenge={challenge}
+                               owner={owner}
                                clusteredTasks={clusteredTasks}
                                loadingChallenge={this.state.loadingChallenge}
                                refreshChallenge={this.loadChallenge}
@@ -121,9 +127,10 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchChallengeActivity: (challengeId, startDate, endDate) =>
     dispatch(fetchChallengeActivity(challengeId, startDate, endDate)),
 
-  fetchChallengeActions: (challengeId, suppressReceive, criteria) => {
-    return dispatch(fetchChallengeActions(challengeId, suppressReceive, criteria))
-  },
+  fetchChallengeActions: (challengeId, suppressReceive, criteria) =>
+    dispatch(fetchChallengeActions(challengeId, suppressReceive, criteria)),
+
+  fetchUser: userId => dispatch(fetchBasicUser(userId)),
 })
 
 export default (WrappedComponent) =>

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -397,8 +397,8 @@ export class ChallengeDetail extends Component {
   }
 
   render() {
-    const challenge = this.props.browsedChallenge;
-    if (!_isObject(challenge) || this.props.loadingBrowsedChallenge) {
+    const { challenge, owner } = this.props;
+    if (!_isObject(challenge) || !_isObject(owner) || this.props.loadingBrowsedChallenge) {
       return (
         <div className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-min-h-screen-50 mr-items-center mr-justify-center lg:mr-flex mr-text-center mr-py-8">
           <BusySpinner />
@@ -562,6 +562,19 @@ export class ChallengeDetail extends Component {
                           day="2-digit"
                         />
                       </li>
+                      <li>
+                        <strong className="mr-text-yellow">
+                          <FormattedMessage {...messages.ownerLabel} />:
+                        </strong>{' '}
+                        <a
+                          className="mr-text-green-lighter hover:mr-text-white"
+                          href={process.env.REACT_APP_OSM_SERVER + '/user/' + owner.osmProfile.displayName}
+                          target="_blank"
+                          rel="noopener"
+                        >
+                          {owner.osmProfile.displayName}
+                        </a>
+                      </li>
                       {/* Disable Link tell project leaderboard page is reimplemented */}
                       {/* <li>
                         <Link
@@ -589,7 +602,11 @@ export class ChallengeDetail extends Component {
 export default WithCurrentUser(
   WithClusteredTasks(
     WithStartChallenge(
-      WithBrowsedChallenge(WithCurrentChallenge(injectIntl(ChallengeDetail)))
+      WithBrowsedChallenge(
+        WithCurrentChallenge(
+          injectIntl(ChallengeDetail)
+        )
+      )
     )
   )
 )

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -397,7 +397,7 @@ export class ChallengeDetail extends Component {
   }
 
   render() {
-    const { challenge, owner } = this.props;
+    const { browsedChallenge: challenge, owner } = this.props;
     if (!_isObject(challenge) || !_isObject(owner) || this.props.loadingBrowsedChallenge) {
       return (
         <div className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-min-h-screen-50 mr-items-center mr-justify-center lg:mr-flex mr-text-center mr-py-8">

--- a/src/components/ChallengeDetail/ChallengeDetail.test.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.test.js
@@ -29,6 +29,7 @@ describe("ChallengeDetail", () => {
           lastTaskRefresh: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"),
           dataOriginDate: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx").slice(0, 10),
         }}
+        owner={{ id: 2, osmProfile: { displayName: "Somebody" } }}
         intl={{
           formatMessage: () => '',
           formatDate: () => '',
@@ -59,6 +60,7 @@ describe("ChallengeDetail", () => {
           dataOriginDate: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx").slice(0, 10),
           enabled: true,
         }}
+        owner={{ id: 2, osmProfile: { displayName: "Somebody" } }}
         intl={{
           formatMessage: () => '',
           formatDate: () => '',

--- a/src/components/ChallengeDetail/Messages.js
+++ b/src/components/ChallengeDetail/Messages.js
@@ -54,6 +54,11 @@ export default defineMessages({
     defaultMessage: "Task Data Sourced",
   },
 
+  ownerLabel: {
+    id: 'ChallengeDetails.fields.owner.label',
+    defaultMessage: 'Owner',
+  },
+
   dataOriginDateLabel: {
     id: "ChallengeDetails.fields.lastChallengeDetails.DataOriginDate.label",
     defaultMessage: "Tasks built on {refreshDate} from data sourced on {sourceDate}.",

--- a/src/components/HOCs/WithProject/WithProject.js
+++ b/src/components/HOCs/WithProject/WithProject.js
@@ -11,6 +11,7 @@ import { fetchProject } from '../../../services/Project/Project'
 import { fetchProjectChallenges,
          fetchProjectChallengeActions }
        from '../../../services/Challenge/Challenge'
+import { fetchBasicUser } from '../../../services/User/User'
 import { PROJECT_CHALLENGE_LIMIT } from '../../../services/Project/Project'
 
 
@@ -57,6 +58,12 @@ const WithProject = function(WrappedComponent, options={}) {
             const project = normalizedProject.entities.projects[normalizedProject.result]
             this.setState({project: project})
 
+            if (options.includeOwner) {
+              let normalizedOwner = await props.fetchUser(project.owner);
+              let owner = normalizedOwner.entities.users[normalizedOwner.result];
+              this.setState({ owner })
+            }
+
             if (options.includeChallenges) {
               const retrievals = []
               retrievals.push(props.fetchProjectChallenges(projectId))
@@ -97,10 +104,17 @@ const WithProject = function(WrappedComponent, options={}) {
         challenges = this.challengeProjects(this.state.project.id, this.props)
       }
 
+      let owner = this.props.owner
+      if (options.includeOwner) {
+        owner = this.state.owner
+      }
+
       return <WrappedComponent {..._omit(this.props, ['fetchProject',
                                                       'fetchProjectChallenges',
-                                                      'fetchProjectChallengeActions'])}
+                                                      'fetchProjectChallengeActions',
+                                                      'fetchUser'])}
                                project={this.state.project}
+                               owner={owner}
                                challenges={challenges} />
     }
   }
@@ -116,6 +130,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(fetchProjectChallenges(projectId, -1)),
   fetchProjectChallengeActions: projectId =>
     dispatch(fetchProjectChallengeActions(projectId, false, false)),
+  fetchUser: userId => dispatch(fetchBasicUser(userId)),
 })
 
 export default (WrappedComponent, options) =>

--- a/src/components/ProjectDetail/Messages.js
+++ b/src/components/ProjectDetail/Messages.js
@@ -46,6 +46,11 @@ export default defineMessages({
     defaultMessage: "Featured",
   },
 
+  ownerLabel: {
+    id: "ProjectDetails.fields.owner.label",
+    defaultMessage: "Owner",
+  },
+
   createdOnLabel: {
     id: "ProjectDetails.fields.created.label",
     defaultMessage: "Created",

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -38,8 +38,8 @@ export class ProjectDetail extends Component {
   }
 
   render() {
-    const project = this.props.project
-    if (!_isObject(project)) {
+    const { project, owner } = this.props;
+    if (!_isObject(project) || !_isObject(owner)) {
       return (
         <div className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-min-h-screen-50 mr-items-center mr-justify-center lg:mr-flex mr-text-center mr-py-8">
           <BusySpinner />
@@ -116,20 +116,27 @@ export class ProjectDetail extends Component {
                     <ol className="mr-card-challenge__meta">
                       <li>
                         <strong className="mr-text-yellow">
-                          <FormattedMessage
-                            {...messages.createdOnLabel}
-                          />
-                          :
+                          <FormattedMessage {...messages.ownerLabel} />:
+                        </strong>{' '}
+                        <a
+                          className="mr-text-green-lighter hover:mr-text-white"
+                          href={process.env.REACT_APP_OSM_SERVER + '/user/' + owner.osmProfile.displayName}
+                          target="_blank"
+                          rel="noopener"
+                        >
+                          {owner.osmProfile.displayName}
+                        </a>
+                      </li>
+                      <li>
+                        <strong className="mr-text-yellow">
+                          <FormattedMessage {...messages.createdOnLabel} />:
                         </strong>{' '}
                         <FormattedDate value={parseISO(project.created)}
                                         year='numeric' month='long' day='2-digit' />
                       </li>
                       <li>
                         <strong className="mr-text-yellow">
-                          <FormattedMessage
-                            {...messages.modifiedOnLabel}
-                          />
-                          :
+                          <FormattedMessage {...messages.modifiedOnLabel} />:
                         </strong>{' '}
                         <FormattedDate value={parseISO(project.modified)}
                                         year='numeric' month='long' day='2-digit' />
@@ -196,6 +203,6 @@ export default WithCurrentUser(
           )
         )
       )
-    ), {includeChallenges: true}
+    ), {includeChallenges: true, includeOwner: true}
   )
 )

--- a/src/components/ProjectDetail/ProjectDetail.test.js
+++ b/src/components/ProjectDetail/ProjectDetail.test.js
@@ -8,6 +8,7 @@ describe("ProjectDetail", () => {
     const { getByText } = global.withProvider(
       <ProjectDetail
         project={{ id: 1, created: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"), modified: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx") }}
+        owner={{ id: 2, osmProfile: { displayName: "Somebody" } }}
         unfilteredChallenges={[]}
       />
     );


### PR DESCRIPTION
Closes #1899. Owner names are now shown on the challenge pages (next to challenge difficulty and data source date). The name is a clickable link to the user's OSM profile page.

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/ff7cc247-2ff9-40e9-a3a0-6793167eb2b5">

I've also added a similar link to the Project pages.

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/35cf8a07-630b-4408-82b3-2fffd1805393">
