### PR TITLE
Fix OSM Element Tags widget not updating when switching to next task

### DIFF
--- a/src/components/OSMElementTags/OSMElementTags.jsx
+++ b/src/components/OSMElementTags/OSMElementTags.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo } from 'react'
+import { Fragment, useState, useMemo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl }
        from 'react-intl'
@@ -39,6 +39,11 @@ const OSMElementTags = props => {
   }
 
   const [selectedFeatureId, setSelectedFeatureId] = useState(featureIds[0])
+  
+  useEffect(() => {
+    setSelectedFeatureId(featureIds[0])
+  }, [featureIds])
+
   const widgetLayoutProps = { featureIds, selectedFeatureId, setSelectedFeatureId }
 
   const { isLoading, isError, error: fetchErr, data: element } = useQuery({

--- a/src/components/OSMElementTags/OSMElementTags.jsx
+++ b/src/components/OSMElementTags/OSMElementTags.jsx
@@ -48,7 +48,8 @@ const OSMElementTags = props => {
 
   const { isLoading, isError, error: fetchErr, data: element } = useQuery({
     queryKey: ['OSMElement', selectedFeatureId],
-    queryFn: () => fetchOSMElement(selectedFeatureId)
+    queryFn: () => fetchOSMElement(selectedFeatureId),
+    refetchOnWindowFocus: false,
   })
 
   if (isLoading) {


### PR DESCRIPTION
Resolves issue in this recently added widget: https://github.com/maproulette/maproulette3/pull/2499

Issue: Because the widgets dont reset between tasks, the original state of the initial task was used in this widget despite changing tasks.
Solution: Make it so that the selectedFeatureIds is updated whenever the featureIds change using a useEffect hook.