### PR TITLE
fix feature layer toggling bug

### DIFF
--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -279,18 +279,13 @@ const SimpleLayerToggle = (props) => {
         props.toggleClassName,
       )}
     >
-      <input
-        id={props.layerLabel}
-        type="checkbox"
-        className="mr-checkbox-toggle"
-        checked={props.isLayerActive}
-        onChange={props.toggleLayerActive}
-      />
-      <label
-        htmlFor={props.layerLabel}
-        className="mr-ml-3 mr-text-orange"
-        onClick={(e) => e.preventDefault()}
-      >
+      <label className="mr-text-orange mr-cursor-pointer">
+        <input
+          type="checkbox"
+          className="mr-checkbox-toggle mr-mr-3"
+          checked={props.isLayerActive}
+          onChange={props.toggleLayerActive}
+        />
         {props.layerLabel}
       </label>
     </div>

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -3,7 +3,6 @@ import _clone from "lodash/clone";
 import _filter from "lodash/filter";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
-import _noop from "lodash/noop";
 import _sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { Component, Fragment } from "react";

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -279,16 +279,19 @@ const SimpleLayerToggle = (props) => {
         "mr-my-2 mr-flex mr-items-center mr-leading-none",
         props.toggleClassName,
       )}
-      onClick={props.toggleLayerActive}
     >
       <input
         id={props.layerLabel}
         type="checkbox"
         className="mr-checkbox-toggle"
         checked={props.isLayerActive}
-        onChange={_noop}
+        onChange={props.toggleLayerActive}
       />
-      <label htmlFor={props.layerLabel} className="mr-ml-3 mr-text-orange">
+      <label
+        htmlFor={props.layerLabel}
+        className="mr-ml-3 mr-text-orange"
+        onClick={(e) => e.preventDefault()}
+      >
         {props.layerLabel}
       </label>
     </div>


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2551

This pr makes it so that the checkbox is the only element that acts as a toggle, so users will no longer be able to click on the name of the layer toggle to toggle that layer. This resolves the error as clicking on the name was what was resulting in the bug.