### PR TITLE
Update docker-publish.yml to use semver labels for images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Minor change: the current workflow (which I added very recently) labels images only with the literal git tag. This change instead labels them with the semver version (without leading `v`) which is the more typical Docker convention. E.g. a commit tagged `v3.15.12` will build an image labeled `3.15.12`, `3.15`, `3`, and `latest`.

This was the intended behavior in #2479 (and I described this there) but I misunderstood the docs for the `docker/metadata-action` GH Action so the current behavior is actually different from what I intended. This PR should fix that.