### PR TITLE
fix infinite loading screen on challenge browse page

### DIFF
--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -398,7 +398,7 @@ export class ChallengeDetail extends Component {
 
   render() {
     const { browsedChallenge: challenge, owner } = this.props;
-    if (!_isObject(challenge) || !_isObject(owner) || this.props.loadingBrowsedChallenge) {
+    if (!_isObject(challenge) || this.props.loadingBrowsedChallenge) {
       return (
         <div className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-min-h-screen-50 mr-items-center mr-justify-center lg:mr-flex mr-text-center mr-py-8">
           <BusySpinner />
@@ -562,6 +562,7 @@ export class ChallengeDetail extends Component {
                           day="2-digit"
                         />
                       </li>
+                      {_isObject(owner) ?
                       <li>
                         <strong className="mr-text-yellow">
                           <FormattedMessage {...messages.ownerLabel} />:
@@ -575,6 +576,7 @@ export class ChallengeDetail extends Component {
                           {owner.osmProfile.displayName}
                         </a>
                       </li>
+                      : null}
                       {/* Disable Link tell project leaderboard page is reimplemented */}
                       {/* <li>
                         <Link


### PR DESCRIPTION
Fixes bug where, when the user is signed out, the challenge browse page loads infinitely.
<img width="926" alt="Screenshot 2024-10-01 at 8 53 56 AM" src="https://github.com/user-attachments/assets/18be64b6-94e6-4830-9894-c874b4deb215">

The issue occurred because we retrieve the owner ID from the challenge data. Previously, users were required to be logged in with proper authentication to access certain high-load endpoints. If a user wasn’t logged in, the system would return an empty array. Since this empty array lacked the owner object, the UI failed to meet the conditions needed to move past the loading spinner, causing the bug."