### PR TITLE
add staging notice banner and test environment banners

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,9 @@ REACT_APP_BASE_PATH=''
 REACT_APP_URL='http://127.0.0.1:3000'
 REACT_APP_TITLE='MapRoulette'
 
+# Set to 'production', 'staging', or 'local'
+REACT_APP_ENVIRONMENT='production'
+
 # Features flags. Set each to 'enabled' or 'disabled'.
 REACT_APP_FEATURE_MOBILE_DEVICES='disabled'
 REACT_APP_FEATURE_EDITOR_IMAGERY='disabled' # Send active imagery layer to editors

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,7 @@ import MobileNotSupported
 import CheckForToken from './components/CheckForToken/CheckForToken'
 import './components/Widgets/widget_registry'
 import './App.scss'
+import TestEnvironmentBanner from './components/TestEnvironmentBanner/TestEnvironmentBanner.jsx'
 
 // Setup child components with necessary HOCs
 const TopNav = withRouter(WithCurrentUser(Navbar))
@@ -102,6 +103,7 @@ export class App extends Component {
     return (
       <Fragment>
         <TopNav />
+        <TestEnvironmentBanner />
         <SystemNotices />
         <FundraisingNotices />
         <CheckForToken>

--- a/src/components/AdminPane/AdminPane.jsx
+++ b/src/components/AdminPane/AdminPane.jsx
@@ -21,6 +21,7 @@ import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequire
 import HeadTitle from "../Head/Head";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
+import TestEnvironmentNotice from "./Manage/TestEnvironmentNotice/TestEnvironmentNotice";
 
 /**
  * AdminPane is the top-level component for administration functions. It has a
@@ -55,6 +56,7 @@ export class AdminPane extends Component {
 
     return (
       <Fragment>
+        <TestEnvironmentNotice />
         <EmailRequirementNotice />
         <div className="admin mr-bg-gradient-r-green-dark-blue mr-text-white">
           <div className="admin-pane">

--- a/src/components/AdminPane/Manage/TestEnvironmentNotice/Messages.js
+++ b/src/components/AdminPane/Manage/TestEnvironmentNotice/Messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with TaskUploadingProgress
+ */
+export default defineMessages({
+  title: {
+    id: 'Admin.testEnvironmentNotice.title',
+    defaultMessage: "Testing Something?",
+  },
+
+  description: {
+    id: 'Admin.testEnvironmentNotice.description',
+    defaultMessage: "Consider using the [MapRoulette Staging Website](https://staging.maproulette.org), a clone of MapRoulette often used for development, where you can create test challenges, projects, and similar tasks."
+  },  
+})

--- a/src/components/AdminPane/Manage/TestEnvironmentNotice/Messages.js
+++ b/src/components/AdminPane/Manage/TestEnvironmentNotice/Messages.js
@@ -1,7 +1,7 @@
 import { defineMessages } from 'react-intl'
 
 /**
- * Internationalized messages for use with TaskUploadingProgress
+ * Internationalized messages for use with testEnvironmentNotice
  */
 export default defineMessages({
   title: {

--- a/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.js
+++ b/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { FormattedMessage, injectIntl } from 'react-intl'
+import WithCurrentUser from "../../../HOCs/WithCurrentUser/WithCurrentUser";
+import messages from "./Messages";
+import MarkdownContent from "../../../MarkdownContent/MarkdownContent";
+
+const TestEnvironmentNotice = (props) => {
+      return (
+        <ul className="mr-bg-gradient-b-blue-darker-blue-dark mr-text-white mr-w-full">
+        <li className="mr-flex mr-justify-between mr-items-center mr-w-full mr-py-2 mr-px-16">
+          <div className="mr-flex mr-space-x-4 mr-items-center">
+            <div className="mr-text-yellow mr-text-md mr-whitespace-nowrap">
+              <FormattedMessage {...messages.title} />
+            </div>
+            <MarkdownContent
+              markdown={props.intl.formatMessage(messages.description)}
+              className="mr-text-white mr-text-sm"
+            />
+          </div>
+        </li>
+      </ul>
+      );
+};
+
+export default WithCurrentUser(injectIntl(TestEnvironmentNotice));

--- a/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.jsx
+++ b/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { FormattedMessage, injectIntl } from 'react-intl'
-import WithCurrentUser from "../../../HOCs/WithCurrentUser/WithCurrentUser";
 import messages from "./Messages";
 import MarkdownContent from "../../../MarkdownContent/MarkdownContent";
 
 const TestEnvironmentNotice = (props) => {
-      return (
+    const environment = window.env.REACT_APP_ENVIRONMENT;
+    if(environment === 'production'){
+    return (
         <ul className="mr-bg-gradient-b-blue-darker-blue-dark mr-text-white mr-w-full">
         <li className="mr-flex mr-justify-between mr-items-center mr-w-full mr-py-2 mr-px-16">
           <div className="mr-flex mr-space-x-4 mr-items-center">
@@ -19,7 +20,10 @@ const TestEnvironmentNotice = (props) => {
           </div>
         </li>
       </ul>
-      );
+    );
+  } else {
+    return null;
+  }
 };
 
-export default WithCurrentUser(injectIntl(TestEnvironmentNotice));
+export default injectIntl(TestEnvironmentNotice);

--- a/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.jsx
+++ b/src/components/AdminPane/Manage/TestEnvironmentNotice/TestEnvironmentNotice.jsx
@@ -4,8 +4,9 @@ import messages from "./Messages";
 import MarkdownContent from "../../../MarkdownContent/MarkdownContent";
 
 const TestEnvironmentNotice = (props) => {
-    const environment = window.env.REACT_APP_ENVIRONMENT;
-    if(environment === 'production'){
+  const environment = window.env.REACT_APP_ENVIRONMENT;
+  
+  if(environment === 'production'){
     return (
         <ul className="mr-bg-gradient-b-blue-darker-blue-dark mr-text-white mr-w-full">
         <li className="mr-flex mr-justify-between mr-items-center mr-w-full mr-py-2 mr-px-16">

--- a/src/components/TestEnvironmentBanner/Messages.js
+++ b/src/components/TestEnvironmentBanner/Messages.js
@@ -1,15 +1,15 @@
 import { defineMessages } from 'react-intl'
 
 /**
- * Internationalized messages for use with TaskUploadingProgress
+ * Internationalized messages for use with testEnvironmentBanner
  */
 export default defineMessages({
   stagingTitle: {
-    id: 'Admin.testEnvironmentNotice.stagingTitle',
+    id: 'Admin.testEnvironmentBanner.stagingTitle',
     defaultMessage: "You are in a MapRoulette Staging environment.",
   },
   localTitle: {
-    id: 'Admin.testEnvironmentNotice.localTitle',
+    id: 'Admin.testEnvironmentBanner.localTitle',
     defaultMessage: "You are in a MapRoulette Local environment.",
   }
 })

--- a/src/components/TestEnvironmentBanner/Messages.js
+++ b/src/components/TestEnvironmentBanner/Messages.js
@@ -1,0 +1,15 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with TaskUploadingProgress
+ */
+export default defineMessages({
+  stagingTitle: {
+    id: 'Admin.testEnvironmentNotice.stagingTitle',
+    defaultMessage: "You are in a MapRoulette Staging environment.",
+  },
+  localTitle: {
+    id: 'Admin.testEnvironmentNotice.localTitle',
+    defaultMessage: "You are in a MapRoulette Local environment.",
+  }
+})

--- a/src/components/TestEnvironmentBanner/TestEnvironmentBanner.jsx
+++ b/src/components/TestEnvironmentBanner/TestEnvironmentBanner.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { FormattedMessage, injectIntl } from 'react-intl';
+import messages from "./Messages";
+
+const TestEnvironmentBanner = (props) => {
+  // Check the current environment
+  const environment = window.env.REACT_APP_ENVIRONMENT;
+
+  // Only render the banner if not in production
+  if (environment === 'production') return null;
+
+  return (
+    <ul className="mr-bg-gradient-b-blue-darker-blue-dark mr-text-white mr-w-full">
+      <li className="mr-flex mr-justify-between mr-items-center mr-w-full mr-py-2 mr-px-16">
+        <div className="mr-flex mr-space-x-4 mr-items-center">
+          <div className="mr-text-yellow mr-text-md mr-whitespace-nowrap">
+            {environment === 'staging' ? 
+              <FormattedMessage {...messages.stagingTitle} />
+            : environment === 'local' ?
+              <FormattedMessage {...messages.localTitle} />
+            : null}
+            </div> 
+        </div>
+      </li>
+    </ul>
+  );
+};
+
+export default injectIntl(TestEnvironmentBanner);


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2020


I added a new environment variable to indicate the type of environment the user is in.

```
# Set to 'production', 'staging', or 'local'
REACT_APP_ENVIRONMENT='production'
```

Local environment ui:
<img width="532" alt="Screenshot 2024-11-06 at 11 49 17 AM" src="https://github.com/user-attachments/assets/12b5ec72-5b79-4b44-bbfb-2aec687cc3c1">
Staging environment ui:
<img width="699" alt="Screenshot 2024-11-06 at 11 50 55 AM" src="https://github.com/user-attachments/assets/cb6864bd-1a2e-4488-be80-3b307bfcc3df">
production environment ui:
<img width="1680" alt="Screenshot 2024-11-06 at 11 52 45 AM" src="https://github.com/user-attachments/assets/7e515645-f431-46b3-b51b-8d5f9abd71a3">
<img width="1414" alt="Screenshot 2024-11-06 at 11 52 27 AM" src="https://github.com/user-attachments/assets/041f6f1c-ddda-4c73-b214-a499e1c3b51f">


