### PR TITLE
fix external id editing conditions

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -659,7 +659,7 @@ will not be able to make sense of it.
   disableOsmIdProperty: {
     id: "Admin.EditChallenge.form.disableOsmIdProperty",
     defaultMessage:
-      "This ID cannot be edited after challenge creation, this is to prevent task duplication. [Learn more](https://learn.maproulette.org/documentation/setting-external-task-identifiers/).",
+      "This ID cannot be edited after a challenge has successfuly created tasks, this is to prevent task duplication. [Learn more](https://learn.maproulette.org/documentation/setting-external-task-identifiers/).",
   },
 
   customTaskStyleLabel: {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -659,7 +659,7 @@ will not be able to make sense of it.
   disableOsmIdProperty: {
     id: "Admin.EditChallenge.form.disableOsmIdProperty",
     defaultMessage:
-      "This ID cannot be edited after a challenge has successfuly created tasks, this is to prevent task duplication. [Learn more](https://learn.maproulette.org/documentation/setting-external-task-identifiers/).",
+      "This ID cannot be edited after a challenge has successfully created tasks, this is to prevent task duplication. [Learn more](https://learn.maproulette.org/documentation/setting-external-task-identifiers/).",
   },
 
   customTaskStyleLabel: {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
@@ -54,7 +54,7 @@ export const jsSchema = (intl, user, challengeData) => {
  * > proper markup
  */
 export const uiSchema = (intl, user, challengeData, extraErrors, options = {}) => {
-  const sourceReadOnly = AsEditableChallenge(challengeData);
+  const sourceReadOnly = !AsEditableChallenge(challengeData).hasZeroTasks();
   const isCollapsed = options.longForm && (options.collapsedGroups || []).indexOf(STEP_ID) === -1;
   const toggleCollapsed =
     options.longForm && options.toggleCollapsed


### PR DESCRIPTION
This PR fixes an issue in the External ID field of the Create Challenge form, where users were unable to interact with the field. Previously, the validation only checked for the presence of challenge data, which was always available, preventing interaction. This has been refined to specifically check whether the challenge contains any tasks, ensuring the field behaves correctly.