### PR TITLE
make tasks in task properties widget collapsible

### DIFF
--- a/src/components/EnhancedMap/PropertyList/PropertyList.jsx
+++ b/src/components/EnhancedMap/PropertyList/PropertyList.jsx
@@ -59,8 +59,8 @@ const PropertyList = props => {
 
     return (
       <tr key={key} className="property">
-        <td className={classNames("name", {"mr-border-none mr-links-green-lighter mr-pr-3": darkMode})}>{link}</td>
-        <td className={classNames("value", {"mr-border-none mr-pb-1": darkMode})}>{value}</td>
+        <td className={classNames("name", {"mr-border-none mr-break-words mr-links-green-lighter mr-pr-3": darkMode})}>{link}</td>
+        <td className={classNames("value", {"mr-border-none mr-break-words mr-pb-1": darkMode})}>{value}</td>
       </tr>
     )
   }))
@@ -68,7 +68,7 @@ const PropertyList = props => {
   return (
     <div className="feature-properties mr-ml-4" style={{ maxHeight: "300px", overflow: "auto" }}>
       {!props.hideHeader && header}
-      <table className={classNames("property-list", {"mr-bg-transparent mr-text-white": darkMode, "table": !darkMode})}>
+      <table className={classNames("property-list", {"mr-bg-transparent mr-text-white": darkMode, "table": !darkMode})} style={{ width: "100%", tableLayout: "fixed" }}>
         <tbody>{rows}</tbody>
       </table>
     </div>

--- a/src/components/Widgets/TaskPropertiesWidget/Messages.js
+++ b/src/components/Widgets/TaskPropertiesWidget/Messages.js
@@ -18,4 +18,14 @@ export default defineMessages({
     id: "Widgets.TaskPropertiesWidget.task.label",
     defaultMessage: "Task {taskId}",
   },
+
+  expandAll: {
+    id: "Widgets.TaskPropertiesWidget.expandAll",
+    defaultMessage: "Expand All",
+  },
+
+  collapseAll: {
+    id: "Widgets.TaskPropertiesWidget.collapseAll",
+    defaultMessage: "Collapse All",
+  },
 })

--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
@@ -8,6 +8,7 @@ import PropertyList from '../../EnhancedMap/PropertyList/PropertyList'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import messages from './Messages'
+import './TaskPropertiesWidget.scss'
 
 const descriptor = {
   widgetKey: 'TaskPropertiesWidget',
@@ -21,49 +22,23 @@ const descriptor = {
 
 const TaskPropertiesWidget = (props) => {
   const taskList = _get(props.taskBundle, 'tasks') || [props.task];
-  const initialCollapsedState = {};
+  const [collapsed, setCollapsed] = useState();
 
-  taskList.forEach((task) => {
-    const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements);
-    featurePropertiesList.forEach((_, index) => {
-      initialCollapsedState[`${task.id}-${index}`] = true;
-    });
-  });
-
-  const [collapsed, setCollapsed] = useState(initialCollapsedState); 
-  const [allCollapsed, setAllCollapsed] = useState(true); 
-
-  const toggleCollapseAll = () => {
-    const newCollapsedState = {};
-    taskList.forEach((task) => {
-      const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements);
-      featurePropertiesList.forEach((_, index) => {
-        newCollapsedState[`${task.id}-${index}`] = !allCollapsed;
-      });
-    });
-    setCollapsed(newCollapsedState);
-    setAllCollapsed(!allCollapsed); 
-  }
-
-  const toggleCollapse = (index) => {
-    setCollapsed(prevState => ({
-      ...prevState,
-      [index]: !prevState[index], 
-    }));
+  const toggleCollapsed = () => {
+    setCollapsed(!collapsed);
   }
 
   const propertyLists = _map(taskList, (task) => {
-    const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements)
+    const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements);
 
     return (
       <div key={task.id} className="mr-mb-4 border-b mr-border-gray-300 pb-2">
         {
           featurePropertiesList.map((feature, index) => {
-            const featureIndex = `${task.id}-${index}`; 
-            const isCollapsed = collapsed[featureIndex]; 
+            const featureIndex = `${task.id}-${index}`;
             return (
-              <div key={featureIndex} className="mr-pb-2 mr-border-b mr-bg-gray-100">
-                <div className="mr-text-yellow mr-cursor-pointer mr-p-1 mr-rounded mr-flex mr-justify-between mr-items-center" onClick={() => toggleCollapse(featureIndex)}>
+              <details key={featureIndex} open={!collapsed} className="mr-pb-2 mr-border-b mr-bg-gray-100">
+                <summary className="mr-text-yellow mr-cursor-pointer mr-p-1 mr-rounded mr-flex mr-justify-between mr-items-center">
                   <div className="mr-flex mr-items-center">
                     <div className="mr-text-yellow mr-font-bold mr-text-lg">
                       <FormattedMessage {...messages.taskLabel} values={{taskId: task.id}}/>
@@ -72,15 +47,9 @@ const TaskPropertiesWidget = (props) => {
                       {feature.properties?.id || feature.geometry?.type}
                     </span>
                   </div>
-                  <div className="mr-cursor-pointer">
-                    {isCollapsed ? '▼' : '▲'}
-                  </div>
-                </div>
-                {!isCollapsed && ( 
-                  <PropertyList featureProperties={feature.properties} hideHeader
-                    lightMode={false} {...props} />
-                )}
-              </div>
+                </summary>
+                <PropertyList featureProperties={feature.properties} hideHeader lightMode={false} {...props} />
+              </details>
             )
           })
         }
@@ -94,8 +63,8 @@ const TaskPropertiesWidget = (props) => {
       className="task-properties-widget"
       widgetTitle={<FormattedMessage {...messages.title} />}
       rightHeaderControls={
-        <div onClick={toggleCollapseAll} className="mr-cursor-pointer mr-button mr-button--small mr-text-sm mr-ml-4">
-          {allCollapsed ? <FormattedMessage {...messages.expandAll} /> : <FormattedMessage {...messages.collapseAll} />}
+        <div onClick={toggleCollapsed} className="mr-cursor-pointer mr-button mr-button--small mr-text-sm mr-ml-4">
+          {collapsed ? <FormattedMessage {...messages.expandAll} /> : <FormattedMessage {...messages.collapseAll} />}
         </div>
       }
     >

--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import _get from 'lodash/get'
 import _map from 'lodash/map'
@@ -19,45 +19,91 @@ const descriptor = {
   defaultHeight: 6,
 }
 
-export default class TaskPropertiesWidget extends Component {
-  render() {
-    const taskList = _get(this.props.taskBundle, 'tasks') || [this.props.task]
-    const propertyLists = _map(taskList, (task) => {
-      const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(this.props.osmElements)
+const TaskPropertiesWidget = (props) => {
+  const taskList = _get(props.taskBundle, 'tasks') || [props.task];
+  const initialCollapsedState = {};
 
-      return (
-        <div key={task.id} className="mr-mb-6">
-          <div className="mr-text-yellow">
-            <FormattedMessage {...messages.taskLabel} values={{taskId: task.id}}/>
-          </div>
-          {
-            featurePropertiesList.map((feature, index) => {
-              return (
-                <div key={index}>
-                  <div className="mr-text-yellow mr-ml-2">
-                    {feature.properties?.id || feature.geometry?.type}
-                  </div>
-                  <PropertyList featureProperties={feature.properties} hideHeader
-                    lightMode={false} {...this.props} />
-                </div>
-              )
-            })
-          }
-        </div>
-      )
-    })
+  taskList.forEach((task) => {
+    const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements);
+    featurePropertiesList.forEach((_, index) => {
+      initialCollapsedState[`${task.id}-${index}`] = true;
+    });
+  });
 
+  const [collapsed, setCollapsed] = useState(initialCollapsedState); 
+  const [allCollapsed, setAllCollapsed] = useState(true); 
+
+  const toggleCollapseAll = () => {
+    const newCollapsedState = {};
+    taskList.forEach((task) => {
+      const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements);
+      featurePropertiesList.forEach((_, index) => {
+        newCollapsedState[`${task.id}-${index}`] = !allCollapsed;
+      });
+    });
+    setCollapsed(newCollapsedState);
+    setAllCollapsed(!allCollapsed); 
+  }
+
+  const toggleCollapse = (index) => {
+    setCollapsed(prevState => ({
+      ...prevState,
+      [index]: !prevState[index], 
+    }));
+  }
+
+  const propertyLists = _map(taskList, (task) => {
+    const featurePropertiesList = AsMappableTask(task).osmFeatureProperties(props.osmElements)
 
     return (
-      <QuickWidget
-        {...this.props}
-        className="task-properties-widget"
-        widgetTitle={<FormattedMessage {...messages.title} />}
-      >
-        {propertyLists}
-      </QuickWidget>
+      <div key={task.id} className="mr-mb-4 border-b mr-border-gray-300 pb-2">
+        {
+          featurePropertiesList.map((feature, index) => {
+            const featureIndex = `${task.id}-${index}`; 
+            const isCollapsed = collapsed[featureIndex]; 
+            return (
+              <div key={featureIndex} className="mr-pb-2 mr-border-b mr-bg-gray-100">
+                <div className="mr-text-yellow mr-cursor-pointer mr-p-1 mr-rounded mr-flex mr-justify-between mr-items-center" onClick={() => toggleCollapse(featureIndex)}>
+                  <div className="mr-flex mr-items-center">
+                    <div className="mr-text-yellow mr-font-bold mr-text-lg">
+                      <FormattedMessage {...messages.taskLabel} values={{taskId: task.id}}/>
+                    </div>
+                    <span className="mr-text-grey-lighter mr-mx-2 mr-mt-1">
+                      {feature.properties?.id || feature.geometry?.type}
+                    </span>
+                  </div>
+                  <div className="mr-cursor-pointer">
+                    {isCollapsed ? '▼' : '▲'}
+                  </div>
+                </div>
+                {!isCollapsed && ( 
+                  <PropertyList featureProperties={feature.properties} hideHeader
+                    lightMode={false} {...props} />
+                )}
+              </div>
+            )
+          })
+        }
+      </div>
     )
-  }
+  })
+
+  return (
+    <QuickWidget
+      {...props}
+      className="task-properties-widget"
+      widgetTitle={<FormattedMessage {...messages.title} />}
+      rightHeaderControls={
+        <div onClick={toggleCollapseAll} className="mr-cursor-pointer mr-button mr-button--small mr-text-sm mr-ml-4">
+          {allCollapsed ? <FormattedMessage {...messages.expandAll} /> : <FormattedMessage {...messages.collapseAll} />}
+        </div>
+      }
+    >
+      {propertyLists}
+    </QuickWidget>
+  )
 }
 
 registerWidgetType(TaskPropertiesWidget, descriptor)
+
+export default TaskPropertiesWidget;

--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.scss
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.scss
@@ -1,0 +1,29 @@
+details {
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  max-height: 100px;
+}
+
+details[open] {
+  max-height: 500px;
+}
+
+details > summary {
+  position: relative; 
+  padding-left: 1.5em; 
+  cursor: pointer; 
+  transition: transform 0.2s ease;
+}
+
+details > summary::before {
+  content: '▶'; 
+  position: absolute;
+  right: 10px;
+  color: #FFFD86; 
+  font-size: 1.2em; 
+  transition: transform 0.2s ease; 
+}
+
+details[open] > summary::before {
+  transform: rotate(90deg); 
+}


### PR DESCRIPTION
This PR enhances the usability of the task properties widget for bundles.
<img width="431" alt="Screenshot 2024-12-09 at 10 02 08 AM" src="https://github.com/user-attachments/assets/9d94d10c-9b5e-46b2-a31d-6de6f276524c">
<img width="431" alt="Screenshot 2024-12-09 at 10 02 20 AM" src="https://github.com/user-attachments/assets/699063ee-ec19-47bc-a82c-86990634d382">
<img width="425" alt="Screenshot 2024-12-09 at 10 02 57 AM" src="https://github.com/user-attachments/assets/c099da72-0563-47e2-b16b-f402e1aea9ff">
