### PR TITLE
Add GH workflow to trigger redeploy after new packages are published

### DIFF
--- a/.github/workflows/trigger-redeploy.yaml
+++ b/.github/workflows/trigger-redeploy.yaml
@@ -1,0 +1,20 @@
+name: Trigger Redeploy
+
+on:
+  # run whenever a new maproulette/maproulette-frontend package is published to GHCR
+  registry_package:
+    types: [published]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send trigger-workflow webhook to maproulette-deploy repository
+        run: |
+          curl -L \
+            -X POST \
+            https://api.github.com/repos/maproulette/maproulette-deploy/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"event_type": "trigger-workflow" }'


### PR DESCRIPTION
I'm working on a new staging environment that will be automatically redeployed whenever changes are made to the main branch of the maproulette3 or maproulette-backend repos.

The deployment code lives in maproulette/maproulette-deploy (private for now but I will make this public soon, just need to audit for secret leaks first). This PR adds a workflow to the frontend repo which is triggered when new packages are published (there's an existing repo which builds and publishes packages to GHCR whenever code changes are made). The workflow sends a webhook to the deploy repo to trigger _its_ workflow, which is responsible for deploying the new package version onto the staging server.

I haven't tested this yet (GH actions are hard to test locally) so it may need some iteration, but I'm pretty sure this approach will work.