### PR TITLE
Improve error messages when Rapid editor fails to load

### DIFF
--- a/public/static/rapid-editor.html
+++ b/public/static/rapid-editor.html
@@ -4,9 +4,6 @@
     <meta charset='utf-8'>
     <!-- Adapted from Rapid's code examples at https://github.com/facebook/Rapid/tree/main/dist/examples -->
     <title>Rapid Editor</title>
-    <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/@rapideditor/rapid@2.3/dist/rapid.min.js'></script>
-    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@rapideditor/rapid@2.3/dist/rapid.min.css'>
-
     <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'/>
     <meta name='mobile-web-app-capable' content='yes'/>
     <meta name='apple-mobile-web-app-status-bar-style' content='black-translucent'/>
@@ -25,12 +22,29 @@
   <body>
     <div id='rapid-container'></div>
 
-    <script>
-      function setupRapid(container) {
-        if (typeof Rapid === 'undefined' || !Rapid.utilDetect().support) {
-          container.innerHTML = 'Sorry, the Rapid editor does not support your web browser.';
-          container.style.padding = '20px';
-          return;
+    <script type="module">
+      // TODO: this should be a variable in .env but Create React App doesn't run
+      // Webpack on files in public/ so we can't access those variables here yet.
+      const RAPID_CDN_URL = 'https://cdn.jsdelivr.net/npm/@rapideditor/rapid@2.3/dist/';
+
+      // add Rapid CSS stylesheet link to the document head
+      // (this causes the browser to load the stylesheet asynchronously)
+      let stylesheet = document.createElement('link');
+      stylesheet.rel = 'stylesheet';
+      stylesheet.href = RAPID_CDN_URL + 'rapid.min.css';
+      document.head.append(stylesheet);
+
+      // load Rapid JS (this is a compiled bundle, not an ES module;
+      // window.Rapid will be defined after it executes)
+      await import(RAPID_CDN_URL + 'rapid.min.js');
+
+      async function setupRapid(container) {
+        if (typeof Rapid === 'undefined') {
+          throw new Error(`The bundle loaded from ${RAPID_CDN_URL} did not set window.Rapid`);
+        }
+
+        if (!Rapid.utilDetect().support) {
+          throw new Error('Sorry, the Rapid editor does not support your web browser.');
         }
 
         // Get the token passed in from the parent window. May be null in dev mode.
@@ -46,7 +60,7 @@
         // Create and configure the main editor Context
         const context = new Rapid.Context();
         context.containerNode = container;
-        context.assetPath = 'https://cdn.jsdelivr.net/npm/@rapideditor/rapid@2.3/dist/';
+        context.assetPath = RAPID_CDN_URL;
 
         if (token) {
           context.preauth =  {
@@ -66,12 +80,11 @@
           );
         }
 
-        window.rapidContext = context; // allow parent window to access context
-        context.initAsync();
+        await context.initAsync();
+        return context;
       }
 
-      const container = document.getElementById('rapid-container');
-      setupRapid(container);
+      window.setupRapid = () => setupRapid(document.getElementById('rapid-container'));
     </script>
   </body>
 </html>


### PR DESCRIPTION
Previously if Rapid failed to load from the CDN, a user would see a message that the Rapid editor didn't support their browser, which was confusing. The text was also rendered inside the iframe, so it displayed in the browser default style (black, serif), which is hard to read against MapRoulette's dark green background.

This PR changes the way the iframe initializes. The parent now has to call `iframe.contentWindow.setupRapid()`, which returns a promise. The promise normally resolves with a Rapid editor context. If it rejects, it provides an error message that tells the user what went wrong. The `RapidEditor` component has been adjusted to call this method and display any error that it returns to the user. I've made sure to return different error messages in the case where Rapid fails to load from the CDN vs when it loads but then detects that the user's browser is not supported.

I've also changed the way Rapid's JavaScript bundle and CSS stylesheet are loaded, in order to deduplicate the occurrences of the Rapid CDN URL to a single constant definition. This will make it easier to implement #2438, although there are still some more problems to solve before that can be completed (I left a source code comment with a bit more details on this).