### PR TITLE
fix project picker modal filtering

### DIFF
--- a/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
+++ b/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
@@ -4,13 +4,13 @@ import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
 import { Component, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
+import BusySpinner from "../../../BusySpinner/BusySpinner";
 import WithPagedProjects from "../../../HOCs/WithPagedProjects/WithPagedProjects";
 import WithSearch from "../../../HOCs/WithSearch/WithSearch";
 import WithSearchResults from "../../../HOCs/WithSearchResults/WithSearchResults";
 import Modal from "../../../Modal/Modal";
 import SearchBox from "../../../SearchBox/SearchBox";
 import messages from "./Messages";
-import BusySpinner from "../../../BusySpinner/BusySpinner";
 
 export function ProjectPickerModal(props) {
   const [isSearching, setIsSearching] = useState(false);

--- a/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
+++ b/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
@@ -2,7 +2,7 @@ import { get as levenshtein } from "fast-levenshtein";
 import _compact from "lodash/compact";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
-import { Component, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import BusySpinner from "../../../BusySpinner/BusySpinner";
 import WithPagedProjects from "../../../HOCs/WithPagedProjects/WithPagedProjects";

--- a/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
+++ b/src/components/AdminPane/Manage/ProjectPickerModal/ProjectPickerModal.jsx
@@ -21,21 +21,23 @@ export function ProjectPickerModal(props) {
     }
 
     setIsSearching(true);
-    props.searchProjects(
-      {
-        searchQuery: queryCriteria.query,
-        page: 0,
-        onlyEnabled: false,
-      },
-      queryCriteria?.page?.resultsPerPage
-    ).finally(() => {
-      setIsSearching(false);
-    });
+    props
+      .searchProjects(
+        {
+          searchQuery: queryCriteria.query,
+          page: 0,
+          onlyEnabled: false,
+        },
+        queryCriteria?.page?.resultsPerPage,
+      )
+      .finally(() => {
+        setIsSearching(false);
+      });
   };
 
   const ProjectSearch = useMemo(
     () => WithSearch(SearchBox, "projectPickerModal", (criteria) => executeSearch(criteria)),
-    [] // Empty dependency array since executeSearch only depends on props
+    [], // Empty dependency array since executeSearch only depends on props
   );
 
   return (
@@ -78,16 +80,16 @@ const CandidateProjectList = function (props) {
       if (searchQuery && (project.displayName || project.name)) {
         const projectName = (project.displayName || project.name).toLowerCase();
         const searchQueryLower = searchQuery.toLowerCase();
-        
+
         // Check if any word in the project name contains the search query
         const words = projectName.split(/\s+/);
-        const hasMatch = words.some(word => word.includes(searchQueryLower));
-        
+        const hasMatch = words.some((word) => word.includes(searchQueryLower));
+
         // Calculate Levenshtein distance for fuzzy matching
         const similarity = levenshtein(searchQueryLower, projectName);
-        
+
         // Prioritize direct substring matches, then use Levenshtein as fallback
-        index = hasMatch ? 1000 : (100 - similarity);
+        index = hasMatch ? 1000 : 100 - similarity;
       }
 
       return { project, index };


### PR DESCRIPTION
Issue: The project list in the project modal displayed results inconsistently, with some projects appearing out of order or missing entirely. This PR ensures that any project containing the search term is always included in the results and is prioritized at the top of the list.