### PR TITLE
Fix docker build (.git directory is required now)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 /build
 /dist


### PR DESCRIPTION
With #2508, building now depends on git. Docker was being instructed to exclude the `.git` directory from the build context which was causing the build to fail.

It might be a good idea to add a fallback so that it's still possible to build without git (e.g. if someone downloads a release tarball, or builds on a system where git isn't installed), but not a high priority.