### PR TITLE
Prevent codecov from polluting PRs with useless comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: 18%
         threshold: 1%
+comment: false


### PR DESCRIPTION
I find it really annoying that Codecov posts a comment on every single PR review (triggering a notification). And I find it extremely hard to review other people's PRs in the web UI when Codecov has put a big warning next to every third line of code saying that it's not covered (like in the screenshot below).

So I'm proposing to silence its comments on PRs. You can still view the coverage report in the "Checks" tab of the PR.

Discussion welcome if you feel that these features are useful and don't want them turned off.

<img width="796" alt="image" src="https://github.com/user-attachments/assets/556a8d0b-735a-4516-ae01-fec0af9ef66a">
