### PR TITLE
Move bundling functionality to frontend and completion flow

### DIFF
--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
@@ -97,10 +97,6 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
         _set(searchCriteria, 'filters.archived', true)
       }
 
-      if (this.props.taskBundle && this.props.bundledOnly ){
-        _set(searchCriteria, 'filters.bundleId', this.props.taskBundle.bundleId)
-      }
-
       if (window.env.REACT_APP_DISABLE_TASK_CLUSTERS && !overrideDisable) {
         return this.setState({ loading: false })
       }
@@ -181,10 +177,6 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
       }
       else if (!_isEqual(_omit(prevProps.criteria, ['page', 'pageSize']),
             _omit(this.props.criteria, ['page', 'pageSize']))) {
-        this.debouncedFetchClusters(this.state.showAsClusters)
-      } else if(this.props.taskBundle && 
-        (this.props.bundledOnly !== prevProps.bundledOnly || 
-        this.props.taskBundle !== prevProps.taskBundle)){
         this.debouncedFetchClusters(this.state.showAsClusters)
       }
     }

--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.jsx
@@ -202,14 +202,12 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
     onBulkTaskSelection = taskIds => {
       const tasks = this.clustersAsTasks().filter(task => {
         const taskId = task.id || task.taskId
-        const alreadyBundled = task.bundleId && this.props.taskBundle?.bundleId !== task.bundleId
+        const alreadyBundled = task.bundleId && this.props.initialBundle?.bundleId !== task.bundleId
         
         return taskIds.includes(taskId) && !alreadyBundled &&
           !(
             this.props.task &&
-            ![0, 3, 6].includes(task.taskStatus || task.status) &&
-            (!this.props.taskBundle?.taskIds?.includes(taskId) &&
-              !this.props.initialBundle?.taskIds?.includes(taskId))
+            ![0, 3, 6].includes(task.taskStatus || task.status)
           ) &&
           taskId
       })

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -22,14 +22,13 @@ import {
 export function WithTaskBundle(WrappedComponent) {
   return class extends Component {
     state = {
-      loading: false,
-      bundleEditsDisabled: false,
       initialBundle: null,
       taskBundle: null,
-      completingTask: null,
+      bundleEditsDisabled: false,
       selectedTasks: [],
       resetSelectedTasks: null,
-      errorMessage: null
+      errorMessage: null,
+      loading: false,
     }
 
     async componentDidMount() {
@@ -43,7 +42,7 @@ export function WithTaskBundle(WrappedComponent) {
     async componentDidUpdate(prevProps) {
       const { task } = this.props
       if (_get(task, 'id') !== _get(prevProps, 'task.id')) {
-        this.setState({ selectedTasks: [], taskBundle: null, initialBundle: null, loading: false, completingTask: null })
+        this.setState({ selectedTasks: [], taskBundle: null, initialBundle: null, loading: false })
         if (_isFinite(_get(task, 'bundleId'))) {
           await this.fetchBundle(task.bundleId)
         }
@@ -180,10 +179,6 @@ export function WithTaskBundle(WrappedComponent) {
       this.resetSelectedTasks()
     }
 
-    setCompletingTask = task => {
-      this.setState({ selectedTasks: [], completingTask: task })
-    }
-
     updateTaskBundle = async () => {
       const { taskBundle, initialBundle } = this.state
       if (taskBundle || initialBundle) {
@@ -207,8 +202,6 @@ export function WithTaskBundle(WrappedComponent) {
           taskBundle={this.state.taskBundle}
           initialBundle={this.state.initialBundle}
           taskBundleLoading={this.state.loading}
-          setCompletingTask={this.setCompletingTask}
-          completingTask={this.props.completingTask}
           createTaskBundle={this.createTaskBundle}
           updateTaskBundle={this.updateTaskBundle}
           resetTaskBundle={this.resetTaskBundle}

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -109,7 +109,7 @@ export function WithTaskBundle(WrappedComponent) {
         }
       } catch (error) {
         console.error("Error fetching bundle:", error)
-        this.setState({ errorMessage: "Failed to fetch task bundle. Please try again." })
+        this.setState({ errorMessage: {fetchBundleError} })
       } finally {
         this.setState({ loading: false })
       }
@@ -171,7 +171,7 @@ export function WithTaskBundle(WrappedComponent) {
         return task.entities.tasks[taskId]
       } catch (error) {
         console.error(`Failed to lock task ${taskId}:`, error)
-        this.setState({ errorMessage: `Failed to lock task ${taskId}. Please try again.` })
+        this.setState({ errorMessage: {lockTaskError, values: { taskId }} })
         throw error
       } finally {
         this.setState({ loading: false })

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -42,6 +42,7 @@ export function WithTaskBundle(WrappedComponent) {
         await this.fetchBundle(task.bundleId)
       }
       this.updateBundlingConditions()
+      window.addEventListener('beforeunload', this.handleBeforeUnload)
     }
 
     async componentDidUpdate(prevProps) {
@@ -61,6 +62,14 @@ export function WithTaskBundle(WrappedComponent) {
     }
 
     componentWillUnmount() {
+      this.stopLockRefresh()
+      if (this.state.taskBundle) {
+        this.unlockTasks(this.state.taskBundle, null)
+      }
+      window.removeEventListener('beforeunload', this.handleBeforeUnload)
+    }
+
+    handleBeforeUnload = () => {
       this.stopLockRefresh()
       if (this.state.taskBundle) {
         this.unlockTasks(this.state.taskBundle, null)

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -14,7 +14,7 @@ import {
   releaseMultipleTasks
 } from '../../../services/Task/Task'
 
-const LOCK_REFRESH_INTERVAL = 600000
+const LOCK_REFRESH_INTERVAL = 600000 // 10 minutes
 
 /**
  * WithTaskBundle passes down methods for creating new task bundles and

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -168,9 +168,7 @@ export function WithTaskBundle(WrappedComponent) {
 
     updateTaskBundle = async () => {
       const { taskBundle, initialBundle } = this.state
-      debugger
       if (taskBundle || initialBundle) {
-        debugger
         if(!taskBundle && initialBundle) {
           await this.props.deleteTaskBundle(initialBundle.bundleId)
           return null

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -95,7 +95,9 @@ export function WithTaskBundle(WrappedComponent) {
           selectedTasks: taskBundle?.taskIds || [], 
           bundleEditsDisabled: this.updateBundlingConditions() 
         })
-        this.startLockRefresh()
+        if(!this.props.taskReadOnly) {
+          this.startLockRefresh()
+        }
       } catch (error) {
         console.error("Error fetching bundle:", error)
         this.setState({ errorMessage: "Failed to fetch task bundle. Please try again." })

--- a/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
+++ b/src/components/HOCs/WithTaskBundle/WithTaskBundle.jsx
@@ -241,6 +241,17 @@ export function WithTaskBundle(WrappedComponent) {
       this.setState({ taskBundle: updatedTaskBundle })
     }
 
+    addTaskToBundle = async (taskId) => {
+      const { taskBundle } = this.state
+      const task =  await this.lockTask(taskId)
+      const updatedTaskBundle = { 
+        ...taskBundle, 
+        taskIds: [...taskBundle.taskIds, taskId], 
+        tasks: [...taskBundle.tasks, task] 
+      }
+      this.setState({ taskBundle: updatedTaskBundle })
+    }
+
     updateTaskBundle = async () => {
       const { taskBundle, initialBundle } = this.state
       if (taskBundle || initialBundle) {
@@ -272,6 +283,7 @@ export function WithTaskBundle(WrappedComponent) {
           updateTaskBundle={this.updateTaskBundle}
           resetTaskBundle={this.resetTaskBundle}
           removeTaskFromBundle={this.removeTaskFromBundle}
+          addTaskToBundle={this.addTaskToBundle}
           clearActiveTaskBundle={this.clearActiveTaskBundle}
           setSelectedTasks={(selectedTasks) => this.setState({ selectedTasks })}
           selectedTasks={this.state.selectedTasks}

--- a/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.jsx
+++ b/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.jsx
@@ -33,14 +33,14 @@ export const WithTaskClusterMarkers = function(WrappedComponent) {
      */
     updateMapMarkers() {
       const markers = _map(this.props.taskClusters, cluster => {
-        const cluserStatus = cluster.status ?? cluster.taskStatus
+        const clusterStatus = cluster.status ?? cluster.taskStatus
         const clusterId = cluster.id ?? cluster.taskId 
-        const alreadyBundled = cluster.bundleId && !this.props.taskBundle?.bundleId !== cluster.bundleId
+        const alreadyBundled = cluster.bundleId && this.props.initialBundle?.bundleId !== cluster.bundleId
 
         const bundleConflict = Boolean(
           (clusterId &&
           this.props.task &&
-          ![0, 3, 6].includes(cluserStatus) &&
+          ![0, 3, 6].includes(clusterStatus) &&
           !this.props.taskBundle?.taskIds?.includes(clusterId) &&
           !this.props.initialBundle?.taskIds?.includes(clusterId)) ||
           alreadyBundled

--- a/src/components/ReviewTaskControls/ReviewTaskControls.jsx
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.jsx
@@ -50,7 +50,6 @@ export class ReviewTaskControls extends Component {
     if(this.state.tags) {
       this.props.saveTaskTags(this.props.task, this.state.tags)
     }
-    this.props.setCompletingTask(this.props.task.id)
 
     const history = _cloneDeep(this.props.history)
     _merge(_get(history, 'location.state', {}), alternateCriteria)

--- a/src/components/ReviewTaskPane/ReviewTaskPane.jsx
+++ b/src/components/ReviewTaskPane/ReviewTaskPane.jsx
@@ -168,7 +168,7 @@ export class ReviewTaskPane extends Component {
         />
         </MediaQuery>
         <MediaQuery query="(max-width: 1023px)">
-          <MapPane completingTask={this.state.completingTask}>
+          <MapPane>
             <TaskMap isMobile
                      task={this.props.task}
                      challenge={this.props.task.parent}

--- a/src/components/TaskAnalysisTable/Messages.js
+++ b/src/components/TaskAnalysisTable/Messages.js
@@ -253,4 +253,14 @@ export default defineMessages({
     id: "Admin.TaskAnalysisTable.confirmActionWarning",
     defaultMessage: "This process can take awhile, depending on the challenge size, and cannot be undone.",
   },
+
+  lockTaskError: {
+    id: "Widgets.TaskBundleWidget.lockTaskError",
+    defaultMessage: "Failed to lock task {taskId}. Please try again.",
+  },
+
+  failedLockError: {
+    id: "Widgets.TaskBundleWidget.failedLockError",
+    defaultMessage: "Failed to lock one or more tasks. Please try again.",
+  },
 })

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -308,7 +308,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     accessor: task => props.isTaskSelected(task.id),
     Cell: ({ value, original }) => {
       const status = original.status ?? original.taskStatus
-      const alreadyBundled = original.bundleId && !props.taskBundle?.bundleId !== original.bundleId
+      const alreadyBundled = original.bundleId && props.initialBundle?.bundleId !== original.bundleId
       const enableSelecting =
       !alreadyBundled &&
       !props.bundling &&
@@ -317,10 +317,9 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       original.taskId !== props.task?.id &&
       props.workspace.name !== 'taskReview' &&
       !AsCooperativeWork(props.task).isTagType()
-    
 
       return (
-        props.highlightPrimaryTask && original.id === props.task?.id && !original.bundleId ?
+        props.highlightPrimaryTask && original.id === props.task?.id && !alreadyBundled ?
           <span className="mr-text-green-lighter">✓</span> :
           enableSelecting ?
             <input
@@ -426,7 +425,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
 
       const isActiveTask = taskId === task?.id
       const isInActiveBundle = taskBundle?.taskIds?.includes(taskId);
-      const alreadyBundled = bundleId && taskBundle?.bundleId !== bundleId;
+      const alreadyBundled = bundleId && initialBundle?.bundleId !== bundleId;
       const validBundlingStatus = initialBundle?.taskIds?.includes(taskId) || [0, 3, 6].includes(status)
 
       return (

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -425,10 +425,10 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       const alreadyBundled = row._original.bundleId && props.taskBundle?.bundleId !== row._original.bundleId
       const enableBundleEdits = props.initialBundle?.taskIds?.includes(row._original.id) ||
                                 [0, 3, 6].includes(row._original.status)
-
+      const isInActiveBundle = props.taskBundle?.taskIds?.includes(row._original.id)
       return (
         <div>
-          {!isTaskSelected && enableBundleEdits && !alreadyBundled && (
+          {!isTaskSelected && enableBundleEdits && !alreadyBundled && isInActiveBundle && (
             <button
               disabled={props.bundleEditsDisabled}
               className="mr-text-red-light"

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -423,14 +423,14 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       const { taskBundle, task, initialBundle } = props;
       const { id: taskId, bundleId, status } = row._original;
 
-      const isTaskSelected = taskId === task?.id
+      const isActiveTask = taskId === task?.id
       const isInActiveBundle = taskBundle?.taskIds?.includes(taskId);
       const alreadyBundled = bundleId && taskBundle?.bundleId !== bundleId;
-      const enableBundleEdits = initialBundle?.taskIds?.includes(taskId) || [0, 3, 6].includes(status) && !alreadyBundled
+      const validBundlingStatus = initialBundle?.taskIds?.includes(taskId) || [0, 3, 6].includes(status)
 
       return (
         <div>
-          {!isTaskSelected && enableBundleEdits && isInActiveBundle && (
+          {!isActiveTask && validBundlingStatus && isInActiveBundle && !alreadyBundled && (
             <button
               disabled={props.bundleEditsDisabled}
               className="mr-text-red-light"
@@ -445,7 +445,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
             </button>
           )}
   
-          {isTaskSelected && <div className="mr-text-yellow">Primary Task</div>}
+          {isActiveTask && <div className="mr-text-yellow">Primary Task</div>}
         </div>
       );
     },

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -255,6 +255,7 @@ export class TaskAnalysisTableInternal extends Component {
               <ViewTaskSubComponent taskId={props.original.id} />
             }
             unbundleTask={this.props.unbundleTask}
+            bundleTask={this.props.bundleTask}
             collapseOnDataChange={false}
             minRows={1}
             manual
@@ -444,6 +445,23 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
               <FormattedMessage {...messages.unbundle} />
             </button>
           )}
+
+
+          {!isActiveTask && validBundlingStatus && !isInActiveBundle && !alreadyBundled && (
+            <button
+              disabled={props.bundleEditsDisabled}
+              className="mr-text-green-lighter"
+              style={{
+                cursor: props.bundleEditsDisabled ? 'default' : 'pointer',
+                opacity: props.bundleEditsDisabled ? 0.3 : 1,
+                pointerEvents: props.bundleEditsDisabled ? 'none' : 'auto'
+              }}
+              onClick={() => props.bundleTask(row._original)}
+            >
+              <FormattedMessage {...messages.bundle} />
+            </button>
+          )}
+  
   
           {isActiveTask && <div className="mr-text-yellow">Primary Task</div>}
         </div>

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -420,15 +420,17 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     accessor: 'remove',
     minWidth: 110,
     Cell: ({ row }) => {
-      const bundlePrimary = props.taskBundle?.tasks.find(task => task.isBundlePrimary)
-      const isTaskSelected = row._original.id === (bundlePrimary?.id || props.task?.id)
-      const alreadyBundled = row._original.bundleId && props.taskBundle?.bundleId !== row._original.bundleId
-      const enableBundleEdits = props.initialBundle?.taskIds?.includes(row._original.id) ||
-                                [0, 3, 6].includes(row._original.status)
-      const isInActiveBundle = props.taskBundle?.taskIds?.includes(row._original.id)
+      const { taskBundle, task, initialBundle } = props;
+      const { id: taskId, bundleId, status } = row._original;
+
+      const isTaskSelected = taskId === task?.id
+      const isInActiveBundle = taskBundle?.taskIds?.includes(taskId);
+      const alreadyBundled = bundleId && taskBundle?.bundleId !== bundleId;
+      const enableBundleEdits = initialBundle?.taskIds?.includes(taskId) || [0, 3, 6].includes(status) && !alreadyBundled
+
       return (
         <div>
-          {!isTaskSelected && enableBundleEdits && !alreadyBundled && isInActiveBundle && (
+          {!isTaskSelected && enableBundleEdits && isInActiveBundle && (
             <button
               disabled={props.bundleEditsDisabled}
               className="mr-text-red-light"

--- a/src/components/TaskClusterMap/MapMarkers.jsx
+++ b/src/components/TaskClusterMap/MapMarkers.jsx
@@ -92,7 +92,6 @@ const Markers = (props) => {
     };
   }, []);
 
-
   useEffect(() => {
     if ((props.taskMarkers && mapMarkers.length === 0) || props.delayMapLoad || (props.bundledOnly !== prevProps.current.bundledOnly) || !_isEqual(props.taskMarkers, prevProps.current.taskMarkers) || props.selectedClusters !== prevProps.current.selectedClusters) {
       refreshSpidered();

--- a/src/components/TaskClusterMap/MapMarkers.jsx
+++ b/src/components/TaskClusterMap/MapMarkers.jsx
@@ -92,15 +92,16 @@ const Markers = (props) => {
     };
   }, []);
 
+
   useEffect(() => {
-    if (!props.taskMarkers || props.delayMapLoad || !_isEqual(props.taskMarkers, prevProps.current.taskMarkers) || props.selectedClusters !== prevProps.current.selectedClusters) {
+    if ((props.taskMarkers && mapMarkers.length === 0) || props.delayMapLoad || (props.bundledOnly !== prevProps.current.bundledOnly) || !_isEqual(props.taskMarkers, prevProps.current.taskMarkers) || props.selectedClusters !== prevProps.current.selectedClusters) {
       refreshSpidered();
       generateMarkers();
     } else if (!_isEqual(spidered, prevProps.current.spidered)) {
       generateMarkers();
     }
     prevProps.current = { ...props, spidered: spidered };
-  }, [props.taskMarkers, props.selectedClusters, spidered]);
+  }, [props.taskMarkers, props.selectedClusters, spidered, props.taskBundle, props.bundledOnly]);
 
   useEffect(() => {
     setSpidered(new Map());
@@ -272,6 +273,9 @@ const Markers = (props) => {
 
   const generateMarkers = () => {
     let consolidatedMarkers = consolidateMarkers(props.taskMarkers);
+    if(props.taskBundle && props.bundledOnly) {
+      consolidatedMarkers = consolidatedMarkers.filter(m => props.taskBundle.taskIds.includes(m.options.taskId));
+    }
 
     if (spidered.size > 0) {
       consolidatedMarkers = _reject(consolidatedMarkers, (m) => spidered.has(m.options.taskId));

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -64,6 +64,8 @@ export const TaskClusterMap = (props) => {
     // Check condition for toggling showAsClusters
     if (!props.showAsClusters && props.totalTaskCount > UNCLUSTER_THRESHOLD && !props.createTaskBundle) {
       props.toggleShowAsClusters();
+    } else if (props.showAsClusters && props.totalTaskCount <= UNCLUSTER_THRESHOLD && props.createTaskBundle) {
+      props.toggleShowAsClusters();
     }
 
     // Handle loading state changes

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -62,7 +62,7 @@ export const TaskClusterMap = (props) => {
 
   useEffect(() => {
     // Check condition for toggling showAsClusters
-    if (!props.showAsClusters && props.totalTaskCount > UNCLUSTER_THRESHOLD) {
+    if (!props.showAsClusters && props.totalTaskCount > UNCLUSTER_THRESHOLD && !props.createTaskBundle) {
       props.toggleShowAsClusters();
     }
 
@@ -250,7 +250,7 @@ export const TaskClusterMap = (props) => {
       <ResizeMap />
       <AttributionControl position="bottomleft" prefix={false} />
       {(Boolean(props.loading) || Boolean(props.loadingChallenge)) && <BusySpinner mapMode xlarge />}
-      {props.totalTaskCount && props.totalTaskCount <= UNCLUSTER_THRESHOLD && !searchOpen && !props.loading &&
+      {props.totalTaskCount && props.totalTaskCount <= UNCLUSTER_THRESHOLD && !searchOpen && !props.loading && !props.createTaskBundle &&
         <label htmlFor="show-clusters-input" className="mr-absolute mr-z-10 mr-top-0 mr-left-0 mr-mt-2 mr-ml-2 mr-shadow mr-rounded-sm mr-bg-black-50 mr-px-2 mr-py-1 mr-text-white mr-text-xs mr-flex mr-items-center">
           <input
             id="show-clusters-input"

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -140,8 +140,6 @@ export class ActiveTaskControls extends Component {
       this.props.saveTaskTags(this.props.task, this.state.tags)
     }
 
-    this.props.setCompletingTask(this.props.task.id)
-
     const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected
 
     if (!_isUndefined(this.state.submitRevision)) {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -139,6 +139,7 @@ export class ActiveTaskControls extends Component {
     if(this.state.tags) {
       this.props.saveTaskTags(this.props.task, this.state.tags)
     }
+
     this.props.setCompletingTask(this.props.task.id)
 
     const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -133,7 +133,9 @@ export class ActiveTaskControls extends Component {
   }
 
   /** Mark the task as complete with the given status */
-  complete = taskStatus => {
+  complete = async taskStatus => {
+    const taskBundle = await this.props.updateTaskBundle()
+
     if(this.state.tags) {
       this.props.saveTaskTags(this.props.task, this.state.tags)
     }
@@ -142,14 +144,14 @@ export class ActiveTaskControls extends Component {
     const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected
 
     if (!_isUndefined(this.state.submitRevision)) {
-      this.props.updateTaskReviewStatus(this.props.task, this.state.submitRevision,
+     await this.props.updateTaskReviewStatus(this.props.task, this.state.submitRevision,
                                         this.state.comment, null,
                                         this.state.revisionLoadBy, this.props.history,
-                                        this.props.taskBundle, this.state.requestedNextTask,
+                                        taskBundle, this.state.requestedNextTask,
                                         taskStatus, null)
     }
     else {
-      this.props.completeTask(this.props.task, this.props.task.parent.id,
+      await this.props.completeTask(this.props.task, this.props.task.parent.id,
                               taskStatus, this.state.comment, null,
                               revisionSubmission ? null : this.props.taskLoadBy,
                               this.props.user.id,
@@ -157,7 +159,7 @@ export class ActiveTaskControls extends Component {
                               this.state.requestedNextTask,
                               this.state.osmComment,
                               this.props.tagEdits,
-                              this.props.taskBundle)
+                              taskBundle)
       if (revisionSubmission) {
         if (this.state.revisionLoadBy === TaskReviewLoadMethod.inbox) {
           this.props.history.push('/inbox')

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -143,7 +143,7 @@ export class ActiveTaskControls extends Component {
     const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected
 
     if (!_isUndefined(this.state.submitRevision)) {
-     await this.props.updateTaskReviewStatus(this.props.task, this.state.submitRevision,
+      await this.props.updateTaskReviewStatus(this.props.task, this.state.submitRevision,
                                         this.state.comment, null,
                                         this.state.revisionLoadBy, this.props.history,
                                         taskBundle, this.state.requestedNextTask,

--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -107,17 +107,15 @@ export const TaskMapContent = (props) => {
 
   useMapEvents({
     moveend: () => {
-      if (props.task.id !== props.completingTask) {
-        const bounds = map.getBounds()
-        const zoom = map.getZoom()
-        props.setTaskMapBounds(props.task.id, bounds, zoom, false)
-        if (props.setWorkspaceContext) {
-          props.setWorkspaceContext({
-            taskMapTask: props.task,
-            taskMapBounds: bounds,
-            taskMapZoom: zoom
-          })
-        }
+      const bounds = map.getBounds()
+      const zoom = map.getZoom()
+      props.setTaskMapBounds(props.task.id, bounds, zoom, false)
+      if (props.setWorkspaceContext) {
+        props.setWorkspaceContext({
+          taskMapTask: props.task,
+          taskMapBounds: bounds,
+          taskMapZoom: zoom
+        })
       }
     },
   })

--- a/src/components/TaskPane/TaskPane.jsx
+++ b/src/components/TaskPane/TaskPane.jsx
@@ -127,16 +127,7 @@ export class TaskPane extends Component {
                   needsReview, requestedNextTask, osmComment, tagEdits, taskBundle) => {
     this.props.completeTask(task, challengeId, taskStatus, comment, tags, taskLoadBy, userId,
                             needsReview, requestedNextTask, osmComment, tagEdits,
-                            this.state.completionResponses, taskBundle).then(() => {
-      this.clearCompletingTask()
-    })
-  }
-
-  clearCompletingTask = () => {
-    // Clear on next tick to give our animation transition a chance to clean up.
-    setTimeout(() => {
-      this.props.setCompletingTask(null)
-    }, 0)
+                            this.state.completionResponses, taskBundle)
   }
 
   setCompletionResponse = (propertyName, value) => {
@@ -387,23 +378,15 @@ export class TaskPane extends Component {
               </div>
             }
             completeTask={this.completeTask}
-            completingTask={this.props.completingTask}
             setCompletionResponse={this.setCompletionResponse}
             setNeedsResponses={this.setNeedsResponses}
             completionResponses={completionResponses}
             needsResponses={this.state.needsResponses}
             templateRevision={isCompletionStatus(this.props.task.status)}
           />
-          {this.props.completingTask && this.props.completingTask === this.props.task.id &&
-           <div
-             className="mr-fixed mr-top-0 mr-bottom-0 mr-left-0 mr-right-0 mr-z-200 mr-bg-blue-firefly-75 mr-flex mr-justify-center mr-items-center"
-           >
-             <BusySpinner big inline />
-           </div>
-          }
         </MediaQuery>
         <MediaQuery query="(max-width: 1023px)">
-          <MapPane completingTask={this.props.completingTask}>
+          <MapPane>
             <TaskMap isMobile
                      task={this.props.task}
                      challenge={this.props.task.parent}

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -134,4 +134,24 @@ export default defineMessages({
     id: "Widgets.TaskBundleWidget.readOnly",
     defaultMessage: "Previewing task in read-only mode",
   },
+
+  fetchBundleError: {
+    id: "Widgets.TaskBundleWidget.fetchBundleError",
+    defaultMessage: "Failed to fetch task bundle. Please try again.",
+  },
+
+  lockTaskError: {
+    id: "Widgets.TaskBundleWidget.lockTaskError",
+    defaultMessage: "Failed to lock task {taskId}. Please try again.",
+  },
+
+  refreshTaskLockError: {
+    id: "Widgets.TaskBundleWidget.refreshTaskLockError",
+    defaultMessage: "Failed to refresh task lock. Please try again.",
+  },
+
+  updateTaskBundleError: {
+    id: "Widgets.TaskBundleWidget.updateTaskBundleError",
+    defaultMessage: "Failed to update task bundle. Please try again.",
+  },
 })

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -159,4 +159,9 @@ export default defineMessages({
     id: "Widgets.TaskBundleWidget.updateTaskBundleError",
     defaultMessage: "Failed to update task bundle. Please try again.",
   },
+
+  tooManyTasks: {
+    id: "Widgets.TaskBundleWidget.tooManyTasks",
+    defaultMessage: "Initial bundle cannot exceed 50 tasks",
+  },
 })

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -95,8 +95,8 @@ export default defineMessages({
   },
 
   unbundleTasksLabel: {
-    id: "Widgets.TaskBundleWidget.controls.stopBundling.label",
-    defaultMessage: "Stop Bundling Tasks",
+    id: "Widgets.TaskBundleWidget.controls.stopBundlinsg.label",
+    defaultMessage: "Delete Bundle",
   },
 
   resetBundleLabel: {

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -164,4 +164,29 @@ export default defineMessages({
     id: "Widgets.TaskBundleWidget.tooManyTasks",
     defaultMessage: "Initial bundle cannot exceed 50 tasks",
   },
+
+  bundleLimitError: {
+    id: "Widgets.TaskBundleWidget.bundleLimitError",
+    defaultMessage: "Cannot create bundle with more than 50 tasks",
+  },
+
+  lockError: {
+    id: "Widgets.TaskBundleWidget.lockError", 
+    defaultMessage: "Failed to lock tasks. Please try again.",
+  },
+
+  unlockError: {
+    id: "Widgets.TaskBundleWidget.unlockError",
+    defaultMessage: "Failed to unlock tasks. Please try again.", 
+  },
+
+  refreshError: {
+    id: "Widgets.TaskBundleWidget.refreshError",
+    defaultMessage: "Failed to refresh task locks. Please try again.",
+  },
+
+  bundleTypeError: {
+    id: "Widgets.TaskBundleWidget.bundleTypeError", 
+    defaultMessage: "Cannot bundle tasks of different types together",
+  },
 })

--- a/src/components/Widgets/TaskBundleWidget/Messages.js
+++ b/src/components/Widgets/TaskBundleWidget/Messages.js
@@ -93,6 +93,11 @@ export default defineMessages({
     id: "Widgets.TaskBundleWidget.removeFromBundle",
     defaultMessage: "Remove from bundle",
   },
+  
+  addToBundle: {
+    id: "Widgets.TaskBundleWidget.addToBundle",
+    defaultMessage: "Add to bundle",
+  },
 
   unbundleTasksLabel: {
     id: "Widgets.TaskBundleWidget.controls.stopBundlinsg.label",

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -11,14 +11,16 @@ import _pick from 'lodash/pick'
 import _map from 'lodash/map'
 import bbox from '@turf/bbox'
 import { point, featureCollection } from '@turf/helpers'
-import { WidgetDataTarget, registerWidgetType } from '../../../services/Widget/Widget'
-import { buildSearchURL } from '../../../services/SearchCriteria/SearchCriteria'
+import { WidgetDataTarget, registerWidgetType }
+       from '../../../services/Widget/Widget'
+       import { buildSearchURL } from '../../../services/SearchCriteria/SearchCriteria'
 import MapPane from '../../EnhancedMap/MapPane/MapPane'
 import TaskClusterMap from '../../TaskClusterMap/TaskClusterMap'
 import TaskPropertyFilter from '../../TaskFilters/TaskPropertyFilter'
 import TaskPriorityFilter from '../../TaskFilters/TaskPriorityFilter'
 import TaskStatusFilter from '../../TaskFilters/TaskStatusFilter'
-import WithSelectedClusteredTasks from '../../HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks'
+import WithSelectedClusteredTasks
+       from '../../HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks'
 import WithBrowsedChallenge from '../../HOCs/WithBrowsedChallenge/WithBrowsedChallenge'
 import WithNearbyTasks from '../../HOCs/WithNearbyTasks/WithNearbyTasks'
 import WithTaskClusterMarkers from '../../HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers'
@@ -27,11 +29,13 @@ import WithClusteredTasks from '../../HOCs/WithClusteredTasks/WithClusteredTasks
 import WithFilterCriteria from '../../HOCs/WithFilterCriteria/WithFilterCriteria'
 import WithTaskPropertyKeys from '../../HOCs/WithTaskPropertyKeys/WithTaskPropertyKeys'
 import WithBoundedTasks from '../../HOCs/WithBoundedTasks/WithBoundedTasks'
-import WithFilteredClusteredTasks from '../../HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks'
+import WithFilteredClusteredTasks
+       from '../../HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks'
 import WithSavedFilters from '../../HOCs/WithSavedFilters/WithSavedFilters'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import AsCooperativeWork from '../../../interactions/Task/AsCooperativeWork'
-import WithWebSocketSubscriptions from '../../HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions'
+import WithWebSocketSubscriptions
+       from '../../HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions'
 import { toLatLngBounds } from '../../../services/MapBounds/MapBounds'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import BusySpinner from '../../BusySpinner/BusySpinner'
@@ -88,7 +92,7 @@ export default class TaskBundleWidget extends Component {
 
     const shortcuts = keyboardShortcutGroups.taskEditing;
     if (event.key === shortcuts.completeTogether.key) {
-      this.bundleTasks();
+      this.bundleTasks()
     }
   }
 
@@ -97,7 +101,7 @@ export default class TaskBundleWidget extends Component {
    * and initially within bounds of "nearby" tasks as a starting point for the
    * widget map
    */
-  initializeClusterFilters(prevProps = {}) {
+  initializeClusterFilters(prevProps={}) {
     // If the nearby tasks loaded, update bounds
     if (_get(this.props, 'nearbyTasks.tasks.length', 0) > 0 &&
         !_isEqual(this.props.nearbyTasks, prevProps.nearbyTasks)) {
@@ -105,10 +109,9 @@ export default class TaskBundleWidget extends Component {
     }
   }
 
-  initializeWebsocketSubscription(prevProps = {}) {
+  initializeWebsocketSubscription(prevProps={}) {
     const challengeId = _get(this.props.task, 'parent.id')
-    if (_isFinite(challengeId) &&
-        (challengeId !== _get(prevProps.task, 'parent.id'))) {
+    if (_isFinite(challengeId) && (challengeId !== _get(prevProps.task, 'parent.id'))) {
       this.props.subscribeToChallengeTaskMessages(challengeId)
     }
   }
@@ -164,18 +167,18 @@ export default class TaskBundleWidget extends Component {
   }
 
   saveFilters = () => {
-    if (!this.props.criteria) return
+    if(!this.props.criteria) return
     const searchURL = buildSearchURL(this.props.criteria)
-    this.props.updateUserAppSetting(this.props.user.id, { 'taskBundleFilters': searchURL })
+    this.props.updateUserAppSetting(this.props.user.id, {'taskBundleFilters': searchURL})
   }
 
   revertFilters = () => {
-    if (this.props.clearAllFilters) {
+    if(this.props.clearAllFilters) {
       this.props.clearAllFilters()
     }
-
-    if (this.props.updateUserAppSetting) {
-      this.props.updateUserAppSetting(this.props.user.id, { 'taskBundleFilters': '' })
+    
+    if(this.props.updateUserAppSetting) {
+      this.props.updateUserAppSetting(this.props.user.id, {'taskBundleFilters': ''})
     }
   }
 
@@ -188,7 +191,7 @@ export default class TaskBundleWidget extends Component {
     if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
       this.props.selectTasks([this.props.task])
     }
-    if (this.props.taskBundle) {
+    if(this.props.taskBundle) {
       this.props.selectTasks(this.props.taskBundle.tasks)
       this.setBoundsToNearbyTask()
     }
@@ -207,7 +210,7 @@ export default class TaskBundleWidget extends Component {
         _pick(this.props.keyboardShortcutGroups.taskEditing, 'completeTogether'),
         this.handleKeyboardShortcuts
       )
-    } else if (this.state.shortcutActive === true && this.props.selectedTaskCount(this.props.taskInfo.totalCount) <= 1) {
+    } else if (this.state.shortcutActive === true && this.props.selectedTaskCount(this.props.taskInfo.totalCount) <= 1){
       this.setState({ shortcutActive: false })
       this.props.deactivateKeyboardShortcut(shortcutGroup, 'completeTogether', this.handleKeyboardShortcuts)
     }
@@ -217,19 +220,16 @@ export default class TaskBundleWidget extends Component {
         this.props.task.id !== prevProps.task.id) {
       this.props.resetSelectedTasks()
       this.setBoundsToNearbyTask()
-    } else if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
+    }
+    else if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
       this.props.selectTasks([this.props.task])
     }
-    if (this.props.taskBundle && this.props.taskBundle !== prevProps.taskBundle) {
+    if(this.props.taskBundle && this.props.taskBundle !== prevProps.taskBundle) {
       await this.props.resetSelectedTasks()
       this.props.selectTasks(this.props.taskBundle.tasks)
-      if (!prevProps.taskBundle) {
+      if(!prevProps.taskBundle){
         this.setBoundsToNearbyTask()
       }
-    }
-
-    if (this.props.selectedTasks.selected.size !== prevProps.selectedTasks.selected.size) {
-      this.setState({ bundleButtonDisabled: false });
     }
   }
 
@@ -280,7 +280,7 @@ const calculateTasksInChallenge = props => {
 const ActiveBundle = props => {
   const showMarkerPopup = markerData => {
     return (
-      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] : [0.5, -5]}>
+      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] :  [0.5, -5]}>
         <div className="marker-popup-content">
           <TaskMarkerContent
             {...props}
@@ -299,13 +299,15 @@ const ActiveBundle = props => {
   const bundleCenter = toLatLngBounds(
     bbox({
       type: 'FeatureCollection',
-      features: _map(props.taskBundle.tasks, task => ({
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [task.location.coordinates[0], task.location.coordinates[1]]
-        }
-      }))
+      features: _map(props.taskBundle.tasks, task =>
+        ({
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [task.location.coordinates[0], task.location.coordinates[1]]
+          }
+        })
+      )
     })
   );
 
@@ -326,7 +328,7 @@ const ActiveBundle = props => {
     <TaskAnalysisTable
       {...props}
       selectedTasks={new Map()}
-      taskData={props.bundledOnly && props.taskBundle ? _get(props, 'taskBundle.tasks') : _get(props, 'taskInfo.tasks')}
+      taskData={props.bundledOnly && props.taskBundle ? _get(props, 'taskBundle.tasks'): _get(props, 'taskInfo.tasks')}
       totalTaskCount={
         _get(props, 'taskInfo.totalCount') ||
         _get(props, 'taskInfo.tasks.length')
@@ -348,7 +350,7 @@ const ActiveBundle = props => {
 
   return (
     <div className="mr-h-full mr-rounded">
-      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px` }}>
+      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px`}}>
         {props.loading ? (
           <BusySpinner className="mr-h-full mr-flex mr-items-center" />
         ) : (
@@ -476,17 +478,17 @@ const BuildBundle = props => {
 
   const totalTaskCount = _get(props, 'taskInfo.totalCount') || _get(props, 'taskInfo.tasks.length')
   const bundleButton = !props.taskReadOnly && props.selectedTaskCount(totalTaskCount) > 1 && !props.bundleEditsDisabled ? (
-    <button
-      className="mr-button mr-button--green-lighter mr-button--small"
-      onClick={props.bundleTasks}
-    >
-      <FormattedMessage {...messages.bundleTasksLabel} />
-    </button>
+      <button
+        className="mr-button mr-button--green-lighter mr-button--small"
+        onClick={props.bundleTasks}
+      >
+        <FormattedMessage {...messages.bundleTasksLabel} />
+      </button>
   ) : null
 
   const showMarkerPopup = (markerData) => {
     return (
-      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] : [0.5, -5]}>
+      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] :  [0.5, -5]}>
         <div className="marker-popup-content">
           <TaskMarkerContent
             {...props}
@@ -498,7 +500,7 @@ const BuildBundle = props => {
     )
   }
 
-  const map = (
+  const map =
     <ClusterMap
       {...props}
       showMarkerPopup={showMarkerPopup}
@@ -511,11 +513,10 @@ const BuildBundle = props => {
       fitbBoundsControl
       showSelectMarkersInView
     />
-  )
 
   return (
     <div className="mr-pb-2 mr-h-full mr-rounded">
-      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px` }}>
+      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px`}}>
         {props.loading ?
           <BusySpinner className="mr-h-full mr-flex mr-items-center" /> :
           <MapPane showLasso>{map}</MapPane>
@@ -550,11 +551,11 @@ const BuildBundle = props => {
             </li>
           </ul>
         </div>
-
+        
         <div className={`mr-flex mr-space-x-3 mr-items-center ${props.widgetLayout && props.widgetLayout?.w === 4 ? 'mr-justify-between' : 'mr-justify-end'}`}>
-          {<ClearFiltersControl clearFilters={props.clearAllFilters} />}
+        {<ClearFiltersControl clearFilters={props.clearAllFilters}/>}
           <Dropdown
-            className="mr-flex mr-items-center"
+          className="mr-flex mr-items-center"
             dropdownButton={(dropdown) => (
               <button
                 onClick={dropdown.toggleDropdownVisible}
@@ -569,8 +570,8 @@ const BuildBundle = props => {
             )}
             dropdownContent={(dropdown) => (
               <div className='mr-flex mr-flex-col mr-space-y-2'>
-                <SaveFiltersControl saveFilters={props.saveFilters} closeDropdown={dropdown.closeDropdown} />
-                <RevertFiltersControl revertFilters={props.revertFilters} />
+                <SaveFiltersControl saveFilters={props.saveFilters} closeDropdown={dropdown.closeDropdown}/>
+                <RevertFiltersControl revertFilters={props.revertFilters}/>
               </div>
             )}
           />
@@ -581,7 +582,7 @@ const BuildBundle = props => {
           {...props}
           taskData={_get(props, 'taskInfo.tasks')}
           totalTaskCount={totalTaskCount}
-          totalTasksInChallenge={calculateTasksInChallenge(props)}
+          totalTasksInChallenge={ calculateTasksInChallenge(props) }
           showColumns={['selected', 'featureId', 'id', 'status', 'priority', 'comments']}
           customHeaderControls={bundleButton}
           suppressManagement
@@ -629,8 +630,8 @@ registerWidgetType(
   ), descriptor
 )
 
-const RevertFiltersControl = ({ revertFilters }) => {
-  const handleClick = () => { revertFilters() }
+const RevertFiltersControl = ({revertFilters}) => {
+  const handleClick = () => {revertFilters()}
   return (
     <button className="mr-flex mr-items-center mr-text-current hover:mr-text-green-lighter mr-transition-colors"
       onClick={handleClick}>
@@ -639,9 +640,9 @@ const RevertFiltersControl = ({ revertFilters }) => {
   )
 }
 
-const SaveFiltersControl = ({ saveFilters, closeDropdown }) => {
+const SaveFiltersControl = ({saveFilters, closeDropdown}) => {
   const handleClick = () => {
-    saveFilters()
+    saveFilters() 
     closeDropdown()
   }
   return (
@@ -652,7 +653,7 @@ const SaveFiltersControl = ({ saveFilters, closeDropdown }) => {
   )
 }
 
-const ClearFiltersControl = ({ clearFilters }) => (
+const ClearFiltersControl = ({clearFilters}) => (
   <button className="mr-flex mr-items-center mr-text-green-lighter"
     onClick={clearFilters}>
     <SvgSymbol sym="close-icon"

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -256,13 +256,17 @@ export default class TaskBundleWidget extends Component {
       >
         <WidgetContent
           {...this.props}
-          errorMessage={this.props.errorMessage}
           saveFilters={this.saveFilters}
           revertFilters={this.revertFilters}
           bundleTasks={this.bundleTasks}
           unbundleTask={this.unbundleTask}
           loading={this.props.loading}
         />
+        {this.props.errorMessage && (
+          <div className="mr-text-red">
+            <FormattedMessage id={this.props.errorMessage} defaultMessage={this.props.errorMessage} />
+          </div>
+        )}
       </QuickWidget>
     )
   }
@@ -357,7 +361,9 @@ const ActiveBundle = props => {
           <MapPane>{map}</MapPane>
         )}
         {props.errorMessage && (
-          <div className="mr-text-red">{props.errorMessage}</div>
+          <div className="mr-text-red">
+            <FormattedMessage {...messages[props.errorMessage]} />
+          </div>
         )}
         <h3 className="mr-text-lg mr-text-center mr-text-pink-light mr-mt-4">
           <FormattedMessage
@@ -523,8 +529,10 @@ const BuildBundle = props => {
         }
       </div>
       {props.errorMessage && (
-          <div className="mr-text-red">{props.errorMessage}</div>
-        )}
+        <div className="mr-text-red">
+          <FormattedMessage {...messages[props.errorMessage]} />
+        </div>
+      )}
       <div className={props.widgetLayout && props.widgetLayout?.w === 4 ? "mr-my-4 mr-px-4 mr-space-y-3" : "mr-my-4 mr-px-4 xl:mr-flex xl:mr-justify-between mr-items-center"}>
         {props.initialBundle && (
           <button

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -583,16 +583,18 @@ const BuildBundle = props => {
           ))}
         </div>
       )}
-      <div className={props.widgetLayout && props.widgetLayout?.w === 4 ? "mr-my-4 mr-px-4 mr-space-y-3" : "mr-my-4 mr-px-4 xl:mr-flex xl:mr-justify-between mr-items-center"}>
+        <div className="mr-flex mr-justify-end mr-mt-2">
         {props.initialBundle && (
           <button
-            className={`mr-button mr-button--red mr-button--small ${props.bundleEditsDisabled ? 'mr-text-grey-light mr-cursor-default' : 'mr-text-green-lighter'}`} // Conditional classes
+            className={`mr-button mr-button--red mr-button--small mr-mt-2 mr-float-right ${props.bundleEditsDisabled ? 'mr-text-grey-light mr-cursor-default' : 'mr-text-green-lighter'}`}
             onClick={props.resetTaskBundle}
             disabled={props.bundleEditsDisabled}
           >
             <FormattedMessage {...messages.resetBundleLabel} />
           </button>
         )}
+        </div>
+      <div className={props.widgetLayout && props.widgetLayout?.w === 4 ? "mr-my-4 mr-px-4 mr-space-y-3" : "mr-my-4 mr-px-4 xl:mr-flex xl:mr-justify-between mr-items-center"}>
         <div className="mr-flex mr-items-center">
           <p className="mr-text-base mr-uppercase mr-text-mango mr-mr-8">
             <FormattedMessage {...messages.filterListLabel} />

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -68,6 +68,7 @@ const shortcutGroup = 'taskEditing'
 export default class TaskBundleWidget extends Component {
   state = {
     shortcutActive: false,
+    bundleButtonDisabled: false,
   }
 
   handleKeyboardShortcuts = (event) => {
@@ -114,7 +115,7 @@ export default class TaskBundleWidget extends Component {
 
   bundleTasks = () => {
     if (this.props.taskBundle || this.props.bundleEditsDisabled) {
-      return
+      return;
     }
 
     const selectedArray = Array.from(this.props.selectedTasks.selected.values());
@@ -126,7 +127,12 @@ export default class TaskBundleWidget extends Component {
       }
     });
 
+    this.setState({ bundleButtonDisabled: true });
     this.props.createTaskBundle([...this.props.selectedTasks.selected.keys()]);
+
+    setTimeout(() => {
+      this.setState({ bundleButtonDisabled: false });
+    }, 5000);
   }
 
   unbundleTask = (task) => {
@@ -221,6 +227,10 @@ export default class TaskBundleWidget extends Component {
         this.setBoundsToNearbyTask()
       }
     }
+
+    if (this.props.selectedTasks.selected.size !== prevProps.selectedTasks.selected.size) {
+      this.setState({ bundleButtonDisabled: false });
+    }
   }
 
   componentWillUnmount() {
@@ -234,7 +244,7 @@ export default class TaskBundleWidget extends Component {
   }
 
   render() {
-    const WidgetContent = this.props.taskBundle ? ActiveBundle : BuildBundle
+    const WidgetContent = this.props.taskBundle ? ActiveBundle : BuildBundle;
     return (
       <QuickWidget
         {...this.props}
@@ -246,6 +256,7 @@ export default class TaskBundleWidget extends Component {
       >
         <WidgetContent
           {...this.props}
+          errorMessage={this.props.errorMessage}
           saveFilters={this.saveFilters}
           revertFilters={this.revertFilters}
           bundleTasks={this.bundleTasks}
@@ -334,7 +345,7 @@ const ActiveBundle = props => {
       defaultPageSize={5}
     />
   )
-console.log(props)
+
   return (
     <div className="mr-h-full mr-rounded">
       <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px` }}>
@@ -342,6 +353,9 @@ console.log(props)
           <BusySpinner className="mr-h-full mr-flex mr-items-center" />
         ) : (
           <MapPane>{map}</MapPane>
+        )}
+        {props.errorMessage && (
+          <div className="mr-text-red">{props.errorMessage}</div>
         )}
         <h3 className="mr-text-lg mr-text-center mr-text-pink-light mr-mt-4">
           <FormattedMessage
@@ -507,7 +521,9 @@ const BuildBundle = props => {
           <MapPane showLasso>{map}</MapPane>
         }
       </div>
-
+      {props.errorMessage && (
+          <div className="mr-text-red">{props.errorMessage}</div>
+        )}
       <div className={props.widgetLayout && props.widgetLayout?.w === 4 ? "mr-my-4 mr-px-4 mr-space-y-3" : "mr-my-4 mr-px-4 xl:mr-flex xl:mr-justify-between mr-items-center"}>
         {props.initialBundle && (
           <button

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -261,8 +261,6 @@ export default class TaskBundleWidget extends Component {
     if (this.props.updateTaskBundleError) {
       newErrors.add('updateTaskBundleError')
     }
-
-
     // Only update state if errors have changed
     if (newErrors.size !== this.state.errors.size || 
         [...newErrors].some(error => !this.state.errors.has(error))) {
@@ -399,6 +397,11 @@ const ActiveBundle = props => {
           {[...props.errors].map(errorType => (
             <div key={errorType}>
               <FormattedMessage {...messages[errorType]} />
+              {errorType === 'lockError' && props.failedLocks && (
+                <span className="mr-ml-2">
+                  ({props.failedLocks.join(', ')})
+                </span>
+              )}
             </div>
           ))}
         </div>
@@ -511,7 +514,6 @@ const ActiveBundle = props => {
 }
 
 const BuildBundle = props => {
-  console.log(props.errors)
   if (props.virtualChallenge || _isFinite(props.virtualChallengeId)) {
     return (
       <div className="mr-text-base">
@@ -572,6 +574,11 @@ const BuildBundle = props => {
           {[...props.errors].map(errorType => (
             <div key={errorType}>
               <FormattedMessage {...messages[errorType]} />
+              {errorType === 'lockError' && props.failedLocks && (
+                <span className="mr-ml-2">
+                  ({props.failedLocks.join(', ')})
+                </span>
+              )}
             </div>
           ))}
         </div>

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -11,16 +11,14 @@ import _pick from 'lodash/pick'
 import _map from 'lodash/map'
 import bbox from '@turf/bbox'
 import { point, featureCollection } from '@turf/helpers'
-import { WidgetDataTarget, registerWidgetType }
-       from '../../../services/Widget/Widget'
-       import { buildSearchURL } from '../../../services/SearchCriteria/SearchCriteria'
+import { WidgetDataTarget, registerWidgetType } from '../../../services/Widget/Widget'
+import { buildSearchURL } from '../../../services/SearchCriteria/SearchCriteria'
 import MapPane from '../../EnhancedMap/MapPane/MapPane'
 import TaskClusterMap from '../../TaskClusterMap/TaskClusterMap'
 import TaskPropertyFilter from '../../TaskFilters/TaskPropertyFilter'
 import TaskPriorityFilter from '../../TaskFilters/TaskPriorityFilter'
 import TaskStatusFilter from '../../TaskFilters/TaskStatusFilter'
-import WithSelectedClusteredTasks
-       from '../../HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks'
+import WithSelectedClusteredTasks from '../../HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks'
 import WithBrowsedChallenge from '../../HOCs/WithBrowsedChallenge/WithBrowsedChallenge'
 import WithNearbyTasks from '../../HOCs/WithNearbyTasks/WithNearbyTasks'
 import WithTaskClusterMarkers from '../../HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers'
@@ -29,13 +27,11 @@ import WithClusteredTasks from '../../HOCs/WithClusteredTasks/WithClusteredTasks
 import WithFilterCriteria from '../../HOCs/WithFilterCriteria/WithFilterCriteria'
 import WithTaskPropertyKeys from '../../HOCs/WithTaskPropertyKeys/WithTaskPropertyKeys'
 import WithBoundedTasks from '../../HOCs/WithBoundedTasks/WithBoundedTasks'
-import WithFilteredClusteredTasks
-       from '../../HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks'
+import WithFilteredClusteredTasks from '../../HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks'
 import WithSavedFilters from '../../HOCs/WithSavedFilters/WithSavedFilters'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import AsCooperativeWork from '../../../interactions/Task/AsCooperativeWork'
-import WithWebSocketSubscriptions
-       from '../../HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions'
+import WithWebSocketSubscriptions from '../../HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions'
 import { toLatLngBounds } from '../../../services/MapBounds/MapBounds'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import BusySpinner from '../../BusySpinner/BusySpinner'
@@ -74,26 +70,9 @@ export default class TaskBundleWidget extends Component {
     shortcutActive: false,
   }
 
-  bundleTasks = () => {
-    if(_get(this.props, 'taskBundle.tasks.length', 0) > 0 || this.props.bundleEditsDisabled){
-      return
-    }
-
-    const selectedArray = Array.from(this.props.selectedTasks.selected.values());
-    const isCooperative = AsCooperativeWork(this.props.task).isCooperative();
-
-    selectedArray.forEach(item => {
-      if (AsCooperativeWork(item).isCooperative() !== isCooperative) {
-        throw new Error("Bundle type mismatch, not all tasks are of the same type");
-      }
-    });
-
-    this.props.createTaskBundle([...this.props.selectedTasks.selected.keys()]);
-  }
-
   handleKeyboardShortcuts = (event) => {
     const { activeKeyboardShortcuts, textInputActive, taskReadOnly, keyboardShortcutGroups } = this.props;
-    
+
     // Return early if any of the following conditions are met:
     // - Shortcut group is not active
     // - Typing in inputs
@@ -112,18 +91,12 @@ export default class TaskBundleWidget extends Component {
     }
   }
 
-  unbundleTask = (task) => {
-    const taskId = task.id ?? task.taskId 
-    this.props.removeTaskFromBundle(taskId)
-    this.props.toggleTaskSelection(task)
-  }
-
   /**
    * Initialize the cluster filters to include tasks from the current challenge
    * and initially within bounds of "nearby" tasks as a starting point for the
    * widget map
    */
-  initializeClusterFilters(prevProps={}) {
+  initializeClusterFilters(prevProps = {}) {
     // If the nearby tasks loaded, update bounds
     if (_get(this.props, 'nearbyTasks.tasks.length', 0) > 0 &&
         !_isEqual(this.props.nearbyTasks, prevProps.nearbyTasks)) {
@@ -131,16 +104,35 @@ export default class TaskBundleWidget extends Component {
     }
   }
 
-  initializeWebsocketSubscription(prevProps={}) {
+  initializeWebsocketSubscription(prevProps = {}) {
     const challengeId = _get(this.props.task, 'parent.id')
     if (_isFinite(challengeId) &&
-       (challengeId !== _get(prevProps.task, 'parent.id'))) {
+        (challengeId !== _get(prevProps.task, 'parent.id'))) {
       this.props.subscribeToChallengeTaskMessages(challengeId)
     }
   }
 
-  updateBounds = (challengeId, bounds, zoom) => {
-    this.props.updateTaskFilterBounds(bounds, zoom)
+  bundleTasks = () => {
+    if (this.props.taskBundle || this.props.bundleEditsDisabled) {
+      return
+    }
+
+    const selectedArray = Array.from(this.props.selectedTasks.selected.values());
+    const isCooperative = AsCooperativeWork(this.props.task).isCooperative();
+
+    selectedArray.forEach(item => {
+      if (AsCooperativeWork(item).isCooperative() !== isCooperative) {
+        throw new Error("Bundle type mismatch, not all tasks are of the same type");
+      }
+    });
+
+    this.props.createTaskBundle([...this.props.selectedTasks.selected.keys()]);
+  }
+
+  unbundleTask = (task) => {
+    const taskId = task.id ?? task.taskId 
+    this.props.removeTaskFromBundle(taskId)
+    this.props.toggleTaskSelection(task)
   }
 
   setBoundsToNearbyTask = () => {
@@ -153,7 +145,7 @@ export default class TaskBundleWidget extends Component {
     if (taskList) {
       taskList?.push(mappableTask)
     }
-    
+
     if (!taskList || taskList.length === 0) {
       return
     }
@@ -166,18 +158,18 @@ export default class TaskBundleWidget extends Component {
   }
 
   saveFilters = () => {
-    if(!this.props.criteria) return
+    if (!this.props.criteria) return
     const searchURL = buildSearchURL(this.props.criteria)
-    this.props.updateUserAppSetting(this.props.user.id, {'taskBundleFilters': searchURL})
+    this.props.updateUserAppSetting(this.props.user.id, { 'taskBundleFilters': searchURL })
   }
 
   revertFilters = () => {
-    if(this.props.clearAllFilters) {
+    if (this.props.clearAllFilters) {
       this.props.clearAllFilters()
     }
-    
-    if(this.props.updateUserAppSetting) {
-      this.props.updateUserAppSetting(this.props.user.id, {'taskBundleFilters': ''})
+
+    if (this.props.updateUserAppSetting) {
+      this.props.updateUserAppSetting(this.props.user.id, { 'taskBundleFilters': '' })
     }
   }
 
@@ -190,13 +182,13 @@ export default class TaskBundleWidget extends Component {
     if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
       this.props.selectTasks([this.props.task])
     }
-    if(this.props.taskBundle) {
+    if (this.props.taskBundle) {
       this.props.selectTasks(this.props.taskBundle.tasks)
       this.setBoundsToNearbyTask()
     }
   }
 
-  async componentDidUpdate (prevProps) {
+  async componentDidUpdate(prevProps) {
     if (!this.props.taskBundle) {
       this.initializeClusterFilters(prevProps)
       this.initializeWebsocketSubscription(prevProps)
@@ -209,10 +201,9 @@ export default class TaskBundleWidget extends Component {
         _pick(this.props.keyboardShortcutGroups.taskEditing, 'completeTogether'),
         this.handleKeyboardShortcuts
       )
-    } else if (this.state.shortcutActive === true && this.props.selectedTaskCount(this.props.taskInfo.totalCount) <= 1){
+    } else if (this.state.shortcutActive === true && this.props.selectedTaskCount(this.props.taskInfo.totalCount) <= 1) {
       this.setState({ shortcutActive: false })
-      this.props.deactivateKeyboardShortcut(shortcutGroup, 'completeTogether',
-      this.handleKeyboardShortcuts)
+      this.props.deactivateKeyboardShortcut(shortcutGroup, 'completeTogether', this.handleKeyboardShortcuts)
     }
 
     if (_isFinite(_get(this.props, 'task.id')) &&
@@ -220,14 +211,13 @@ export default class TaskBundleWidget extends Component {
         this.props.task.id !== prevProps.task.id) {
       this.props.resetSelectedTasks()
       this.setBoundsToNearbyTask()
-    }
-    else if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
+    } else if (this.props.task && this.props.selectedTasks && !this.props.isTaskSelected(this.props.task.id)) {
       this.props.selectTasks([this.props.task])
     }
-    if(this.props.taskBundle && this.props.taskBundle !== prevProps.taskBundle) {
+    if (this.props.taskBundle && this.props.taskBundle !== prevProps.taskBundle) {
       await this.props.resetSelectedTasks()
       this.props.selectTasks(this.props.taskBundle.tasks)
-      if(!prevProps.taskBundle){
+      if (!prevProps.taskBundle) {
         this.setBoundsToNearbyTask()
       }
     }
@@ -240,13 +230,11 @@ export default class TaskBundleWidget extends Component {
       this.props.unsubscribeFromChallengeTaskMessages(challengeId)
     }
 
-    this.props.deactivateKeyboardShortcut(shortcutGroup, 'completeTogether',
-                                          this.handleKeyboardShortcuts)
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'completeTogether', this.handleKeyboardShortcuts)
   }
 
   render() {
-    const WidgetContent = this.props.taskBundle ?
-                          ActiveBundle : BuildBundle
+    const WidgetContent = this.props.taskBundle ? ActiveBundle : BuildBundle
     return (
       <QuickWidget
         {...this.props}
@@ -260,7 +248,6 @@ export default class TaskBundleWidget extends Component {
           {...this.props}
           saveFilters={this.saveFilters}
           revertFilters={this.revertFilters}
-          updateBounds={this.updateBounds}
           bundleTasks={this.bundleTasks}
           unbundleTask={this.unbundleTask}
           loading={this.props.loading}
@@ -282,7 +269,7 @@ const calculateTasksInChallenge = props => {
 const ActiveBundle = props => {
   const showMarkerPopup = markerData => {
     return (
-      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] :  [0.5, -5]}>
+      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] : [0.5, -5]}>
         <div className="marker-popup-content">
           <TaskMarkerContent
             {...props}
@@ -301,15 +288,13 @@ const ActiveBundle = props => {
   const bundleCenter = toLatLngBounds(
     bbox({
       type: 'FeatureCollection',
-      features: _map(props.taskBundle.tasks, task =>
-        ({
-          type: 'Feature',
-          geometry: {
-            type: 'Point',
-            coordinates: [task.location.coordinates[0], task.location.coordinates[1]]
-          }
-        })
-      )
+      features: _map(props.taskBundle.tasks, task => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [task.location.coordinates[0], task.location.coordinates[1]]
+        }
+      }))
     })
   );
 
@@ -330,7 +315,7 @@ const ActiveBundle = props => {
     <TaskAnalysisTable
       {...props}
       selectedTasks={new Map()}
-      taskData={props.bundledOnly && props.taskBundle ? _get(props, 'taskBundle.tasks'): _get(props, 'taskInfo.tasks')}
+      taskData={props.bundledOnly && props.taskBundle ? _get(props, 'taskBundle.tasks') : _get(props, 'taskInfo.tasks')}
       totalTaskCount={
         _get(props, 'taskInfo.totalCount') ||
         _get(props, 'taskInfo.tasks.length')
@@ -349,18 +334,24 @@ const ActiveBundle = props => {
       defaultPageSize={5}
     />
   )
-
+console.log(props)
   return (
     <div className="mr-h-full mr-rounded">
-      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px`}}>
+      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px` }}>
         {props.loading ? (
           <BusySpinner className="mr-h-full mr-flex mr-items-center" />
         ) : (
           <MapPane>{map}</MapPane>
         )}
+        <h3 className="mr-text-lg mr-text-center mr-text-pink-light mr-mt-4">
+          <FormattedMessage
+            {...messages.simultaneousTasks}
+            values={{ taskCount: props.taskBundle.taskIds.length }}
+          />
+        </h3>
         <div className="mr-flex mr-justify-between mr-content-center mr-my-4">
           <button
-            className="mr-button mr-button--green-lighter mr-button--small"
+            className="mr-button mr-button--green-lighter mr-button--small mr-mr-2"
             onClick={() => props.setBundledOnly(!props.bundledOnly)}
           >
             {props.bundledOnly ? (
@@ -369,35 +360,30 @@ const ActiveBundle = props => {
               <FormattedMessage {...messages.displayBundledTasksLabel} />
             )}
           </button>
-          <h3 className="mr-text-lg mr-text-center mr-text-pink-light">
-            <FormattedMessage
-              {...messages.simultaneousTasks}
-              values={{ taskCount: props.taskBundle.taskIds.length }}
-            />
-          </h3>
-          {props.initialBundle &&
-          <button
-            disabled={(props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length))}
-            className="mr-button mr-button--green-lighter mr-button--small"
-            style={{
-              cursor: (props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length)) ? 'default' : 'pointer',
-              opacity:(props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length)) ? 0.3 : 1
-            }}
-            onClick={() => props.resetTaskBundle()}
-          >
+          {props.initialBundle && (
+            <button
+              disabled={(props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length))}
+              className="mr-button mr-button--green-lighter mr-button--small mr-mr-2"
+              style={{
+                cursor: (props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length)) ? 'default' : 'pointer',
+                opacity: (props.bundleEditsDisabled || (props.initialBundle && props.initialBundle?.taskIds?.length === props.taskBundle?.taskIds?.length)) ? 0.3 : 1
+              }}
+              onClick={() => props.resetTaskBundle()}
+            >
               <FormattedMessage {...messages.resetBundleLabel} />
-          </button>
-}
+            </button>
+          )}
           <button
             disabled={(props.bundleEditsDisabled)}
             className="mr-button mr-button--green-lighter mr-button--small"
             style={{
-              cursor: 'pointer',
-              opacity: 1
+              cursor: props.bundleEditsDisabled ? 'default' : 'pointer',
+              opacity: props.bundleEditsDisabled ? 0.3 : 1
             }}
+
             onClick={() => props.clearActiveTaskBundle()}
           >
-              <FormattedMessage {...messages.unbundleTasksLabel} />
+            <FormattedMessage {...messages.unbundleTasksLabel} />
           </button>
         </div>
         <div
@@ -476,17 +462,17 @@ const BuildBundle = props => {
 
   const totalTaskCount = _get(props, 'taskInfo.totalCount') || _get(props, 'taskInfo.tasks.length')
   const bundleButton = !props.taskReadOnly && props.selectedTaskCount(totalTaskCount) > 1 && !props.bundleEditsDisabled ? (
-      <button
-        className="mr-button mr-button--green-lighter mr-button--small"
-        onClick={props.bundleTasks}
-      >
-        <FormattedMessage {...messages.bundleTasksLabel} />
-      </button>
+    <button
+      className="mr-button mr-button--green-lighter mr-button--small"
+      onClick={props.bundleTasks}
+    >
+      <FormattedMessage {...messages.bundleTasksLabel} />
+    </button>
   ) : null
 
   const showMarkerPopup = (markerData) => {
     return (
-      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] :  [0.5, -5]}>
+      <Popup key={markerData.options.taskId} offset={props.task.id === markerData.options.taskId ? [0.5, -16] : [0.5, -5]}>
         <div className="marker-popup-content">
           <TaskMarkerContent
             {...props}
@@ -498,7 +484,7 @@ const BuildBundle = props => {
     )
   }
 
-  const map =
+  const map = (
     <ClusterMap
       {...props}
       showMarkerPopup={showMarkerPopup}
@@ -511,10 +497,11 @@ const BuildBundle = props => {
       fitbBoundsControl
       showSelectMarkersInView
     />
+  )
 
   return (
     <div className="mr-pb-2 mr-h-full mr-rounded">
-      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px`}}>
+      <div className="mr-h-3/4 mr-min-h-80 mr-max-h-screen-80" style={{ maxHeight: `${props.widgetLayout.w * 80}px` }}>
         {props.loading ?
           <BusySpinner className="mr-h-full mr-flex mr-items-center" /> :
           <MapPane showLasso>{map}</MapPane>
@@ -522,6 +509,15 @@ const BuildBundle = props => {
       </div>
 
       <div className={props.widgetLayout && props.widgetLayout?.w === 4 ? "mr-my-4 mr-px-4 mr-space-y-3" : "mr-my-4 mr-px-4 xl:mr-flex xl:mr-justify-between mr-items-center"}>
+        {props.initialBundle && (
+          <button
+            className={`mr-button mr-button--red mr-button--small ${props.bundleEditsDisabled ? 'mr-text-grey-light mr-cursor-default' : 'mr-text-green-lighter'}`} // Conditional classes
+            onClick={props.resetTaskBundle}
+            disabled={props.bundleEditsDisabled}
+          >
+            <FormattedMessage {...messages.resetBundleLabel} />
+          </button>
+        )}
         <div className="mr-flex mr-items-center">
           <p className="mr-text-base mr-uppercase mr-text-mango mr-mr-8">
             <FormattedMessage {...messages.filterListLabel} />
@@ -538,11 +534,11 @@ const BuildBundle = props => {
             </li>
           </ul>
         </div>
-        
+
         <div className={`mr-flex mr-space-x-3 mr-items-center ${props.widgetLayout && props.widgetLayout?.w === 4 ? 'mr-justify-between' : 'mr-justify-end'}`}>
-        {<ClearFiltersControl clearFilters={props.clearAllFilters}/>}
+          {<ClearFiltersControl clearFilters={props.clearAllFilters} />}
           <Dropdown
-          className="mr-flex mr-items-center"
+            className="mr-flex mr-items-center"
             dropdownButton={(dropdown) => (
               <button
                 onClick={dropdown.toggleDropdownVisible}
@@ -557,8 +553,8 @@ const BuildBundle = props => {
             )}
             dropdownContent={(dropdown) => (
               <div className='mr-flex mr-flex-col mr-space-y-2'>
-                <SaveFiltersControl saveFilters={props.saveFilters} closeDropdown={dropdown.closeDropdown}/>
-                <RevertFiltersControl revertFilters={props.revertFilters}/>
+                <SaveFiltersControl saveFilters={props.saveFilters} closeDropdown={dropdown.closeDropdown} />
+                <RevertFiltersControl revertFilters={props.revertFilters} />
               </div>
             )}
           />
@@ -569,7 +565,7 @@ const BuildBundle = props => {
           {...props}
           taskData={_get(props, 'taskInfo.tasks')}
           totalTaskCount={totalTaskCount}
-          totalTasksInChallenge={ calculateTasksInChallenge(props) }
+          totalTasksInChallenge={calculateTasksInChallenge(props)}
           showColumns={['selected', 'featureId', 'id', 'status', 'priority', 'comments']}
           customHeaderControls={bundleButton}
           suppressManagement
@@ -617,8 +613,8 @@ registerWidgetType(
   ), descriptor
 )
 
-const RevertFiltersControl = ({revertFilters}) => {
-  const handleClick = () => {revertFilters()}
+const RevertFiltersControl = ({ revertFilters }) => {
+  const handleClick = () => { revertFilters() }
   return (
     <button className="mr-flex mr-items-center mr-text-current hover:mr-text-green-lighter mr-transition-colors"
       onClick={handleClick}>
@@ -627,9 +623,9 @@ const RevertFiltersControl = ({revertFilters}) => {
   )
 }
 
-const SaveFiltersControl = ({saveFilters, closeDropdown}) => {
+const SaveFiltersControl = ({ saveFilters, closeDropdown }) => {
   const handleClick = () => {
-    saveFilters() 
+    saveFilters()
     closeDropdown()
   }
   return (
@@ -640,7 +636,7 @@ const SaveFiltersControl = ({saveFilters, closeDropdown}) => {
   )
 }
 
-const ClearFiltersControl = ({clearFilters}) => (
+const ClearFiltersControl = ({ clearFilters }) => (
   <button className="mr-flex mr-items-center mr-text-green-lighter"
     onClick={clearFilters}>
     <SvgSymbol sym="close-icon"

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -117,7 +117,7 @@ export default class TaskBundleWidget extends Component {
   }
 
   createBundle = () => {
-    if (this.props.taskBundle || this.props.bundleEditsDisabled) {
+    if (this.props.taskBundle || this.props.bundleEditsDisabled || this.props.selectedTasks.selected.size > 50) {
       return;
     }
 
@@ -492,10 +492,11 @@ const BuildBundle = props => {
   const totalTaskCount = _get(props, 'taskInfo.totalCount') || _get(props, 'taskInfo.tasks.length')
   const bundleButton = !props.taskReadOnly && props.selectedTaskCount(totalTaskCount) > 1 && !props.bundleEditsDisabled ? (
       <button
-        className="mr-button mr-button--green-lighter mr-button--small"
+        className={`mr-button mr-button--green-lighter mr-button--small ${props.selectedTasks.selected.size > 50 ? 'mr-opacity-50 mr-cursor-not-allowed' : ''}`}
+        disabled={props.selectedTasks.selected.size > 50}
         onClick={props.createBundle}
       >
-        <FormattedMessage {...messages.bundleTasksLabel} />
+        {props.selectedTasks.selected.size > 50 ? <FormattedMessage {...messages.tooManyTasks} /> : <FormattedMessage {...messages.bundleTasksLabel} />}
       </button>
   ) : null
 

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -62,7 +62,7 @@ const descriptor = {
 const ClusterMap = WithChallengeTaskClusters(
   WithTaskClusterMarkers(TaskClusterMap('taskBundling')),
   true,
-  true,
+  false,
   false,
   false
 )
@@ -92,7 +92,7 @@ export default class TaskBundleWidget extends Component {
 
     const shortcuts = keyboardShortcutGroups.taskEditing;
     if (event.key === shortcuts.completeTogether.key) {
-      this.bundleTasks()
+      this.createBundle()
     }
   }
 
@@ -116,7 +116,7 @@ export default class TaskBundleWidget extends Component {
     }
   }
 
-  bundleTasks = () => {
+  createBundle = () => {
     if (this.props.taskBundle || this.props.bundleEditsDisabled) {
       return;
     }
@@ -141,6 +141,12 @@ export default class TaskBundleWidget extends Component {
   unbundleTask = (task) => {
     const taskId = task.id ?? task.taskId 
     this.props.removeTaskFromBundle(taskId)
+    this.props.toggleTaskSelection(task)
+  }
+
+  bundleTask = (task) => {
+    const taskId = task.id ?? task.taskId 
+    this.props.addTaskToBundle(taskId)
     this.props.toggleTaskSelection(task)
   }
 
@@ -258,8 +264,9 @@ export default class TaskBundleWidget extends Component {
           {...this.props}
           saveFilters={this.saveFilters}
           revertFilters={this.revertFilters}
-          bundleTasks={this.bundleTasks}
+          createBundle={this.createBundle}
           unbundleTask={this.unbundleTask}
+          bundleTask={this.bundleTask}
           loading={this.props.loading}
         />
         {this.props.errorMessage && (
@@ -486,7 +493,7 @@ const BuildBundle = props => {
   const bundleButton = !props.taskReadOnly && props.selectedTaskCount(totalTaskCount) > 1 && !props.bundleEditsDisabled ? (
       <button
         className="mr-button mr-button--green-lighter mr-button--small"
-        onClick={props.bundleTasks}
+        onClick={props.createBundle}
       >
         <FormattedMessage {...messages.bundleTasksLabel} />
       </button>

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.jsx
@@ -119,7 +119,21 @@ class TaskMarkerContent extends Component {
                     >
                       <FormattedMessage {...messages.removeFromBundle} />
                     </button>
-                  ) : null}
+                  ) : (
+                    !alreadyBundled && (
+                      <button
+                        disabled={this.props.bundleEditsDisabled}
+                        onClick={() => this.props.bundleTask(this.props.marker.options)}
+                        className="mr-text-green mr-border-solid mr-border mr-border-green mr-px-2 mr-mb-1"
+                        style={{
+                          cursor: this.props.bundleEditsDisabled ? 'default' : 'pointer',
+                          opacity: this.props.bundleEditsDisabled ? 0.3 : 1,
+                        }}
+                      >
+                        <FormattedMessage {...messages.addToBundle} />
+                      </button>
+                    )
+                  )}
                 </div>
               ) : null}
             </label>

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.jsx
@@ -22,7 +22,7 @@ class TaskMarkerContent extends Component {
     const bundlePrimary = this.props.taskBundle?.tasks.find(task => task.isBundlePrimary === true)
     const statusMessage = messagesByStatus[this.props.marker.options.status ?? this.props.marker.options.taskStatus]
     const priorityMessage = messagesByPriority[this.props.marker.options.priority ?? this.props.marker.options.taskPriority ]
-    const alreadyBundled = this.props.marker.options.bundleId && this.props.taskBundle?.bundleId !== this.props.marker.options.bundleId
+    const alreadyBundled = this.props.marker.options.bundleId && this.props.initialBundle?.bundleId !== this.props.marker.options.bundleId
 
     const checkBoxEnabled =
       !this.props.bundling &&
@@ -88,11 +88,11 @@ class TaskMarkerContent extends Component {
                   checked={selected}
                   onChange={this.toggleSelection}
                 />
-              ) : !this.props.bundling && !this.props.marker.options.bundleId && this.props.marker.options.taskId === this.props.task.id ? (
+              ) : !this.props.bundling && !alreadyBundled && this.props.marker.options.taskId === this.props.task.id ? (
                 <span className="mr-mr-1">✓</span>
               ) : !this.props.bundling ? <span className="mr-mr-1"><FormattedMessage {...messages.unableToSelect} /></span> : null}
 
-              {!this.props.bundling && !this.props.marker.options.bundleId && (checkBoxEnabled || this.props.marker.options.taskId === this.props.task.id) && (
+              {!this.props.bundling && !alreadyBundled && (checkBoxEnabled || this.props.marker.options.taskId === this.props.task.id) && (
                 <span>
                   <FormattedMessage {...messages.selectedLabel} />
                   {this.props.marker.options.taskId === this.props.task.id && (

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -33,7 +33,6 @@ export default {
     locked: messages.taskLocked,
     lockRefreshFailure: messages.taskLockRefreshFailure,
     bundleFailure: messages.taskBundleFailure,
-    removeTaskFromBundleFailure: messages.removeTaskFromBundleFailure,
     bundleCooperative: messages.taskBundleCooperative,
     addCommentFailure: messages.addCommentFailure,
     bundleNotCooperative: messages.taskBundleNotCooperative,

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -95,10 +95,6 @@ export default defineMessages({
     id: "Errors.task.bundleFailure",
     defaultMessage: "Unable to bundle tasks together",
   },
-  removeTaskFromBundleFailure: {
-    id: "Errors.task.removeTaskFromBundleFailure",
-    defaultMessage: "Unable to remove task from bundle",
-  },
   taskBundleCooperative: {
     id: "Errors.task.bundleCooperative",
     defaultMessage: "The main task is Cooperative. All selected tasks must be Cooperative.",

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -80,7 +80,6 @@ export const PARAMS_MAP = {
   reviewedBy: 'r',
   metaReviewedBy: 'mr',
   completedBy: 'm',
-  bundleId: 'bid',
   challengeId: 'cid',
   challenge: 'cs',
   projectId: 'pid',
@@ -293,9 +292,6 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
 
   if (_isFinite(filters.difficulty)) {
     searchParameters[PARAMS_MAP.difficulty] = filters.difficulty
-  }
-  if (filters.bundleId) {
-    searchParameters[PARAMS_MAP.bundleId] = filters.bundleId
   }
 
   if (boundingBox) {

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -153,7 +153,9 @@ const apiRoutes = (factory) => {
       updateCompletionResponses: factory.put("/task/:id/responses"),
       lockBundle: factory.post("/task/bundle/lock"),
       unlockBundle: factory.post("/task/bundle/unlock"),
-      refreshBundleLocks: factory.post("/task/bundle/refresh"),
+      refreshMultipleTaskLocks: factory.post("/task/bundle/refresh"),
+      startMultipleTasks: factory.post("/task/bundle/lock"),
+      releaseMultipleTasks: factory.post("/task/bundle/unlock"),
     },
     keywords: {
       find: factory.get("/keywords"),

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -119,7 +119,6 @@ const apiRoutes = (factory) => {
       bundle: factory.post("/taskBundle"),
       updateBundle: factory.post("/taskBundle/:bundleId/update"),
       deleteBundle: factory.delete("/taskBundle/:bundleId"),
-      removeTaskFromBundle: factory.post("/taskBundle/:id/unbundle"),
       fetchBundle: factory.post("/taskBundle/:bundleId"),
       bundled: {
         updateStatus: factory.put("/taskBundle/:bundleId/:status"),

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -117,7 +117,7 @@ const apiRoutes = (factory) => {
       fetchReviewClusters: factory.get("/taskCluster/review"),
       inCluster: factory.get("/tasksInCluster/:clusterId"),
       bundle: factory.post("/taskBundle"),
-      resetBundle: factory.post("/taskBundle/:bundleId/reset"),
+      updateBundle: factory.post("/taskBundle/:bundleId/update"),
       deleteBundle: factory.delete("/taskBundle/:bundleId"),
       removeTaskFromBundle: factory.post("/taskBundle/:id/unbundle"),
       fetchBundle: factory.post("/taskBundle/:bundleId"),

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -151,6 +151,9 @@ const apiRoutes = (factory) => {
       testCooperativeWork: factory.post("/change/test"),
       applyTagFix: factory.post("/task/:id/fix/apply"),
       updateCompletionResponses: factory.put("/task/:id/responses"),
+      lockBundle: factory.post("/task/bundle/lock"),
+      unlockBundle: factory.post("/task/bundle/unlock"),
+      refreshBundleLocks: factory.post("/task/bundle/refresh"),
     },
     keywords: {
       find: factory.get("/keywords"),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -914,7 +914,7 @@ export const deleteTask = function(taskId) {
   }
 }
 
-export const bundleTasks = function(primaryId, taskIds, bundleTypeMismatch, bundleName="") {
+export const bundleTasks = function(primaryId, taskIds, bundleName="") {
   return function(dispatch) {
     return new Endpoint(api.tasks.bundle, {
       json: {name: bundleName, primaryId, taskIds},
@@ -927,12 +927,6 @@ export const bundleTasks = function(primaryId, taskIds, bundleTypeMismatch, bund
         )
       }
       else {
-        if (bundleTypeMismatch === "cooperative") {
-          dispatch(addError(AppErrors.task.bundleCooperative))
-        } else if (bundleTypeMismatch === "notCooperative") {
-          dispatch(addError(AppErrors.task.bundleNotCooperative))
-        }
-
         const errorMessage = await error.response.text()
         if (errorMessage.includes('already assigned to bundle')) {
           const numberPattern = /\d+/
@@ -961,18 +955,12 @@ export const bundleTasks = function(primaryId, taskIds, bundleTypeMismatch, bund
   }
 }
 
-  export const resetTaskBundle = function(initialBundle) {
-    const params = {};
+  export const updateTaskBundle = function(initialBundle, taskIds) {
+    const params = {taskIds: taskIds};
     const bundleId = initialBundle.bundleId;
-    let taskIdsArray = [];
-
-    if (initialBundle && initialBundle.taskIds) { 
-        taskIdsArray.push(...initialBundle.taskIds); 
-        params.taskIds = taskIdsArray;
-    }
 
     return function(dispatch) {
-      return new Endpoint(api.tasks.resetBundle, {
+      return new Endpoint(api.tasks.updateBundle, {
         variables: {bundleId},
         params
       }).execute()

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -203,8 +203,10 @@ export const fetchTask = function(taskId, suppressReceive=false, includeMapillar
       if (!suppressReceive) {
         dispatch(receiveTasks(normalizedResults.entities))
       }
-
       return normalizedResults
+    }).catch(error => {
+      dispatch(addError(AppErrors.task.fetchFailure))
+      console.error("Error fetching task:", error)
     })
   }
 }
@@ -283,6 +285,61 @@ export const refreshTaskLock = function(taskId) {
     }).execute()
   }
 }
+
+/**
+ * Refreshes an active task lock owned by the current user
+ */
+export const refreshTasksLocks = function(taskIds) {
+  return function() {
+    return new Endpoint(api.task.refreshLock, {
+      schema: taskSchema(),
+      variables: {taskIds: taskIds}
+    }).execute().then(response => {
+      const lockedTasks = response.locked || [];
+      const notLockedTasks = taskIds.filter(id => !lockedTasks.includes(id));
+      return { lockedTasks, notLockedTasks };
+    }).catch(error => {
+      console.error("Error refreshing task locks:", error);
+      throw error;
+    });
+  }
+}
+
+/**
+ * Refreshes an active task lock owned by the current user
+ */
+export const unlockTasks = function(taskIds) {
+  return function() {
+    return new Endpoint(api.task.refreshBunledTasksLocks, {
+      schema: taskSchema(),
+      variables: {taskIds: taskIds}
+    }).execute().catch(error => {
+      console.error("Error unlocking tasks:", error);
+      throw error;
+    });
+  }
+}
+
+/**
+ * Refreshes an active task lock owned by the current user
+ */
+export const lockTasks = function(taskIds) {
+  return function() {
+    return new Endpoint(api.task.refreshBunledTasksLocks, {
+      schema: taskSchema(),
+      variables: {taskIds: taskIds}
+    }).execute().then(response => {
+      const lockedTasks = response.locked || [];
+      const notLockedTasks = taskIds.filter(id => !lockedTasks.includes(id));
+      return { lockedTasks, notLockedTasks };
+    }).catch(error => {
+      console.error("Error locking tasks:", error);
+      throw error;
+    });
+  }
+}
+
+
 
 /**
  * Mark the given task as completed with the given status.

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -997,29 +997,6 @@ export const deleteTaskBundle = function(bundleId) {
   }
 }
 
-export const removeTaskFromBundle = function (initialBundleTaskIds, bundleId, taskIds) {
-  return function (dispatch) {
-    return new Endpoint(api.tasks.removeTaskFromBundle, {
-      variables: { id: bundleId },
-      params: { id: bundleId, taskIds: taskIds, preventTaskIdUnlocks: initialBundleTaskIds || [] },
-    })
-      .execute()
-      .then((results) => {
-        return results;
-      })
-      .catch((error) => {
-        if (isSecurityError(error)) {
-          dispatch(ensureUserLoggedIn()).then(() =>
-            dispatch(addError(AppErrors.user.unauthorized))
-          );
-        } else {
-          dispatch(addError(AppErrors.task.removeTaskFromBundleFailure));
-          console.log(error.response || error);
-        }
-      });
-  };
-};
-
 /**
  * Retrieve and process a single task retrieval from the given endpoint (next
  * task, previous task, random task, etc).

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -309,7 +309,7 @@ export const refreshMultipleTaskLocks = function(taskIds) {
  * Refreshes an active task lock owned by the current user
  */
 export const releaseMultipleTasks = function(taskIds) {
-  return function() {
+  return function(dispatch) {
     return new Endpoint(api.task.releaseMultipleTasks, {
       schema: [taskSchema()],
       params: {taskIds: taskIds}

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -983,9 +983,7 @@ export const deleteTaskBundle = function(bundleId) {
   return function(dispatch) {
     return new Endpoint(api.tasks.deleteBundle, {
       variables: {bundleId},
-    }).execute().then(() => {
-      return true
-    }).catch(error => {
+    }).execute().catch(error => {
       if (isSecurityError(error)) {
         dispatch(ensureUserLoggedIn()).then(() =>
           dispatch(addError(AppErrors.user.unauthorized))
@@ -995,7 +993,6 @@ export const deleteTaskBundle = function(bundleId) {
         dispatch(addError(AppErrors.task.bundleFailure))
         console.log(error.response || error)
       }
-      return false
     })
   }
 }


### PR DESCRIPTION
Issue:
Bundles are not being reset or deleted when a user remains inactive for an extended period, meeting the conditions required to bypass the bundle reset. This leads to various issues, such as finalized conditions in the completion step not being properly set.

Solution:
Rather than updating bundles in the database every time they are created or edited, bundles will only be modified when a user completes a task relying on the task locked status's to prevent other users from bundling the tasks a user has bundled.

