### PR TITLE
re-enable view challenge leaderboard link

### DIFF
--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -577,15 +577,14 @@ export class ChallengeDetail extends Component {
                         </a>
                       </li>
                       : null}
-                      {/* Disable Link tell project leaderboard page is reimplemented */}
-                      {/* <li>
+                      <li>
                         <Link
                           className="mr-text-green-lighter hover:mr-text-white"
                           to={`/challenge/${challenge.id}/leaderboard`}
                         >
                           <FormattedMessage {...messages.viewLeaderboard} />
                         </Link>
-                      </li> */}
+                      </li>
                       <div className="mr-mb-3" />
                       {this.renderDetailTabs()}
                     </ol>


### PR DESCRIPTION
Re enable "view leaderboard" on challenge browse page. 

<img width="404" alt="Screenshot 2024-10-15 at 7 37 38 PM" src="https://github.com/user-attachments/assets/c6814f5c-8d9c-426b-940d-129c17a1263d">
