### PR TITLE
remove unused property in WebSocketClient.js

### DIFF
--- a/src/services/Server/WebSocketClient.js
+++ b/src/services/Server/WebSocketClient.js
@@ -197,7 +197,7 @@ export default class WebSocketClient {
    *
    * @private
    */
-  handleClose(e) {
+  handleClose() {
     if (this.isCleanedUp) {
       return;
     }


### PR DESCRIPTION
Somehow this undefined prop made it to the main branch without being noticed and is now breaking tests. This pr removes the undefined property resolving the issue.