### PR TITLE
Enable Challenge and Project leaderboards

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,8 @@ import Profile from './pages/Profile/Profile'
 import Metrics from './pages/Metrics/Metrics'
 import Dashboard from './pages/Dashboard/Dashboard.js'
 import Leaderboard from './pages/Leaderboard/Leaderboard'
-// Disable Pages till leaderboards support unique queries
-// import ChallengeLeaderboard from './pages/Leaderboard/ChallengeLeaderboard'
-// import ProjectLeaderboard from './pages/Leaderboard/ProjectLeaderboard'
+import ChallengeLeaderboard from './pages/Leaderboard/ChallengeLeaderboard'
+import ProjectLeaderboard from './pages/Leaderboard/ProjectLeaderboard'
 // import CountryLeaderboard from './pages/Leaderboard/CountryLeaderboard'
 import ChallengePane from './components/ChallengePane/ChallengePane'
 import ChallengeDetail from './components/ChallengeDetail/ChallengeDetail'
@@ -137,10 +136,9 @@ export class App extends Component {
             <CachedRoute path='/teams' component={Teams} />
             <CachedRoute path='/social' component={Social} />
             <CachedRoute path='/activity' component={GlobalActivity} />
-            {/* Disable Pages till leaderboards support unique queries */}
-            {/* <CachedRoute path='/challenge/:challengeId/leaderboard' component={ChallengeLeaderboard} />
+            <CachedRoute path='/challenge/:challengeId/leaderboard' component={ChallengeLeaderboard} />
             <CachedRoute path='/project/:projectId/leaderboard' component={ProjectLeaderboard} />
-            <CachedRoute path='/country/:countryCode/leaderboard' component={CountryLeaderboard} /> */}
+             {/* <CachedRoute path='/country/:countryCode/leaderboard' component={CountryLeaderboard} /> */}
             <CachedRoute path='/challenge/:challengeId/task/:taskId/inspect' component={InspectTask} />
             <CachedRoute path='/challenge/:challengeId/task/:taskId/review' component={CurrentReviewTaskPane} />
             <CachedRoute path='/challenge/:challengeId/task/:taskId/meta-review' component={CurrentMetaReviewTaskPane}/>

--- a/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard.js
+++ b/src/components/AdminPane/Manage/ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard.js
@@ -14,14 +14,9 @@ export default class ChallengeOwnerLeaderboard extends Component {
   render() {
     const userType = this.props.userType
 
-    if(userType === "mapper") return (
-      <div className="mr-mt-8 mr-text-red"> <FormattedMessage {...messages.challengeOwnerLeaderboardDisabled}/></div>
-   )
-
     if (!this.props.leaderboard) {
       return null
     }
-
 
     const showNumberTasks = this.props.leaderboard.length > 0 ?
       this.props.leaderboard[0].completedTasks > 0 : false

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -141,8 +141,7 @@ export class ProjectDetail extends Component {
                         <FormattedDate value={parseISO(project.modified)}
                                         year='numeric' month='long' day='2-digit' />
                       </li>
-                      {/* Disable Link tell project leaderboard page is reimplemented */}
-                      {/* {_get(this.props, 'challenges.length', 0) > 0 &&
+                      {_get(this.props, 'challenges.length', 0) > 0 &&
                         <li>
                           <Link
                             className="mr-text-green-lighter hover:mr-text-white"
@@ -151,7 +150,7 @@ export class ProjectDetail extends Component {
                             <FormattedMessage {...messages.viewLeaderboard} />
                           </Link>
                         </li>
-                      } */}
+                      }
                     </ol>
 
                     <div className="mr-card-challenge__description">

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -3,7 +3,6 @@ import _isArray from 'lodash/isArray'
 import Endpoint from '../Server/Endpoint'
 import { startOfMonth, endOfDay } from 'date-fns'
 import { CHALLENGE_INCLUDE_LOCAL } from '../Challenge/Challenge'
-import { setupCustomCache } from '../../utils/setupCustomCache'
 import { addError } from '../Error/Error'
 import AppErrors from '../Error/AppErrors'
 
@@ -27,8 +26,6 @@ const CACHE_TIME = 60 * 60 * 1000;
 const GLOBAL_LEADERBOARD_CACHE = "globalLeaderboard";
 const USER_LEADERBOARD_CACHE = "userLeaderboard";
 
-const leaderboardCache = setupCustomCache(CACHE_TIME);
-
 /**
  * Retrieve leaderboard data from the server for the given date range and
  * filters, returning a Promise that resolves to the leaderboard data. Note
@@ -47,17 +44,17 @@ export const fetchLeaderboard = (numberMonths=null, onlyEnabled=true,
     initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
     forUsers, forCountries, startDate, endDate)
 
-    const cachedLeaderboard = leaderboardCache.get({}, params, GLOBAL_LEADERBOARD_CACHE);
-
-    if (cachedLeaderboard) {
-      return cachedLeaderboard;
-    }
-
     try {
-      const results = await new Endpoint(api.users.leaderboard, { params }).execute()
+      let results;
 
-      if (results) {
-        leaderboardCache.set({}, params, results, GLOBAL_LEADERBOARD_CACHE)
+      if (forProjects && forProjects.length > 0) {
+        const projectId = forProjects[0];
+        results = await new Endpoint(api.user.projectLeaderboard, { params: { ...params, projectId } }).execute()
+      } else if (forChallenges && forChallenges.length > 0) {
+        const challengeId = forChallenges[0];
+        results = await new Endpoint(api.user.challengeLeaderboard, { params: { ...params, challengeId } }).execute()
+      } else {
+        results = await new Endpoint(api.users.leaderboard, { params }).execute()
       }
 
       return results
@@ -95,17 +92,19 @@ export const fetchLeaderboardForUser = (userId, bracket=0, numberMonths=1,
   initializeLeaderboardParams(params, numberMonths, forProjects, forChallenges,
                               null, forCountries, startDate, endDate)
 
-  const cachedLeaderboard = leaderboardCache.get(variables, params, USER_LEADERBOARD_CACHE);
-
-  if (cachedLeaderboard) {
-    return cachedLeaderboard;
-  }
-
     try {
-      const results = await new Endpoint(api.users.userLeaderboard, {variables, params}).execute()
+      let results;
 
-      if (results) {
-        leaderboardCache.set(variables, params, results, USER_LEADERBOARD_CACHE)
+      if (forProjects && forProjects.length > 0) {
+        //disabling project user ranks for now
+        //const projectId = forProjects[0];
+        //results = await new Endpoint(api.user.projectLeaderboardForUser, { params: { ...params, projectId }, variables: { userId } }).execute()
+        return []
+      } else if (forChallenges && forChallenges.length > 0) {
+        const challengeId = forChallenges[0];
+        results = await new Endpoint(api.user.challengeLeaderboardForUser, { params: { ...params, challengeId }, variables: { userId } }).execute()
+      } else {
+        results = await new Endpoint(api.users.userLeaderboard, {variables, params}).execute()
       }
 
       return results;

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -96,7 +96,7 @@ export const fetchLeaderboardForUser = (userId, bracket=0, numberMonths=1,
       let results;
 
       if (forProjects && forProjects.length > 0) {
-        //disabling project user ranks for now
+        //disabling project user ranks for now, as it's not supported by the backend
         //const projectId = forProjects[0];
         //results = await new Endpoint(api.user.projectLeaderboardForUser, { params: { ...params, projectId }, variables: { userId } }).execute()
         return []

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -191,7 +191,11 @@ const apiRoutes = (factory) => {
       notifications: factory.get("/user/:userId/notifications"),
       markNotificationsRead: factory.put("/user/:userId/notifications"),
       deleteNotifications: factory.put("/user/:userId/notifications/delete"),
-      announcements: factory.get("/user/announcements")
+      announcements: factory.get("/user/announcements"),
+      challengeLeaderboard: factory.get("/data/user/challengeLeaderboard"),
+      projectLeaderboard: factory.get("/data/user/projectLeaderboard"),
+      challengeLeaderboardForUser: factory.get("/data/user/:userId/challengeLeaderboard"),
+      projectLeaderboardForUser: factory.get("/data/user/:userId/projectLeaderboard")
     },
     teams: {
       find: factory.get("/teams/find"),

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -195,7 +195,7 @@ const apiRoutes = (factory) => {
       challengeLeaderboard: factory.get("/data/user/challengeLeaderboard"),
       projectLeaderboard: factory.get("/data/user/projectLeaderboard"),
       challengeLeaderboardForUser: factory.get("/data/user/:userId/challengeLeaderboard"),
-      projectLeaderboardForUser: factory.get("/data/user/:userId/projectLeaderboard")
+      // projectLeaderboardForUser: factory.get("/data/user/:userId/projectLeaderboard")
     },
     teams: {
       find: factory.get("/teams/find"),


### PR DESCRIPTION
Requires: https://github.com/maproulette/maproulette-backend/pull/1152

This PR re-enables project and challenge leaderboards by utilizing new safe endpoints.

-Top user leaderboard for Challenges
-Top user leaderboard for Projects
-User ranking in Challenges (if user is not near the top, their ranking will still be shown)

User rankings for projects will not be included in this PR.  Comments in the codebase have been included.