### PR TITLE
Profile: Add dom `id` to api key section

### DIFF
--- a/src/pages/Profile/ApiKey.js
+++ b/src/pages/Profile/ApiKey.js
@@ -9,7 +9,7 @@ import messages from './Messages'
 export default class ApiKey extends Component {
   render() {
     return (
-      <section className="mr-section">
+      <section className="mr-section" id="apikey">
         <header className="mr-section__header mr-flex mr-items-center mr-justify-between mr-mb-8">
           <h2 className="mr-h4 mr-text-white">
             <FormattedMessage {...messages.apiKey} />


### PR DESCRIPTION
… to use ad a jump mark like https://maproulette.org/user/profile#apikey

Why: Right now, pages have to explain in text "your api key is listed at the bottom of URL". This UX can be improved easily by allowing to jump to a section via a hash URL.

Those places can then be updates:
- https://github.com/maproulette/maproulette-backend/pull/1149
- https://github.com/osmlab/maproulette-python-client/tree/master?tab=readme-ov-file#getting-started