### PR TITLE
Scrub for RapiD -> Rapid brand update

### DIFF
--- a/.env
+++ b/.env
@@ -71,7 +71,7 @@ REACT_APP_GEOGRAPHIC_INDEXING_DELAY=2
 # iD editor base URL
 REACT_APP_ID_EDITOR_SERVER_URL='https://www.openstreetmap.org/edit'
 
-# RapiD editor base URL
+# Rapid editor base URL
 REACT_APP_RAPID_EDITOR_SERVER_URL='https://rapideditor.org/edit'
 
 # Level0 editor base URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1611,7 +1611,7 @@ Release with [maproulette-backend_v4.3.1](https://github.com/maproulette/maproul
 ### Added
 - Completion and review of multiple tasks together
 - Templates for generating forms to be filled by mapper during task completion
-- RapiD editor option by @gaoxm
+- Rapid editor option by @gaoxm
 - Updated help links by @mvexel
 - Additional resiliency to missing task geometries
 - Option to include specific task properties as columns in CSV exports

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -260,7 +260,7 @@ export const constructIdURI = function (task, mapBounds, options, taskBundle, re
 };
 
 /**
- * Builds a RapiD editor URI for editing of the given task
+ * Builds a Rapid editor URI for editing of the given task
  */
 export const constructRapidURI = function (task, mapBounds, options, replacedComment) {
   const baseUriComponent = `${window.env.REACT_APP_RAPID_EDITOR_SERVER_URL}#`;

--- a/src/services/Editor/Editor.test.js
+++ b/src/services/Editor/Editor.test.js
@@ -363,7 +363,7 @@ describe("constructIdURI", () => {
 });
 
 describe("constructRapidURI", () => {
-  test("the uri specifies the RapiD editor", () => {
+  test("the uri specifies the Rapid editor", () => {
     const uri = constructRapidURI(task, mapBounds);
     expect(uri).toEqual(expect.stringContaining("rapid"));
   });

--- a/src/services/Editor/Messages.js
+++ b/src/services/Editor/Messages.js
@@ -30,6 +30,6 @@ export default defineMessages({
   },
   rapid: {
     id: "Editor.rapid.label",
-    defaultMessage: "Edit in RapiD",
+    defaultMessage: "Edit in Rapid",
   },
 });

--- a/src/services/KeyboardShortcuts/Messages.js
+++ b/src/services/KeyboardShortcuts/Messages.js
@@ -31,7 +31,7 @@ export default defineMessages({
 
   editRapid: {
     id: "KeyMapping.openEditor.editRapid",
-    defaultMessage: "Edit in RapiD",
+    defaultMessage: "Edit in Rapid",
   },
 
   layerOSMData: {


### PR DESCRIPTION
Saw the old brand on the editor button and figured tidying up was easy enough. I presume the lang/ files are all autogenerated even if I could do the translation manually. At worst I can go click through transifix for the various strings there..?