### PR TITLE
disable completion buttons

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,20 +1,26 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
+import React from "react";
 
-class Button extends Component {
-  render() {
-    return (
-      <button {...this.props} className={classNames("mr-button", this.props.className)}>
-        {this.props.children}
-      </button>
-    );
-  }
+/**
+ * Basic button component that includes proper styling for disabled state
+ */
+export default function Button({ className, disabled = false, children, ...otherProps }) {
+  return (
+    <button
+      className={classNames("mr-button", className, {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      disabled={disabled}
+      {...otherProps}
+    >
+      {children}
+    </button>
+  );
 }
 
 Button.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
 };
-
-export default Button;

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
@@ -78,7 +78,7 @@ test("mapDispatchToProps maps some functions", () => {
   mapDispatchToProps(dispatch, {});
 });
 
-test("mapDispatchToProps completeTask calls completeTask", () => {
+test("mapDispatchToProps completeTask calls completeTask", async () => {
   const dispatch = vi.fn(() => Promise.resolve());
   const history = {
     push: vi.fn(),
@@ -86,7 +86,7 @@ test("mapDispatchToProps completeTask calls completeTask", () => {
 
   const mappedProps = mapDispatchToProps(dispatch, { history });
 
-  mappedProps.completeTask(task, challenge.id, completionStatus);
+  await mappedProps.completeTask(task, challenge.id, completionStatus);
   expect(dispatch).toBeCalled();
   expect(completeTask).toBeCalled();
 });
@@ -124,7 +124,10 @@ test("completeTask calls loadRandomTaskFromChallenge without proximate task by d
     push: vi.fn(),
   };
 
-  const mappedProps = mapDispatchToProps(dispatch, { history, challengeId: challenge.id });
+  const mappedProps = mapDispatchToProps(dispatch, {
+    history,
+    challengeId: challenge.id,
+  });
 
   await mappedProps.completeTask(
     task,
@@ -143,7 +146,10 @@ test("completeTask calls loadRandomTaskFromChallenge with task if proximate load
     push: vi.fn(),
   };
 
-  const mappedProps = mapDispatchToProps(dispatch, { history, challengeId: challenge.id });
+  const mappedProps = mapDispatchToProps(dispatch, {
+    history,
+    challengeId: challenge.id,
+  });
 
   await mappedProps.completeTask(
     task,
@@ -179,7 +185,10 @@ test("completeTask routes the user to the new task if there is one", async () =>
     push: vi.fn(),
   };
 
-  const mappedProps = mapDispatchToProps(dispatch, { history, challengeId: challenge.id });
+  const mappedProps = mapDispatchToProps(dispatch, {
+    history,
+    challengeId: challenge.id,
+  });
 
   await mappedProps.completeTask(
     task,

--- a/src/components/ReviewTaskPane/ReviewTaskPane.jsx
+++ b/src/components/ReviewTaskPane/ReviewTaskPane.jsx
@@ -167,7 +167,7 @@ export class ReviewTaskPane extends Component {
           />
         </MediaQuery>
         <MediaQuery query="(max-width: 1023px)">
-          <MapPane completingTask={this.state.completingTask}>
+          <MapPane>
             <TaskMap
               isMobile
               task={this.props.task}

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.jsx
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.jsx
@@ -29,6 +29,7 @@ import {
   messagesByStatus,
 } from "../../services/Task/TaskStatus/TaskStatus";
 import { needsReviewType } from "../../services/User/User";
+import BusySpinner from "../BusySpinner/BusySpinner";
 import ErrorTagDropdown from "../ErrorTagDropdown/ErrorTagDropdown";
 import External from "../External/External";
 import KeywordAutosuggestInput from "../KeywordAutosuggestInput/KeywordAutosuggestInput";
@@ -139,7 +140,10 @@ export class TaskConfirmationModal extends Component {
     const { criteria } = this.state;
     const currentState = this.props.history?.location?.state ?? {};
     const newState = _merge({}, currentState, criteria);
-    this.props.history.replace({ ...this.props.history.location, state: newState });
+    this.props.history.replace({
+      ...this.props.history.location,
+      state: newState,
+    });
   };
 
   currentFilters = () => {
@@ -191,6 +195,7 @@ export class TaskConfirmationModal extends Component {
       : !!this.props.task.parent?.limitReviewTags;
 
     const TasksNearby = reviewConfirmation ? TaskReviewNearbyList : TaskNearbyList;
+    const disabled = this.props.disabled || this.props.isCompleting;
 
     return (
       <External>
@@ -408,6 +413,7 @@ export class TaskConfirmationModal extends Component {
                     <button
                       className="mr-button mr-button--white mr-mr-12 mr-px-8"
                       onClick={this.props.onCancel}
+                      disabled={disabled}
                     >
                       <FormattedMessage {...messages.cancelLabel} />
                     </button>
@@ -415,8 +421,13 @@ export class TaskConfirmationModal extends Component {
                     <button
                       className="mr-button mr-px-8"
                       onClick={() => this.props.onConfirm(this.currentFilters())}
+                      disabled={disabled}
                     >
-                      <FormattedMessage {...messages.submitLabel} />
+                      {this.props.isCompleting ? (
+                        <BusySpinner inline />
+                      ) : (
+                        <FormattedMessage {...messages.submitLabel} />
+                      )}
                     </button>
                   </div>
 
@@ -434,6 +445,7 @@ export class TaskConfirmationModal extends Component {
                           checked={this.props.loadBy === TaskLoadMethod.random}
                           onClick={() => this.props.chooseLoadBy(TaskLoadMethod.random)}
                           onChange={_noop}
+                          disabled={disabled}
                         />
                         <label htmlFor="load-method-random-input" className="mr-ml-1 mr-mr-4">
                           <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.random]} />
@@ -447,6 +459,7 @@ export class TaskConfirmationModal extends Component {
                           checked={this.props.loadBy === TaskLoadMethod.proximity}
                           onClick={() => this.props.chooseLoadBy(TaskLoadMethod.proximity)}
                           onChange={_noop}
+                          disabled={disabled}
                         />
                         <label htmlFor="load-method-proximity-input" className="mr-ml-1">
                           <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />
@@ -455,7 +468,10 @@ export class TaskConfirmationModal extends Component {
                       <div className="mr-text-green-lighter mr-text-center mr-mt-4 hover:mr-text-white mr-cursor-pointer mr-text-xs">
                         <div
                           onClick={() =>
-                            this.setState({ showInstructions: true, instructionsContinue: false })
+                            this.setState({
+                              showInstructions: true,
+                              instructionsContinue: false,
+                            })
                           }
                         >
                           <FormattedMessage {...messages.viewInstructions} />
@@ -479,6 +495,7 @@ export class TaskConfirmationModal extends Component {
                               checked={this.props.loadBy === TaskReviewLoadMethod.next}
                               onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.next)}
                               onChange={_noop}
+                              disabled={disabled}
                             />
                             <label>
                               <FormattedMessage
@@ -494,6 +511,7 @@ export class TaskConfirmationModal extends Component {
                               checked={this.props.loadBy === TaskReviewLoadMethod.nearby}
                               onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.nearby)}
                               onChange={_noop}
+                              disabled={disabled}
                             />
                             <label>
                               <FormattedMessage
@@ -510,6 +528,7 @@ export class TaskConfirmationModal extends Component {
                                 checked={this.props.loadBy === TaskReviewLoadMethod.inbox}
                                 onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.inbox)}
                                 onChange={_noop}
+                                disabled={disabled}
                               />
                               <label>
                                 <FormattedMessage
@@ -526,6 +545,7 @@ export class TaskConfirmationModal extends Component {
                               checked={this.props.loadBy === TaskReviewLoadMethod.all}
                               onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.all)}
                               onChange={_noop}
+                              disabled={disabled}
                             />
                             <label>
                               <FormattedMessage
@@ -557,6 +577,7 @@ export class TaskConfirmationModal extends Component {
                           checked={this.props.loadBy === TaskReviewLoadMethod.inbox}
                           onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.inbox)}
                           onChange={_noop}
+                          disabled={disabled}
                         />
                         <label htmlFor="review-load-method-input" className="mr-mr-4">
                           <FormattedMessage
@@ -571,6 +592,7 @@ export class TaskConfirmationModal extends Component {
                           checked={this.props.loadBy === TaskReviewLoadMethod.all}
                           onClick={() => this.props.chooseLoadBy(TaskReviewLoadMethod.all)}
                           onChange={_noop}
+                          disabled={disabled}
                         />
                         <label>
                           <FormattedMessage
@@ -615,7 +637,10 @@ export class TaskConfirmationModal extends Component {
               <InstructionsOverlay
                 {...this.props}
                 close={() =>
-                  this.setState({ showInstructions: false, instructionsContinue: false })
+                  this.setState({
+                    showInstructions: false,
+                    instructionsContinue: false,
+                  })
                 }
                 closeMessage={
                   this.state.instructionsContinue

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -43,13 +43,7 @@ import TaskNextControl from "./TaskNextControl/TaskNextControl";
 import "./ActiveTaskControls.scss";
 
 const hiddenShortcutGroup = "taskCompletion";
-const hiddenShortcuts = [
-  "skip",
-  "falsePositive",
-  "fixed",
-  "tooHard",
-  "alreadyFixed",
-];
+const hiddenShortcuts = ["skip", "falsePositive", "fixed", "tooHard", "alreadyFixed"];
 
 /**
  * ActiveTaskControls renders the appropriate controls for the given
@@ -101,33 +95,24 @@ export class ActiveTaskControls extends Component {
     const { task, taskFeatureProperties } = this.props;
 
     const comment = task.parent.checkinComment;
-    const replacedComment = replacePropertyTags(
-      comment,
-      taskFeatureProperties,
-      false
-    );
+    const replacedComment = replacePropertyTags(comment, taskFeatureProperties, false);
 
     this.props.editTask(
       value,
       this.props.task,
       this.props.mapBounds,
       {
-        imagery:
-          this.props.source.id !== OPEN_STREET_MAP
-            ? this.props.source
-            : undefined,
+        imagery: this.props.source.id !== OPEN_STREET_MAP ? this.props.source : undefined,
         photoOverlay: this.props.showMapillaryLayer ? "mapillary" : null,
       },
       this.props.taskBundle,
-      replacedComment
+      replacedComment,
     );
   };
 
   chooseLoadBy = (loadMethod) => {
     const isVirtual = _isFinite(this.props.virtualChallengeId);
-    const challengeId = isVirtual
-      ? this.props.virtualChallengeId
-      : this.props.challengeId;
+    const challengeId = isVirtual ? this.props.virtualChallengeId : this.props.challengeId;
     this.props.updateUserAppSetting(this.props.user.id, {
       loadMethod: loadMethod,
     });
@@ -155,8 +140,7 @@ export class ActiveTaskControls extends Component {
       }
       this.props.setCompletingTask(this.props.task.id);
 
-      const revisionSubmission =
-        this.props.task.reviewStatus === TaskReviewStatus.rejected;
+      const revisionSubmission = this.props.task.reviewStatus === TaskReviewStatus.rejected;
 
       if (!_isUndefined(this.state.submitRevision)) {
         await this.props.updateTaskReviewStatus(
@@ -169,7 +153,7 @@ export class ActiveTaskControls extends Component {
           this.props.taskBundle,
           this.state.requestedNextTask,
           taskStatus,
-          null
+          null,
         );
       } else {
         await this.props.completeTask(
@@ -184,7 +168,7 @@ export class ActiveTaskControls extends Component {
           this.state.requestedNextTask,
           this.state.osmComment,
           this.props.tagEdits,
-          this.props.taskBundle
+          this.props.taskBundle,
         );
         if (revisionSubmission) {
           if (this.state.revisionLoadBy === TaskReviewLoadMethod.inbox) {
@@ -206,13 +190,9 @@ export class ActiveTaskControls extends Component {
     const intl = this.props.intl;
     const message = intl.formatMessage(messages.rapidDiscardUnsavedChanges);
 
-    if (
-      !this.props.rapidEditorState.hasUnsavedChanges ||
-      window.confirm(message)
-    ) {
+    if (!this.props.rapidEditorState.hasUnsavedChanges || window.confirm(message)) {
       const requireConfirmation =
-        this.props.challenge.requireConfirmation ||
-        this.props.challenge.parent.requireConfirmation;
+        this.props.challenge.requireConfirmation || this.props.challenge.parent.requireConfirmation;
       const disableTaskConfirm =
         !requireConfirmation && this.props.user.settings.disableTaskConfirm;
 
@@ -227,7 +207,7 @@ export class ActiveTaskControls extends Component {
           },
           () => {
             this.confirmCompletion();
-          }
+          },
         );
       } else {
         this.setState({
@@ -265,7 +245,7 @@ export class ActiveTaskControls extends Component {
       taskId,
       this.props.taskLoadBy,
       this.state.comment,
-      this.state.requestedNextTask
+      this.state.requestedNextTask,
     );
   };
 
@@ -331,7 +311,7 @@ export class ActiveTaskControls extends Component {
       const tagsArray = _map(this.props.task.tags, (tag) => tag.name);
       const filteredTagsArray = tagsArray.filter((tag) => tag !== "");
       const uniqueTagsArray = filteredTagsArray.filter(
-        (value, index, self) => self.indexOf(value) === index
+        (value, index, self) => self.indexOf(value) === index,
       );
       const tags = uniqueTagsArray.join(",");
 
@@ -365,15 +345,12 @@ export class ActiveTaskControls extends Component {
       const editMode = this.props.getUserAppSetting
         ? this.props.getUserAppSetting(this.props.user, "isEditMode")
         : false;
-      if (
-        !_isEmpty(this.props.activeKeyboardShortcuts?.[hiddenShortcutGroup]) &&
-        editMode
-      ) {
+      if (!_isEmpty(this.props.activeKeyboardShortcuts?.[hiddenShortcutGroup]) && editMode) {
         hiddenShortcuts.forEach((shortcut) => {
           this.props.deactivateKeyboardShortcut(
             hiddenShortcutGroup,
             shortcut,
-            this.handleKeyboardShortcuts
+            this.handleKeyboardShortcuts,
           );
         });
       } else if (
@@ -386,7 +363,7 @@ export class ActiveTaskControls extends Component {
           this.props.activateKeyboardShortcut(
             hiddenShortcutGroup,
             _pick(this.props.keyboardShortcutGroups.taskCompletion, shortcut),
-            this.handleKeyboardShortcuts
+            this.handleKeyboardShortcuts,
           );
         });
       }
@@ -399,7 +376,7 @@ export class ActiveTaskControls extends Component {
         this.props.deactivateKeyboardShortcut(
           hiddenShortcutGroup,
           shortcut,
-          this.handleKeyboardShortcuts
+          this.handleKeyboardShortcuts,
         );
       });
     }
@@ -415,10 +392,7 @@ export class ActiveTaskControls extends Component {
           })}
         >
           <div className="has-centered-children">
-            <SignInButton
-              className="active-task-controls--signin"
-              {...this.props}
-            />
+            <SignInButton className="active-task-controls--signin" {...this.props} />
           </div>
         </div>
       );
@@ -440,18 +414,17 @@ export class ActiveTaskControls extends Component {
     const editMode = disableRapid
       ? false
       : this.props.getUserAppSetting
-      ? this.props.getUserAppSetting(this.props.user, "isEditMode")
-      : false;
+        ? this.props.getUserAppSetting(this.props.user, "isEditMode")
+        : false;
 
-    const needsRevised =
-      this.props.task.reviewStatus === TaskReviewStatus.rejected;
+    const needsRevised = this.props.task.reviewStatus === TaskReviewStatus.rejected;
 
     const fromInbox = this.props.history?.location?.state?.fromInbox;
 
     const allowedProgressions = allowedStatusProgressions(
       this.props.task.status,
       false,
-      needsRevised
+      needsRevised,
     );
     const isComplete = isCompletionStatus(this.props.task.status);
     const isFinal = isFinalStatus(this.props.task.status);
@@ -463,9 +436,7 @@ export class ActiveTaskControls extends Component {
             <div className="mr-flex mr-mb-2 mr-text-sm mr-text-white mr-whitespace-nowrap">
               <span>
                 <FormattedMessage {...messages.markedAs} />{" "}
-                <FormattedMessage
-                  {...messagesByStatus[this.props.task.status]}
-                />
+                <FormattedMessage {...messagesByStatus[this.props.task.status]} />
               </span>
               {this.props.task.changesetId > 0 && (
                 <a
@@ -549,9 +520,7 @@ export class ActiveTaskControls extends Component {
                 nextTask={this.next}
                 loadBy={this.props.taskLoadBy}
                 chooseLoadBy={(load) =>
-                  needsRevised
-                    ? this.chooseRevisionLoadBy(load)
-                    : this.chooseLoadBy(load)
+                  needsRevised ? this.chooseRevisionLoadBy(load) : this.chooseLoadBy(load)
                 }
                 chooseNextTask={this.chooseNextTask}
                 clearNextTask={this.clearNextTask}
@@ -573,15 +542,9 @@ export class ActiveTaskControls extends Component {
                 setTags={this.setTags}
                 needsReview={this.getNeedsReviewSetting()}
                 toggleNeedsReview={this.toggleNeedsReview}
-                loadBy={
-                  needsRevised
-                    ? this.state.revisionLoadBy
-                    : this.props.taskLoadBy
-                }
+                loadBy={needsRevised ? this.state.revisionLoadBy : this.props.taskLoadBy}
                 chooseLoadBy={(load) =>
-                  needsRevised
-                    ? this.chooseRevisionLoadBy(load)
-                    : this.chooseLoadBy(load)
+                  needsRevised ? this.chooseRevisionLoadBy(load) : this.chooseLoadBy(load)
                 }
                 chooseNextTask={this.chooseNextTask}
                 clearNextTask={this.clearNextTask}
@@ -619,12 +582,10 @@ export default WithSearch(
     WithVisibleLayer(
       WithTaskTags(
         WithTaskReview(
-          WithKeyboardShortcuts(
-            WithTaskFeatureProperties(injectIntl(ActiveTaskControls))
-          )
-        )
-      )
-    )
+          WithKeyboardShortcuts(WithTaskFeatureProperties(injectIntl(ActiveTaskControls))),
+        ),
+      ),
+    ),
   ),
-  "task"
+  "task",
 );

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/CooperativeWorkControls/CooperativeWorkControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/CooperativeWorkControls/CooperativeWorkControls.jsx
@@ -20,6 +20,7 @@ export class CooperativeWorkControls extends Component {
   };
 
   render() {
+    const disabled = this.props.disabled || this.props.isCompleting;
     if (!this.props.task) {
       return null;
     }
@@ -27,7 +28,7 @@ export class CooperativeWorkControls extends Component {
     return (
       <div className="mr-pb-2">
         {this.props.loadingOSMData && <BusySpinner />}
-        <UserEditorSelector {...this.props} className="mr-mb-4" />
+        <UserEditorSelector {...this.props} className="mr-mb-4" disabled={disabled} />
         <p className="mr-text-md mr-mb-2 mr-mt-2">
           <FormattedMessage {...messages.prompt} />
         </p>
@@ -36,6 +37,7 @@ export class CooperativeWorkControls extends Component {
             <TaskFixedControl
               {...this.props}
               fixedLabel={<FormattedMessage {...messages.confirmLabel} />}
+              disabled={disabled}
             />
           )}
 
@@ -43,18 +45,19 @@ export class CooperativeWorkControls extends Component {
             <TaskFalsePositiveControl
               {...this.props}
               falsePositiveLabel={<FormattedMessage {...messages.rejectLabel} />}
+              disabled={disabled}
             />
           )}
         </div>
         <div className="mr-mt-2 breadcrumb mr-w-full mr-flex mr-flex-wrap mr-m-auto">
           {this.props.allowedProgressions.has(TaskStatus.alreadyFixed) && (
-            <TaskAlreadyFixedControl {...this.props} />
+            <TaskAlreadyFixedControl {...this.props} disabled={disabled} />
           )}
           {this.props.allowedProgressions.has(TaskStatus.tooHard) && (
-            <TaskTooHardControl {...this.props} />
+            <TaskTooHardControl {...this.props} disabled={disabled} />
           )}
           {this.props.allowedProgressions.has(TaskStatus.skipped) && (
-            <TaskSkipControl {...this.props} />
+            <TaskSkipControl {...this.props} disabled={disabled} />
           )}
         </div>
       </div>

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl.jsx
@@ -1,5 +1,5 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskStatus } from "../../../../../services/Task/TaskStatus/TaskStatus";
 import Button from "../../../../Button/Button";
@@ -11,29 +11,38 @@ import messages from "./Messages";
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export default class TaskAlreadyFixedControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskStatus.alreadyFixed)}>
-          <FormattedMessage {...messages.alreadyFixedLabel} />
-        </a>
-      );
-    } else {
-      return (
-        <Button
-          className="mr-button--blue-fill mr-mb-2 mr-mr-2"
-          style={{ minWidth: "10rem" }}
-          onClick={() => this.props.complete(TaskStatus.alreadyFixed)}
-        >
-          <FormattedMessage {...messages.alreadyFixedLabel} />
-        </Button>
-      );
-    }
+const TaskAlreadyFixedControl = ({ complete, disabled, asLink }) => {
+  const handleClick = () => !disabled && complete(TaskStatus.alreadyFixed);
+
+  if (asLink) {
+    return (
+      <a onClick={handleClick} className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}>
+        <FormattedMessage {...messages.alreadyFixedLabel} />
+      </a>
+    );
   }
-}
+
+  return (
+    <Button
+      className={classNames("mr-button--blue-fill mr-mb-2 mr-mr-2", {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      style={{ minWidth: "10rem" }}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      <FormattedMessage {...messages.alreadyFixedLabel} />
+    </Button>
+  );
+};
 
 TaskAlreadyFixedControl.propTypes = {
   /** Invoked to mark the task as already-fixed */
   complete: PropTypes.func.isRequired,
+  /** Disable the control */
+  disabled: PropTypes.bool,
+  /** Whether the control should be rendered as a link */
+  asLink: PropTypes.bool,
 };
+
+export default TaskAlreadyFixedControl;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep/TaskCompletionStep.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep/TaskCompletionStep.jsx
@@ -27,6 +27,8 @@ export default class TaskCompletionStep extends Component {
   };
 
   render() {
+    const disabled = this.props.disabled || this.props.isCompleting;
+
     return (
       <div className="mr-items-center mr-justify-center">
         {this.props.needsRevised && (
@@ -47,34 +49,37 @@ export default class TaskCompletionStep extends Component {
             </div>
           </div>
         )}
-
         <UserEditorSelector {...this.props} className="mr-mb-2" />
         <div className="breadcrumb mr-w-full mr-flex mr-flex-wrap mr-m-auto mr-items-center">
           {this.props.needsRevised && (
             <div className="mr-mt-2">
-              <TaskRevisedControl {...this.props} />
+              <TaskRevisedControl {...this.props} disabled={disabled} />
             </div>
           )}
+
           <div className="mr-mt-2">
-            {this.props.allowedProgressions.has(TaskStatus.fixed) && (
-              <TaskFixedControl {...this.props} />
+            {(this.props.allowedProgressions.has(TaskStatus.fixed) || this.props.isCompleting) && (
+              <TaskFixedControl {...this.props} disabled={disabled} />
             )}
 
-            {this.props.allowedProgressions.has(TaskStatus.alreadyFixed) && (
-              <TaskAlreadyFixedControl {...this.props} />
+            {(this.props.allowedProgressions.has(TaskStatus.alreadyFixed) ||
+              this.props.isCompleting) && (
+              <TaskAlreadyFixedControl {...this.props} disabled={disabled} />
             )}
 
-            {this.props.allowedProgressions.has(TaskStatus.falsePositive) && (
-              <TaskFalsePositiveControl {...this.props} />
+            {(this.props.allowedProgressions.has(TaskStatus.falsePositive) ||
+              this.props.isCompleting) && (
+              <TaskFalsePositiveControl {...this.props} disabled={disabled} />
             )}
 
-            {this.props.allowedProgressions.has(TaskStatus.tooHard) && (
-              <TaskTooHardControl {...this.props} />
+            {(this.props.allowedProgressions.has(TaskStatus.tooHard) ||
+              this.props.isCompleting) && (
+              <TaskTooHardControl {...this.props} disabled={disabled} />
             )}
 
-            {this.props.allowedProgressions.has(TaskStatus.skipped) && !this.props.needsRevised && (
-              <TaskSkipControl {...this.props} />
-            )}
+            {((this.props.allowedProgressions.has(TaskStatus.skipped) &&
+              !this.props.needsRevised) ||
+              this.props.isCompleting) && <TaskSkipControl {...this.props} disabled={disabled} />}
           </div>
         </div>
       </div>
@@ -91,4 +96,6 @@ TaskCompletionStep.propTypes = {
   pickEditor: PropTypes.func.isRequired,
   /** Invoked if the user immediately completes the task (false positive) */
   complete: PropTypes.func.isRequired,
+  /** Whether the task completion step is disabled */
+  disabled: PropTypes.bool,
 };

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/TaskFalsePositiveControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/TaskFalsePositiveControl.jsx
@@ -1,5 +1,5 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskStatus } from "../../../../../services/Task/TaskStatus/TaskStatus";
 import Button from "../../../../Button/Button";
@@ -11,36 +11,33 @@ import messages from "./Messages";
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export default class TaskFalsePositiveControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskStatus.falsePositive)}>
-          {this.props.falsePositiveLabel ? (
-            this.props.falsePositiveLabel
-          ) : (
-            <FormattedMessage {...messages.falsePositiveLabel} />
-          )}
-        </a>
-      );
-    }
+const TaskFalsePositiveControl = ({ complete, disabled, asLink, falsePositiveLabel, intl }) => {
+  const handleClick = () => !disabled && complete(TaskStatus.falsePositive);
 
+  const label = falsePositiveLabel || <FormattedMessage {...messages.falsePositiveLabel} />;
+
+  if (asLink) {
     return (
-      <Button
-        className="mr-button--blue-fill mr-mb-2 mr-mr-2"
-        style={{ minWidth: "10rem" }}
-        title={this.props.intl.formatMessage(messages.falsePositiveTooltip)}
-        onClick={() => this.props.complete(TaskStatus.falsePositive)}
-      >
-        {this.props.falsePositiveLabel ? (
-          this.props.falsePositiveLabel
-        ) : (
-          <FormattedMessage {...messages.falsePositiveLabel} />
-        )}
-      </Button>
+      <a onClick={handleClick} className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}>
+        {label}
+      </a>
     );
   }
-}
+
+  return (
+    <Button
+      className={classNames("mr-button--blue-fill mr-mb-2 mr-mr-2", {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      style={{ minWidth: "10rem" }}
+      title={intl?.formatMessage(messages.falsePositiveTooltip)}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      {label}
+    </Button>
+  );
+};
 
 TaskFalsePositiveControl.propTypes = {
   /** Set to true to render in a minimized form */
@@ -53,8 +50,18 @@ TaskFalsePositiveControl.propTypes = {
   activateKeyboardShortcut: PropTypes.func.isRequired,
   /** Invoked when keyboard shortcuts should no longer be active  */
   deactivateKeyboardShortcut: PropTypes.func.isRequired,
+  /** Disable the control */
+  disabled: PropTypes.bool,
+  /** Set to true to render in a link form */
+  asLink: PropTypes.bool,
+  /** Custom label for the false-positive control */
+  falsePositiveLabel: PropTypes.node,
+  /** React-intl intl object */
+  intl: PropTypes.object,
 };
 
 TaskFalsePositiveControl.defaultProps = {
   isMinimized: false,
 };
+
+export default TaskFalsePositiveControl;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/TaskFixedControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/TaskFixedControl.jsx
@@ -1,5 +1,5 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskStatus } from "../../../../../services/Task/TaskStatus/TaskStatus";
 import Button from "../../../../Button/Button";
@@ -10,37 +10,40 @@ import messages from "./Messages";
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export default class TaskFixedControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskStatus.fixed)}>
-          {this.props.fixedLabel ? (
-            this.props.fixedLabel
-          ) : (
-            <FormattedMessage {...messages.fixedLabel} />
-          )}
-        </a>
-      );
-    } else {
-      return (
-        <Button
-          className="mr-button--blue-fill mr-mb-2 mr-mr-2"
-          style={{ minWidth: "10rem" }}
-          onClick={() => this.props.complete(TaskStatus.fixed)}
-        >
-          {this.props.fixedLabel ? (
-            this.props.fixedLabel
-          ) : (
-            <FormattedMessage {...messages.fixedLabel} />
-          )}
-        </Button>
-      );
-    }
+const TaskFixedControl = ({ complete, disabled, asLink, fixedLabel }) => {
+  const handleClick = () => !disabled && complete(TaskStatus.fixed);
+
+  const label = fixedLabel || <FormattedMessage {...messages.fixedLabel} />;
+
+  if (asLink) {
+    return (
+      <a onClick={handleClick} className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}>
+        {label}
+      </a>
+    );
   }
-}
+
+  return (
+    <Button
+      className={classNames("mr-button--blue-fill mr-mb-2 mr-mr-2", {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      style={{ minWidth: "10rem" }}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      {label}
+    </Button>
+  );
+};
 
 TaskFixedControl.propTypes = {
   /** Invoked to mark the task as already-fixed */
   complete: PropTypes.func.isRequired,
+  /** Disable the control */
+  disabled: PropTypes.bool,
+  asLink: PropTypes.bool,
+  fixedLabel: PropTypes.node,
 };
+
+export default TaskFixedControl;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.jsx
@@ -26,6 +26,8 @@ export default class TaskNextControl extends Component {
   };
 
   render() {
+    const disabled = this.props.disabled || this.props.isCompleting;
+
     const loadNearbyModal = (
       <External>
         <Modal
@@ -83,6 +85,7 @@ export default class TaskNextControl extends Component {
                 }
               }}
               title={this.props.intl.formatMessage(messages.nextTooltip)}
+              disabled={disabled}
             >
               <FormattedMessage {...messages.nextLabel} />
             </button>
@@ -100,6 +103,7 @@ export default class TaskNextControl extends Component {
                   checked={this.props.loadBy === TaskLoadMethod.random}
                   onClick={() => this.props.chooseLoadBy(TaskLoadMethod.random)}
                   onChange={_noop}
+                  disabled={disabled}
                 />
                 <label className="mr-ml-1 mr-mr-4" htmlFor="randomnessPreference-random">
                   <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.random]} />
@@ -113,6 +117,7 @@ export default class TaskNextControl extends Component {
                   checked={this.props.loadBy === TaskLoadMethod.proximity}
                   onClick={() => this.props.chooseLoadBy(TaskLoadMethod.proximity)}
                   onChange={_noop}
+                  disabled={disabled}
                 />
                 <label className="mr-ml-1" htmlFor="randomnessPreference-proximity">
                   <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskRevisedControl/TaskRevisedControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskRevisedControl/TaskRevisedControl.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskReviewStatus } from "../../../../../services/Task/TaskReview/TaskReviewStatus";
 import Dropdown from "../../../../Dropdown/Dropdown";
@@ -11,64 +10,79 @@ import messages from "./Messages";
  *
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
-export default class TaskRevisedControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskReviewStatus.needed)}>
-          <FormattedMessage {...messages.revisedLabel} />
-        </a>
-      );
-    } else {
-      return (
-        <Dropdown
-          className={classNames("mr-dropdown--fixed")}
-          dropdownButton={(dropdown) => (
-            <MoreOptionsButton
-              toggleDropdownVisible={dropdown.toggleDropdownVisible}
-              {...this.props}
-            />
-          )}
-          dropdownContent={() => <ListMoreOptionsItems {...this.props} />}
-        />
-      );
-    }
+const MoreOptionsButton = ({ toggleDropdownVisible, intl, disabled }) => (
+  <button
+    className={classNames("mr-dropdown__button mr-button mr-text-green-lighter mr-mr-2", {
+      "mr-opacity-50 mr-cursor-not-allowed": disabled,
+    })}
+    style={{ minWidth: "20.5rem" }}
+    onClick={disabled ? null : toggleDropdownVisible}
+    disabled={disabled}
+  >
+    {intl.formatMessage(messages.revisedLabel)}&hellip;
+  </button>
+);
+
+const ListMoreOptionsItems = ({ complete, task }) => (
+  <ol className="mr-list-dropdown">
+    <li>
+      <a onClick={() => complete(task.status, TaskReviewStatus.needed)}>
+        <FormattedMessage {...messages.resubmit} />
+      </a>
+    </li>
+    <li>
+      <a onClick={() => complete(task.status, TaskReviewStatus.disputed)}>
+        <FormattedMessage {...messages.dispute} />
+      </a>
+    </li>
+  </ol>
+);
+
+const TaskRevisedControl = ({ complete, asLink, intl, task, disabled }) => {
+  if (asLink) {
+    return (
+      <a
+        onClick={disabled ? null : () => complete(TaskReviewStatus.needed)}
+        className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}
+      >
+        <FormattedMessage {...messages.revisedLabel} />
+      </a>
+    );
   }
-}
 
-const MoreOptionsButton = function (props) {
   return (
-    <button
-      className="mr-dropdown__button mr-button mr-text-green-lighter mr-mr-2"
-      style={{ minWidth: "20.5rem" }}
-      onClick={props.toggleDropdownVisible}
-    >
-      {props.intl.formatMessage(messages.revisedLabel)}&hellip;
-    </button>
-  );
-};
-
-const ListMoreOptionsItems = function (props) {
-  return (
-    <ol className="mr-list-dropdown">
-      <li>
-        <a className="" onClick={() => props.complete(props.task.status, TaskReviewStatus.needed)}>
-          <FormattedMessage {...messages.resubmit} />
-        </a>
-      </li>
-      <li>
-        <a
-          className=""
-          onClick={() => props.complete(props.task.status, TaskReviewStatus.disputed)}
-        >
-          <FormattedMessage {...messages.dispute} />
-        </a>
-      </li>
-    </ol>
+    <Dropdown
+      className={classNames("mr-dropdown--fixed")}
+      dropdownButton={(dropdown) => (
+        <MoreOptionsButton
+          toggleDropdownVisible={dropdown.toggleDropdownVisible}
+          intl={intl}
+          disabled={disabled}
+        />
+      )}
+      dropdownContent={() => <ListMoreOptionsItems complete={complete} task={task} />}
+    />
   );
 };
 
 TaskRevisedControl.propTypes = {
   /** Invoked to mark the task as revised */
   complete: PropTypes.func.isRequired,
+  asLink: PropTypes.bool,
+  intl: PropTypes.object.isRequired,
+  task: PropTypes.object.isRequired,
+  disabled: PropTypes.bool,
 };
+
+MoreOptionsButton.propTypes = {
+  toggleDropdownVisible: PropTypes.func.isRequired,
+  intl: PropTypes.object.isRequired,
+  disabled: PropTypes.bool,
+};
+
+ListMoreOptionsItems.propTypes = {
+  complete: PropTypes.func.isRequired,
+  task: PropTypes.object.isRequired,
+};
+
+export default TaskRevisedControl;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.jsx
@@ -1,5 +1,5 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskStatus } from "../../../../../services/Task/TaskStatus/TaskStatus";
 import Button from "../../../../Button/Button";
@@ -10,27 +10,30 @@ import messages from "./Messages";
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export default class TaskSkipControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskStatus.skipped)}>
-          <FormattedMessage {...messages.skipLabel} />
-        </a>
-      );
-    }
+const TaskSkipControl = ({ complete, disabled, asLink }) => {
+  const handleClick = () => !disabled && complete(TaskStatus.skipped);
 
+  if (asLink) {
     return (
-      <Button
-        className="mr-button--blue-fill mr-mb-2 mr-mr-2"
-        style={{ minWidth: "10rem" }}
-        onClick={() => this.props.complete(TaskStatus.skipped)}
-      >
+      <a onClick={handleClick} className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}>
         <FormattedMessage {...messages.skipLabel} />
-      </Button>
+      </a>
     );
   }
-}
+
+  return (
+    <Button
+      className={classNames("mr-button--blue-fill mr-mb-2 mr-mr-2", {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      style={{ minWidth: "10rem" }}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      <FormattedMessage {...messages.skipLabel} />
+    </Button>
+  );
+};
 
 TaskSkipControl.propTypes = {
   /** Set to true to render in a minimized form */
@@ -45,9 +48,15 @@ TaskSkipControl.propTypes = {
   activateKeyboardShortcut: PropTypes.func.isRequired,
   /** Invoked when keyboard shortcuts should no longer be active  */
   deactivateKeyboardShortcut: PropTypes.func.isRequired,
+  /** Disable the control */
+  disabled: PropTypes.bool,
+  /** Set to true to render as a link */
+  asLink: PropTypes.bool,
 };
 
 TaskSkipControl.defaultProps = {
   isMinimized: false,
   suppressIcon: false,
 };
+
+export default TaskSkipControl;

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/TaskTooHardControl.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/TaskTooHardControl.jsx
@@ -1,5 +1,5 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import { TaskStatus } from "../../../../../services/Task/TaskStatus/TaskStatus";
 import Button from "../../../../Button/Button";
@@ -11,29 +11,37 @@ import messages from "./Messages";
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export default class TaskTooHardControl extends Component {
-  render() {
-    if (this.props.asLink) {
-      return (
-        <a onClick={() => this.props.complete(TaskStatus.tooHard)}>
-          <FormattedMessage {...messages.tooHardLabel} />
-        </a>
-      );
-    } else {
-      return (
-        <Button
-          className="mr-button--blue-fill mr-mb-2 mr-mr-2"
-          style={{ minWidth: "10rem" }}
-          onClick={() => this.props.complete(TaskStatus.tooHard)}
-        >
-          <FormattedMessage {...messages.tooHardLabel} />
-        </Button>
-      );
-    }
+const TaskTooHardControl = ({ complete, disabled, asLink }) => {
+  const handleClick = () => !disabled && complete(TaskStatus.tooHard);
+
+  if (asLink) {
+    return (
+      <a onClick={handleClick} className={disabled ? "mr-cursor-not-allowed mr-opacity-50" : ""}>
+        <FormattedMessage {...messages.tooHardLabel} />
+      </a>
+    );
   }
-}
+
+  return (
+    <Button
+      className={classNames("mr-button--blue-fill mr-mb-2 mr-mr-2", {
+        "mr-opacity-50 mr-cursor-not-allowed": disabled,
+      })}
+      style={{ minWidth: "10rem" }}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      <FormattedMessage {...messages.tooHardLabel} />
+    </Button>
+  );
+};
 
 TaskTooHardControl.propTypes = {
   /** Invoked to mark the task as already-fixed */
   complete: PropTypes.func.isRequired,
+  /** Disable the control */
+  disabled: PropTypes.bool,
+  asLink: PropTypes.bool,
 };
+
+export default TaskTooHardControl;

--- a/src/components/TaskPane/TaskPane.jsx
+++ b/src/components/TaskPane/TaskPane.jsx
@@ -10,11 +10,7 @@ import { Redirect } from "react-router";
 import { Link } from "react-router-dom";
 import AsManager from "../../interactions/User/AsManager";
 import { isCompletionStatus } from "../../services/Task/TaskStatus/TaskStatus";
-import {
-  WidgetDataTarget,
-  generateWidgetId,
-  widgetDescriptor,
-} from "../../services/Widget/Widget";
+import { WidgetDataTarget, generateWidgetId, widgetDescriptor } from "../../services/Widget/Widget";
 import { constructChallengeLink } from "../../utils/constructChangesetUrl";
 import BasicDialog from "../BasicDialog/BasicDialog";
 import BusySpinner from "../BusySpinner/BusySpinner";
@@ -140,7 +136,7 @@ export class TaskPane extends Component {
     requestedNextTask,
     osmComment,
     tagEdits,
-    taskBundle
+    taskBundle,
   ) => {
     try {
       await this.props.completeTask(
@@ -156,7 +152,7 @@ export class TaskPane extends Component {
         osmComment,
         tagEdits,
         this.state.completionResponses,
-        taskBundle
+        taskBundle,
       );
       this.clearCompletingTask();
     } catch (error) {
@@ -245,9 +241,7 @@ export class TaskPane extends Component {
       `/admin/project/${this.props.task.parent.parent.id}/` +
       `challenge/${this.props.task.parent.id}/task/${this.props.task.id}/inspect`;
 
-    const isManageable = AsManager(this.props.user).canManageChallenge(
-      this.props.task?.parent
-    );
+    const isManageable = AsManager(this.props.user).canManageChallenge(this.props.task?.parent);
 
     const completionResponses =
       this.state.completionResponses ||
@@ -258,19 +252,15 @@ export class TaskPane extends Component {
     const challenge = this.props.task.parent;
     let favoriteControl = null;
     if (!challenge.isVirtual) {
-      const isFavorited =
-        _findIndex(this.props.user.savedChallenges, { id: challenge.id }) !==
-        -1;
+      const isFavorited = _findIndex(this.props.user.savedChallenges, { id: challenge.id }) !== -1;
       favoriteControl = (
         <li>
           <a
             className="mr-normal-case mr-flex"
             onClick={() =>
-              (isFavorited
-                ? this.props.unsaveChallengeForUser
-                : this.props.saveChallengeForUser)(
+              (isFavorited ? this.props.unsaveChallengeForUser : this.props.saveChallengeForUser)(
                 this.props.user.id,
-                challenge.id
+                challenge.id,
               )
             }
           >
@@ -290,16 +280,12 @@ export class TaskPane extends Component {
               "mr-bg-gradient-r-green-dark-blue mr-text-white mr-pb-8 mr-cards-inverse",
               {
                 "mr-pt-2": !this.props.inspectTask,
-              }
+              },
             )}
             workspaceTitle={
               <div className="mr-flex mr-items-baseline mr-mt-4">
                 <h2 className="mr-text-xl mr-my-0 mr-mr-2 mr-links-inverse">
-                  <ChallengeNameLink
-                    {...this.props}
-                    includeProject
-                    suppressShareLink
-                  />
+                  <ChallengeNameLink {...this.props} includeProject suppressShareLink />
                 </h2>
 
                 {this.props.tryingLock ? (
@@ -351,8 +337,7 @@ export class TaskPane extends Component {
                               _isFinite(this.props.virtualChallengeId)
                                 ? `/browse/virtual/${this.props.virtualChallengeId}`
                                 : `/browse/challenges/${
-                                    this.props.task?.parent?.id ??
-                                    this.props.task.parent
+                                    this.props.task?.parent?.id ?? this.props.task.parent
                                   }`
                             }
                             className="mr-button mr-button--xsmall mr-ml-3"
@@ -391,9 +376,7 @@ export class TaskPane extends Component {
                               onCopy={() => dropdown.closeDropdown()}
                             >
                               <a>
-                                <FormattedMessage
-                                  {...messages.copyVirtualShareLinkLabel}
-                                />
+                                <FormattedMessage {...messages.copyVirtualShareLinkLabel} />
                               </a>
                             </CopyToClipboard>
                           </li>
@@ -404,9 +387,7 @@ export class TaskPane extends Component {
                             onCopy={() => dropdown.closeDropdown()}
                           >
                             <a>
-                              <FormattedMessage
-                                {...messages.copyShareLinkLabel}
-                              />
+                              <FormattedMessage {...messages.copyShareLinkLabel} />
                             </a>
                           </CopyToClipboard>
                         </li>
@@ -427,9 +408,7 @@ export class TaskPane extends Component {
                             <li>
                               <button
                                 className="mr-transition mr-text-green-lighter hover:mr-text-current"
-                                onClick={() =>
-                                  this.props.history.push(taskInspectRoute)
-                                }
+                                onClick={() => this.props.history.push(taskInspectRoute)}
                               >
                                 <FormattedMessage {...messages.inspectLabel} />
                               </button>
@@ -500,9 +479,7 @@ export class TaskPane extends Component {
                   className="mr-button mr-button--white"
                   onClick={() => {
                     this.props.history.push(
-                      `/browse/challenges/${
-                        this.props.task?.parent?.id ?? this.props.task.parent
-                      }`
+                      `/browse/challenges/${this.props.task?.parent?.id ?? this.props.task.parent}`,
                     );
                   }}
                 >
@@ -527,6 +504,6 @@ export default WithChallengePreferences(
     WithLockedTask(WithCooperativeWork(WithTaskBundle(injectIntl(TaskPane)))),
     WidgetDataTarget.task,
     WIDGET_WORKSPACE_NAME,
-    defaultWorkspaceSetup
-  )
+    defaultWorkspaceSetup,
+  ),
 );

--- a/src/components/TaskPane/TaskPane.jsx
+++ b/src/components/TaskPane/TaskPane.jsx
@@ -10,7 +10,11 @@ import { Redirect } from "react-router";
 import { Link } from "react-router-dom";
 import AsManager from "../../interactions/User/AsManager";
 import { isCompletionStatus } from "../../services/Task/TaskStatus/TaskStatus";
-import { WidgetDataTarget, generateWidgetId, widgetDescriptor } from "../../services/Widget/Widget";
+import {
+  WidgetDataTarget,
+  generateWidgetId,
+  widgetDescriptor,
+} from "../../services/Widget/Widget";
 import { constructChallengeLink } from "../../utils/constructChangesetUrl";
 import BasicDialog from "../BasicDialog/BasicDialog";
 import BusySpinner from "../BusySpinner/BusySpinner";
@@ -95,6 +99,7 @@ export class TaskPane extends Component {
     completionResponses: null,
     showLockFailureDialog: false,
     needsResponses: false,
+    completingTask: false,
   };
 
   tryLockingTask = () => {
@@ -123,7 +128,7 @@ export class TaskPane extends Component {
    * WithCurrentTask, but we intercept the call so that we can manage our
    * transition animation as the task prepares to complete.
    */
-  completeTask = (
+  completeTask = async (
     task,
     challengeId,
     taskStatus,
@@ -135,10 +140,10 @@ export class TaskPane extends Component {
     requestedNextTask,
     osmComment,
     tagEdits,
-    taskBundle,
+    taskBundle
   ) => {
-    this.props
-      .completeTask(
+    try {
+      await this.props.completeTask(
         task,
         challengeId,
         taskStatus,
@@ -151,11 +156,13 @@ export class TaskPane extends Component {
         osmComment,
         tagEdits,
         this.state.completionResponses,
-        taskBundle,
-      )
-      .then(() => {
-        this.clearCompletingTask();
-      });
+        taskBundle
+      );
+      this.clearCompletingTask();
+    } catch (error) {
+      console.error("Error completing task:", error);
+      throw error;
+    }
   };
 
   clearCompletingTask = () => {
@@ -238,7 +245,9 @@ export class TaskPane extends Component {
       `/admin/project/${this.props.task.parent.parent.id}/` +
       `challenge/${this.props.task.parent.id}/task/${this.props.task.id}/inspect`;
 
-    const isManageable = AsManager(this.props.user).canManageChallenge(this.props.task?.parent);
+    const isManageable = AsManager(this.props.user).canManageChallenge(
+      this.props.task?.parent
+    );
 
     const completionResponses =
       this.state.completionResponses ||
@@ -249,15 +258,19 @@ export class TaskPane extends Component {
     const challenge = this.props.task.parent;
     let favoriteControl = null;
     if (!challenge.isVirtual) {
-      const isFavorited = _findIndex(this.props.user.savedChallenges, { id: challenge.id }) !== -1;
+      const isFavorited =
+        _findIndex(this.props.user.savedChallenges, { id: challenge.id }) !==
+        -1;
       favoriteControl = (
         <li>
           <a
             className="mr-normal-case mr-flex"
             onClick={() =>
-              (isFavorited ? this.props.unsaveChallengeForUser : this.props.saveChallengeForUser)(
+              (isFavorited
+                ? this.props.unsaveChallengeForUser
+                : this.props.saveChallengeForUser)(
                 this.props.user.id,
-                challenge.id,
+                challenge.id
               )
             }
           >
@@ -277,12 +290,16 @@ export class TaskPane extends Component {
               "mr-bg-gradient-r-green-dark-blue mr-text-white mr-pb-8 mr-cards-inverse",
               {
                 "mr-pt-2": !this.props.inspectTask,
-              },
+              }
             )}
             workspaceTitle={
               <div className="mr-flex mr-items-baseline mr-mt-4">
                 <h2 className="mr-text-xl mr-my-0 mr-mr-2 mr-links-inverse">
-                  <ChallengeNameLink {...this.props} includeProject suppressShareLink />
+                  <ChallengeNameLink
+                    {...this.props}
+                    includeProject
+                    suppressShareLink
+                  />
                 </h2>
 
                 {this.props.tryingLock ? (
@@ -333,7 +350,10 @@ export class TaskPane extends Component {
                             to={
                               _isFinite(this.props.virtualChallengeId)
                                 ? `/browse/virtual/${this.props.virtualChallengeId}`
-                                : `/browse/challenges/${this.props.task?.parent?.id ?? this.props.task.parent}`
+                                : `/browse/challenges/${
+                                    this.props.task?.parent?.id ??
+                                    this.props.task.parent
+                                  }`
                             }
                             className="mr-button mr-button--xsmall mr-ml-3"
                           >
@@ -371,7 +391,9 @@ export class TaskPane extends Component {
                               onCopy={() => dropdown.closeDropdown()}
                             >
                               <a>
-                                <FormattedMessage {...messages.copyVirtualShareLinkLabel} />
+                                <FormattedMessage
+                                  {...messages.copyVirtualShareLinkLabel}
+                                />
                               </a>
                             </CopyToClipboard>
                           </li>
@@ -382,7 +404,9 @@ export class TaskPane extends Component {
                             onCopy={() => dropdown.closeDropdown()}
                           >
                             <a>
-                              <FormattedMessage {...messages.copyShareLinkLabel} />
+                              <FormattedMessage
+                                {...messages.copyShareLinkLabel}
+                              />
                             </a>
                           </CopyToClipboard>
                         </li>
@@ -403,7 +427,9 @@ export class TaskPane extends Component {
                             <li>
                               <button
                                 className="mr-transition mr-text-green-lighter hover:mr-text-current"
-                                onClick={() => this.props.history.push(taskInspectRoute)}
+                                onClick={() =>
+                                  this.props.history.push(taskInspectRoute)
+                                }
                               >
                                 <FormattedMessage {...messages.inspectLabel} />
                               </button>
@@ -424,14 +450,9 @@ export class TaskPane extends Component {
             needsResponses={this.state.needsResponses}
             templateRevision={isCompletionStatus(this.props.task.status)}
           />
-          {this.props.completingTask && this.props.completingTask === this.props.task.id && (
-            <div className="mr-fixed mr-top-0 mr-bottom-0 mr-left-0 mr-right-0 mr-z-200 mr-bg-blue-firefly-75 mr-flex mr-justify-center mr-items-center">
-              <BusySpinner big inline />
-            </div>
-          )}
         </MediaQuery>
         <MediaQuery query="(max-width: 1023px)">
-          <MapPane completingTask={this.props.completingTask}>
+          <MapPane>
             <TaskMap
               isMobile
               task={this.props.task}
@@ -479,7 +500,9 @@ export class TaskPane extends Component {
                   className="mr-button mr-button--white"
                   onClick={() => {
                     this.props.history.push(
-                      `/browse/challenges/${this.props.task?.parent?.id ?? this.props.task.parent}`,
+                      `/browse/challenges/${
+                        this.props.task?.parent?.id ?? this.props.task.parent
+                      }`
                     );
                   }}
                 >
@@ -504,6 +527,6 @@ export default WithChallengePreferences(
     WithLockedTask(WithCooperativeWork(WithTaskBundle(injectIntl(TaskPane)))),
     WidgetDataTarget.task,
     WIDGET_WORKSPACE_NAME,
-    defaultWorkspaceSetup,
-  ),
+    defaultWorkspaceSetup
+  )
 );


### PR DESCRIPTION
This pr resolves: https://github.com/maproulette/maproulette3/issues/2538

What has changed:
Before, users could click on the completion buttons multiple times if they had slow network speed, and in the issue described above, there are some states in the completion process where the user is able to see the completed task version of the completion widget and interact with it, leading to a lot of confusion.

Now, when a user submits a task, the buttons will be greyed out and unclickable, and the completion flow is now async, so the task wont be marked as completed in the ui until the completion endpoint returns and the next task is found.