### PR TITLE
fix rapid race condition

### DIFF
--- a/public/static/rapid-editor.html
+++ b/public/static/rapid-editor.html
@@ -84,7 +84,12 @@
         return context;
       }
 
-      window.setupRapid = () => setupRapid(document.getElementById('rapid-container'));
+      try {
+        const context = await setupRapid(document.getElementById('rapid-container'));
+        window.dispatchEvent(new CustomEvent('setupRapidComplete', { detail: { context }  }));
+      } catch (error) {
+        window.dispatchEvent(new CustomEvent('setupRapidError', { detail: { error }  }));
+      }
     </script>
   </body>
 </html>

--- a/src/components/Widgets/TaskMapWidget/RapidEditor/RapidEditor.js
+++ b/src/components/Widgets/TaskMapWidget/RapidEditor/RapidEditor.js
@@ -80,35 +80,32 @@ const RapidEditor = ({ token, task, mapBounds, comment }) => {
         onLoad={async (event) => {
           let iframe = event.target;
 
-          try {
-            // Listen for the setupRapidComplete event directly on the iframe's contentWindow
-            iframe.contentWindow.addEventListener('setupRapidComplete', async (event) => {
-              let context = event.detail.context;
-              dispatch({ type: SET_RAPIDEDITOR, context: { isRunning: true } });
+          // Listen for the setupRapidComplete event directly on the iframe's contentWindow
+          iframe.contentWindow.addEventListener('setupRapidComplete', async (event) => {
+            let context = event.detail.context;
 
-              // When Rapid re-renders its map, it updates the URL hash of the iframe window.
-              // We listen for this event and update the parent window's hash to match.
-              context.systems.map.on('draw', () => {
-                setHash(iframe.contentWindow.location.hash);
-              });
+            dispatch({ type: SET_RAPIDEDITOR, context: { isRunning: true } });
 
-              // When the user makes an edit, the 'stablechange' event fires. When that happens
-              // we update the 'hasUnsavedChanges' property in our Redux store so that the
-              // MapRoulette UI can change depending on whether the user has unsaved edits.
-              context.systems.editor.on('stablechange', () => {
-                let hasUnsavedChanges = context.systems.editor.hasChanges();
-                dispatch({ type: SET_RAPIDEDITOR, context: { hasUnsavedChanges } });
-              });
+            // When Rapid re-renders its map, it updates the URL hash of the iframe window.
+            // We listen for this event and update the parent window's hash to match.
+            context.systems.map.on('draw', () => {
+              setHash(iframe.contentWindow.location.hash);
             });
 
-            iframe.contentWindow.addEventListener('setupRapidError', async (event) => {
-              setError(event.detail.error);
+            // When the user makes an edit, the 'stablechange' event fires. When that happens
+            // we update the 'hasUnsavedChanges' property in our Redux store so that the
+            // MapRoulette UI can change depending on whether the user has unsaved edits.
+            context.systems.editor.on('stablechange', () => {
+              let hasUnsavedChanges = context.systems.editor.hasChanges();
+              dispatch({ type: SET_RAPIDEDITOR, context: { hasUnsavedChanges } });
             });
-          } catch (err) {
-            setError(err);
-          } finally {
             setIsLoading(false);
-          }
+          });
+
+          iframe.contentWindow.addEventListener('setupRapidError', async (event) => {
+            setError(event.detail.error);
+            setIsLoading(false);
+          });
         }}
       />
     </div>


### PR DESCRIPTION
Resolves https://github.com/maproulette/maproulette3/issues/2469

The race condition occurred because the Rapid editor element was loading before the setupRapid function was defined on the window object. As a result, when the frontend attempted to invoke the setupRapid function during the iframe's load event, it encountered an error due to the function not being available yet.
The solution implemented in this pull request introduces custom event handlers that are linked to the setupRapid function(now moved to run in the script of the iframe). This approach allows the added functionality to execute independently after both the iframe and rapid have fully loaded. 