### PR TITLE
fix import formatting in ActiveTaskControls.jsx

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import _cloneDeep from "lodash/cloneDeep";
-import _get from "lodash/get";
 import _isEmpty from "lodash/isEmpty";
 import _isFinite from "lodash/isFinite";
 import _isObject from "lodash/isObject";
@@ -191,7 +190,9 @@ export class ActiveTaskControls extends Component {
       if (taskStatus === TASK_STATUS_FIXED && disableTaskConfirm) {
         this.setState(
           {
-            osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(this.props.task)}`,
+            osmComment: `${
+              this.props.task.parent.checkinComment
+            }${constructChangesetUrl(this.props.task)}`,
             confirmingStatus: taskStatus,
             submitRevision,
           },
@@ -202,7 +203,9 @@ export class ActiveTaskControls extends Component {
       } else {
         this.setState({
           confirmingTask: this.props.task,
-          osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(this.props.task)}`,
+          osmComment: `${
+            this.props.task.parent.checkinComment
+          }${constructChangesetUrl(this.props.task)}`,
           confirmingStatus: taskStatus,
           submitRevision,
         });
@@ -376,7 +379,9 @@ export class ActiveTaskControls extends Component {
     if (!this.props.user?.isLoggedIn) {
       return (
         <div
-          className={classNames("active-task-controls", { "is-minimized": this.props.isMinimized })}
+          className={classNames("active-task-controls", {
+            "is-minimized": this.props.isMinimized,
+          })}
         >
           <div className="has-centered-children">
             <SignInButton className="active-task-controls--signin" {...this.props} />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -12,26 +12,21 @@ import PropTypes from "prop-types";
 import { Component, Fragment } from "react";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { Link } from "react-router-dom";
+import { replacePropertyTags } from "../../../../hooks/UsePropertyReplacement/UsePropertyReplacement";
 import AsCooperativeWork from "../../../../interactions/Task/AsCooperativeWork";
 import { Editor } from "../../../../services/Editor/Editor";
-import { OPEN_STREET_MAP } from "../../../../services/VisibleLayer/LayerSources";
 import { TaskReviewLoadMethod } from "../../../../services/Task/TaskReview/TaskReviewLoadMethod";
 import { TaskReviewStatus } from "../../../../services/Task/TaskReview/TaskReviewStatus";
 import { TaskStatus } from "../../../../services/Task/TaskStatus/TaskStatus";
 import { TASK_STATUS_FIXED } from "../../../../services/Task/TaskStatus/TaskStatus";
 import {
-	allowedStatusProgressions,
-	isCompletionStatus,
-	isFinalStatus,
-	messagesByStatus,
+  allowedStatusProgressions,
+  isCompletionStatus,
+  isFinalStatus,
+  messagesByStatus,
 } from "../../../../services/Task/TaskStatus/TaskStatus";
-import CooperativeWorkControls from "./CooperativeWorkControls/CooperativeWorkControls";
-import messages from "./Messages";
-import SignInButton from "../../../SignInButton/SignInButton";
-import TaskCompletionStep from "./TaskCompletionStep/TaskCompletionStep";
-import TaskConfirmationModal from "../../../TaskConfirmationModal/TaskConfirmationModal";
-import TaskNextControl from "./TaskNextControl/TaskNextControl";
-import TaskTags from "../../../TaskTags/TaskTags";
+import { OPEN_STREET_MAP } from "../../../../services/VisibleLayer/LayerSources";
+import { constructChangesetUrl } from "../../../../utils/constructChangesetUrl";
 import WithChallengePreferences from "../../../HOCs/WithChallengePreferences/WithChallengePreferences";
 import WithKeyboardShortcuts from "../../../HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts";
 import WithSearch from "../../../HOCs/WithSearch/WithSearch";
@@ -39,8 +34,13 @@ import WithTaskFeatureProperties from "../../../HOCs/WithTaskFeatureProperties/W
 import WithTaskReview from "../../../HOCs/WithTaskReview/WithTaskReview";
 import WithTaskTags from "../../../HOCs/WithTaskTags/WithTaskTags";
 import WithVisibleLayer from "../../../HOCs/WithVisibleLayer/WithVisibleLayer";
-import { constructChangesetUrl } from "../../../../utils/constructChangesetUrl";
-import { replacePropertyTags } from "../../../../hooks/UsePropertyReplacement/UsePropertyReplacement";
+import SignInButton from "../../../SignInButton/SignInButton";
+import TaskConfirmationModal from "../../../TaskConfirmationModal/TaskConfirmationModal";
+import TaskTags from "../../../TaskTags/TaskTags";
+import CooperativeWorkControls from "./CooperativeWorkControls/CooperativeWorkControls";
+import messages from "./Messages";
+import TaskCompletionStep from "./TaskCompletionStep/TaskCompletionStep";
+import TaskNextControl from "./TaskNextControl/TaskNextControl";
 import "./ActiveTaskControls.scss";
 
 const hiddenShortcutGroup = "taskCompletion";

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -4,7 +4,6 @@ import _clone from "lodash/clone";
 import _cloneDeep from "lodash/cloneDeep";
 import _compact from "lodash/compact";
 import _each from "lodash/each";
-import _get from "lodash/get";
 import _flatten from "lodash/flatten";
 import _fromPairs from "lodash/fromPairs";
 import _groupBy from "lodash/groupBy";


### PR DESCRIPTION
Ran `yarn biome check --formatter-enabled=false --linter-enabled=false --organize-imports-enabled=true --write src` to fix build errors in main branch.