### PR TITLE
Fix bug in autosuggest text box causing review widget to crash

### DIFF
--- a/src/components/AutosuggestTextBox/AutosuggestTextBox.jsx
+++ b/src/components/AutosuggestTextBox/AutosuggestTextBox.jsx
@@ -3,7 +3,6 @@ import Downshift from "downshift";
 import _clone from "lodash/clone";
 import _concat from "lodash/concat";
 import _difference from "lodash/difference";
-import _filter from "lodash/filter";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
 import _split from "lodash/split";
@@ -207,10 +206,7 @@ export default class AutosuggestTextBox extends Component {
     }
 
     // Filter out any of our original preferredResults tags so they don't show in the list twice.
-    return _filter(
-      this.props.searchResults,
-      (t) => this.props.preferredResults.indexOf(t.name) === -1,
-    );
+    return this.props.searchResults.filter((t) => !this.props.preferredResults?.contains(t.name));
   };
 
   render() {


### PR DESCRIPTION
Introduced accidentally by me in #2517. Lodash's `_indexOf(arr, elem)` returns -1 if `arr` is undefined, and the AutosuggestTextBox component depended on this behavior. This PR changes the logic to use optional chaining (to guard against `preferredResults` being undefined) and `Array.contains()` (to remove the double negative and make intent clearer).