### PR TITLE
remove intl errors from selected context

### DIFF
--- a/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.jsx
+++ b/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.jsx
@@ -40,6 +40,7 @@ const generateLayer = (props, map, _leaflet) => {
         key={props.intl.locale}
         locale={props.intl.locale}
         messages={props.intl.messages}
+        onError={() => {}} // Suppress errors in the console
         textComponent="span"
       >
         <PropertyList

--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.jsx
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.jsx
@@ -40,6 +40,7 @@ const TaskFeatureLayer = (props) => {
         key={props.intl.locale}
         locale={props.intl.locale}
         messages={props.intl.messages}
+        onError={() => {}} // Suppress errors in the console
         textComponent="span"
       >
         <PropertyList featureProperties={featureProperties} onBack={onBack} />
@@ -61,7 +62,11 @@ const TaskFeatureLayer = (props) => {
         mrLayerLabel={layerLabel}
         data={featureCollection(features)}
         pointToLayer={(point, latLng) => {
-          return L.marker(latLng, { pane, mrLayerLabel: layerLabel, mrLayerId: mrLayerId });
+          return L.marker(latLng, {
+            pane,
+            mrLayerLabel: layerLabel,
+            mrLayerId: mrLayerId,
+          });
         }}
         onEachFeature={(feature, layer) => {
           const styleableFeature = _isFunction(feature.styleLeafletLayer)

--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -162,6 +162,7 @@ export const TaskMapContent = (props) => {
               key={`${description}-${index}`}
               locale={props.intl.locale}
               messages={props.intl.messages}
+              onError={() => {}} // Suppress errors in the console
               textComponent="span"
             >
               <PropertyList

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -57,6 +57,7 @@ const ConnectedIntl = WithUserLocale((props) => (
     key={props.locale}
     locale={props.locale}
     messages={props.messages}
+    onError={() => {}} // Suppress errors in the console
     textComponent="span"
   >
     {props.children}

--- a/src/setupTests.jsx
+++ b/src/setupTests.jsx
@@ -38,7 +38,7 @@ global.withProvider = (ui, { store = reduxStore, ...renderOptions } = {}) => {
     return (
       <Fragment>
         <Provider store={store}>
-          <IntlProvider locale="en">
+          <IntlProvider locale="en" onError={() => {}}>
             <Router history={routerHistory}>{children}</Router>
           </IntlProvider>
         </Provider>


### PR DESCRIPTION
This pr suppresses intl errors, this is to reduce clutter when investigating more impactful errors. There errors will now only show up in the un-selected context:
<img width="449" alt="Screenshot 2025-01-14 at 2 52 06 PM" src="https://github.com/user-attachments/assets/791aaf13-17d5-41f5-b7f3-fe19001ed966" />
