### PR TITLE
Challenge Rapid Dataset support

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -176,6 +176,8 @@
   "Admin.EditChallenge.form.preferredTags.label": "Preferred MR Tags",
   "Admin.EditChallenge.form.presets.description": "Restrict the types of OSM features presented to mappers in iD by default when working on your tasks, helping to keep them focused on mapping things relevant to your challenge. For example, if your challenge is about mapping buildings, you could enable only presets related to buildings and then mappers would not be presented with the option to map an area as, say, a park or a lake.",
   "Admin.EditChallenge.form.presets.label": "Restrict iD Editor Presets",
+  "Admin.EditChallenge.form.datasetUrl.description": "Optionally include a Rapid Editor dataset URL. Datasets can be used to provide geospatial data layers that can be overlaid, analyzed, and edited to create or update maps accurately",
+  "Admin.EditChallenge.form.datasetUrl.label": "Rapid Dataset URL",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.label": "I have a URL to the GeoJSON data",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -600,6 +600,17 @@ will not be able to make sense of it.
       "Insert a custom base map URL here. E.g. `https://'{s}'.tile.openstreetmap.org/'{z}'/'{x}'/'{y}'.png`",
   },
 
+  datasetUrlLabel: {
+    id: "Admin.EditChallenge.form.datasetUrl.label",
+    defaultMessage: "Rapid Dataset URL",
+  },
+
+  datasetUrlDescription: {
+    id: "Admin.EditChallenge.form.datasetUrl.description",
+    defaultMessage:
+      "Optionally include a Rapid Editor dataset URL. Datasets can be used to provide geospatial data layers that can be overlaid, analyzed, and edited to create or update maps accurately",
+  },
+
   exportablePropertiesLabel: {
     id: "Admin.EditChallenge.form.exportableProperties.label",
     defaultMessage: "Properties to export in CSV",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/BasemapSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/BasemapSchema.js
@@ -43,6 +43,11 @@ export const jsSchema = (intl) => {
         enumNames: _map(defaultBasemapChoices, 'name'),
         default: ChallengeBasemap.none.toString(),
       },
+      datasetUrl: {
+        title: intl.formatMessage(messages.datasetUrlLabel),
+        type: "string",
+        default: "",
+      },
     },
     dependencies: { // Only show customBasemap if defaultBasemap set to Custom
       defaultBasemap: {
@@ -87,7 +92,7 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
   const toggleCollapsed = options.longForm && options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
 
   return {
-    "ui:order": ["defaultBasemap", "customBasemap"],
+    "ui:order": ["defaultBasemap", "customBasemap", "datasetUrl"],
     defaultBasemap: {
       "ui:widget": "select",
       "ui:help": intl.formatMessage(messages.defaultBasemapDescription),
@@ -100,5 +105,11 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
       "ui:help": intl.formatMessage(messages.customBasemapDescription),
       "ui:collapsed": isCollapsed,
     },
+    datasetUrl: {
+      "ui:emptyValue": "",
+      "ui:help": intl.formatMessage(messages.datasetUrlDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed
+    }
   }
 }

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -930,7 +930,7 @@ export const fetchChallenges = function (
   return function (dispatch) {
     // The server wants keywords/tags represented as a comma-separated string.
     let challengeData = _clone(originalChallengeData);
-    
+
     if (_isArray(challengeData.tags)) {
       challengeData.tags = challengeData.tags.map(t => t.trim()).join(",");
     } else if (challengeData.tags) {
@@ -1007,6 +1007,7 @@ export const fetchChallenges = function (
           "overpassQL",
           "overpassTargetType",
           "parent",
+          "datasetUrl",
           "remoteGeoJson",
           "status",
           "tags",

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -341,7 +341,7 @@ export const constructRapidURI = function (task, mapBounds, options, replacedCom
     "source=" + encodeURIComponent(task.parent.checkinSource);
 
   const datasetUrl = _get(task.parent, "datasetUrl")
-    ? `data=${task.parent.datasetUrl}`
+    ? "data=" + encodeURIComponent(task.parent.datasetUrl)
     : null;
 
   const presetsComponent = _isEmpty(task.parent.presets)

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -340,6 +340,10 @@ export const constructRapidURI = function (task, mapBounds, options, replacedCom
   const sourceComponent =
     "source=" + encodeURIComponent(task.parent.checkinSource);
 
+  const datasetUrl = _get(task.parent, "datasetUrl")
+    ? `data=${task.parent.datasetUrl}`
+    : null;
+
   const presetsComponent = _isEmpty(task.parent.presets)
     ? null
     : "presets=" + encodeURIComponent(task.parent.presets.join(","));
@@ -366,6 +370,7 @@ export const constructRapidURI = function (task, mapBounds, options, replacedCom
       presetsComponent,
       photoOverlayComponent,
       mapUriComponent,
+      datasetUrl
     ]).join("&")
   );
 };


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2385

Requires: https://github.com/maproulette/maproulette-backend/pull/1159

Users can now add rapid dataset URLs to challenges via the create challenge form.  The dataset url will be added to the rapid parameters in the Edit Mode window on the task inspection page.