### PR TITLE
fix global challenge filtering bug on find challenge page

### DIFF
--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -414,9 +414,7 @@ export const extendedFind = function (criteria, limit = RESULTS_PER_PAGE, admin 
       queryParams.ca = filters.archived;
     }
 
-    if (filters.global) {
-      queryParams.cg = filters.global;
-    }
+    queryParams.cg = Boolean(filters.global);
 
     // Keywords/tags can come from both the the query and the filter, so we need to
     // combine them into a single keywords array.

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -166,9 +166,7 @@ export const generateSearchParametersString = (
   if (filters.archived) {
     searchParameters[PARAMS_MAP.archived] = filters.archived;
   }
-  if (filters.global) {
-    searchParameters[PARAMS_MAP.global] = filters.global;
-  }
+
   if (filters.reviewRequestedBy) {
     searchParameters[PARAMS_MAP.reviewRequestedBy] = filters.reviewRequestedBy;
     if (invertFields.reviewRequestedBy) {

--- a/src/services/Task/TaskClusters.js
+++ b/src/services/Task/TaskClusters.js
@@ -81,6 +81,7 @@ export const fetchTaskClusters = function (
       // pe: limit to enabled projects
       searchParameters.ce = onlyEnabled ? "true" : "false";
       searchParameters.pe = onlyEnabled ? "true" : "false";
+      searchParameters.cg = Boolean(filters.global);
 
       // if we are restricting to onlyEnabled challenges then let's
       // not show 'local' challenges either.


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2532
In tandem with https://github.com/maproulette/maproulette-backend/pull/1168, this pr makes it so that even if there is not global parameter, that the global filter will be set to false. This is important because the default for the filter in the backend is set to true.

I also moved the global filter to the workflows that don't have a defined challengeId to prevent the default of false from affecting work within a global challenge.