### PR TITLE
fix osm data warning and fix infinite loop

### DIFF
--- a/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.jsx
+++ b/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.jsx
@@ -83,6 +83,19 @@ const generateLayer = (props, map, _leaflet) => {
     pane: props.leaflet?.pane,
   });
 
+  // Clear existing layers to ensure proper ordering
+  layerGroup.clearLayers();
+
+  // Get all features and sort them by type to ensure consistent ordering
+  const features = layerGroup.buildFeatures(props.xmlData);
+  const sortedFeatures = features.sort((a, b) => {
+    const typeOrder = { way: 1, area: 2, node: 3, changeset: 4 };
+    return typeOrder[a.type] - typeOrder[b.type];
+  });
+
+  // Add features in the sorted order
+  layerGroup.addData(sortedFeatures);
+
   layerGroup.eachLayer((layer) => {
     layer.options.mrLayerLabel = props.intl.formatMessage(layerMessages.showOSMDataLabel);
     layer.options.fill = false;
@@ -166,7 +179,8 @@ const OSMDataLayerComponent = createPathComponent(
     if (!_isEqual(prevProps.showOSMElements, props.showOSMElements)) {
       instance.clearLayers();
       const newLayers = generateLayer(props, instance);
-      newLayers.eachLayer((layer) => instance.addLayer(layer));
+      // Transfer all layers at once to maintain ordering
+      instance.addLayer(newLayers);
     }
   },
 );

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.jsx
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.jsx
@@ -324,6 +324,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
     fetchOSMData: (bbox) => {
       return fetchOSMData(bbox).catch((error) => {
         dispatch(addError(error));
+        throw error;
       });
     },
 

--- a/src/components/TaskPane/TaskMap/Messages.js
+++ b/src/components/TaskPane/TaskMap/Messages.js
@@ -8,4 +8,21 @@ export default defineMessages({
     id: "Map.layerSelectionList.header",
     defaultMessage: "Select Desired Feature",
   },
+  osmDataAreaTooLarge: {
+    id: "Task.osmData.areaTooLarge",
+    defaultMessage:
+      "The selected area is too large to load OSM data. Please zoom in further to view OSM features.",
+  },
+  osmDataTooLarge: {
+    id: "Task.map.osmData.tooLarge",
+    defaultMessage: "OSM Data Area Too Large",
+  },
+  zoomInForOSMData: {
+    id: "Task.map.osmData.zoomInRequired",
+    defaultMessage: "Please zoom in closer to view OSM data for this area",
+  },
+  osmDataError: {
+    id: "Task.map.osmData.error",
+    defaultMessage: "Error Loading OSM Data",
+  },
 });


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2452

This bug is due to sorting issues when filtering for a specific data type. This pr fixes the the sorting issue resolving the ticket above.

While fixing this, I also discovered and fixed an infinite loop when loading osm data in an area that is too large.