### PR TITLE
remove codecov.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,8 +38,3 @@ jobs:
 
     - name: Run the tests
       run: yarn test -- --coverage
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 18%
-        threshold: 1%
-comment: false


### PR DESCRIPTION
As there has been no extended effort to add unit tests, and the github action is almost always ignored, we can remove this action for now.