### PR TITLE
Configure Biome to organize imports when running 'yarn run format'

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest",
     "test:cov": "vitest run --coverage",
     "lint": "eslint src/",
-    "format": "biome format --write",
+    "format": "biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true --write",
     "check": "biome ci && eslint src/",
     "explore": "source-map-explorer --only-mapped --no-border-checks 'dist/**/*.js'",
     "test:e2e:start": "NODE_ENV=development yarn run build && npx serve dist",


### PR DESCRIPTION
Biome is configured to enforce formatting in CI, which includes checking that imports are organized in the conventional order. But it was accidentally configured _not_ to organize import statements when running `yarn run format`. This fixes that discrepancy (`yarn run format` will now also sort imports, and CI formatting checks should always pass if you ran `yarn run format` before committing).