### PR TITLE
Rewrite all `Array.forEach` and lodash `_each` as plain for loops

### DIFF
--- a/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimelineWidget.jsx
+++ b/src/components/ActivityTimeline/UserActivityTimeline/UserActivityTimelineWidget.jsx
@@ -84,12 +84,12 @@ export default class UserActivityTimelineWidget extends Component {
     // descriptions into a Map (tracking the total count of the dups), so we
     // can keep the timeline tidy and show a count instead of simply repeating
     // the same action multiple times for a challenge.
-    groupedByDate.forEach((dateGroup) => {
+    for (const dateGroup of groupedByDate) {
       // Group activities on this day by challenge
       const groupedByChallenge = _toPairs(_groupBy(dateGroup[1], "challengeId"));
 
       // Consolidate duplicate activities for each challenge into Map
-      groupedByChallenge.forEach((challengeGroup) => {
+      for (const challengeGroup of groupedByChallenge) {
         challengeGroup[1] = challengeGroup[1].reduce(
           (challengeEntries, entry) =>
             challengeEntries.set(
@@ -98,9 +98,9 @@ export default class UserActivityTimelineWidget extends Component {
             ),
           new Map(),
         );
-      });
+      }
       dateGroup[1] = groupedByChallenge;
-    });
+    }
 
     // Sort date groups in descending date order.
     const latestEntries = _reverse(_sortBy(groupedByDate, (pairs) => parseISO(pairs[0]).getTime()));

--- a/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
+++ b/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
@@ -103,11 +103,9 @@ async function convertAndBundleGeoJson(challenge) {
         data.features = [];
 
         if (allLines?.length) {
-          allLines.forEach((taskLine) => {
-            JSON.parse(taskLine).features.forEach((feature) => {
-              data.features.push(feature);
-            });
-          });
+          for (const taskLine of allLines) {
+            data.features.push(...JSON.parse(taskLine).features);
+          }
         }
       } else if (challenge.localGeoJSON) {
         data = JSON.parse(challenge.localGeoJSON);

--- a/src/components/AdminPane/HOCs/WithChallengeResultParents/WithChallengeResultParents.jsx
+++ b/src/components/AdminPane/HOCs/WithChallengeResultParents/WithChallengeResultParents.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _uniqBy from "lodash/uniqBy";
 import { Component } from "react";
@@ -23,10 +22,16 @@ const WithChallengeResultParents = function (WrappedComponent) {
         : this.props.projects;
 
       const projectsWithChallengeSearchResults = new Set();
-      _each(this.props.filteredChallenges, (c) => {
+
+      for (const c of this.props.filteredChallenges) {
         projectsWithChallengeSearchResults.add(c.parent);
-        _each(c.virtualParents, (vp) => projectsWithChallengeSearchResults.add(vp));
-      });
+
+        if (c.virtualParents) {
+          for (const vp of c.virtualParents) {
+            projectsWithChallengeSearchResults.add(vp);
+          }
+        }
+      }
 
       // Include both project results and projects that have challenge results.
       return _uniqBy(

--- a/src/components/AdminPane/HOCs/WithComboSearch/WithComboSearch.js
+++ b/src/components/AdminPane/HOCs/WithComboSearch/WithComboSearch.js
@@ -1,5 +1,3 @@
-import _each from "lodash/each";
-import _toPairs from "lodash/toPairs";
 import WithSearch from "../../../HOCs/WithSearch/WithSearch";
 
 /**
@@ -18,10 +16,9 @@ import WithSearch from "../../../HOCs/WithSearch/WithSearch";
 const WithComboSearch = (WrappedComponent, searches) => {
   let Combo = WrappedComponent;
 
-  _each(
-    _toPairs(searches),
-    (searchConfig) => (Combo = WithSearch(Combo, searchConfig[0], searchConfig[1])),
-  );
+  for (const [searchName, searchFunction] of Object.entries(searches)) {
+    Combo = WithSearch(Combo, searchName, searchFunction);
+  }
 
   return Combo;
 };

--- a/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.jsx
+++ b/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.jsx
@@ -1,9 +1,7 @@
-import _each from "lodash/each";
 import _fromPairs from "lodash/fromPairs";
 import _isEmpty from "lodash/isEmpty";
 import _isObject from "lodash/isObject";
 import _map from "lodash/map";
-import _values from "lodash/values";
 import PropTypes from "prop-types";
 import { Component } from "react";
 import { TaskPriority } from "../../../../services/Task/TaskPriority/TaskPriority";
@@ -21,7 +19,7 @@ export default function (WrappedComponent) {
       _fromPairs(_map(metrics, (value, label) => [label, (1.0 * value) / total]));
 
     updateTotals = (actions, totalTasks, taskMetrics) => {
-      _each(actions, (value, label) => {
+      for (const [label, value] of Object.entries(actions)) {
         if (label === "avgTimeSpent") {
           taskMetrics.totalTimeSpent = Number.isFinite(taskMetrics.totalTimeSpent)
             ? taskMetrics.totalTimeSpent + value * actions.tasksWithTime
@@ -36,7 +34,7 @@ export default function (WrappedComponent) {
             ? taskMetrics.percentages[label] + percentage
             : percentage;
         }
-      });
+      }
     };
 
     render() {
@@ -72,7 +70,7 @@ export default function (WrappedComponent) {
         taskMetricsByPriority.percentages = {};
         taskMetricsByPriority.averages = {};
 
-        _each(_values(TaskPriority), (priority) => {
+        for (const priority of Object.values(TaskPriority)) {
           taskMetricsByPriority[priority] = { percentages: {}, averages: {} };
 
           for (let challenge of challenges) {
@@ -92,7 +90,7 @@ export default function (WrappedComponent) {
             taskMetricsByPriority[priority].percentages,
             totalChallenges,
           );
-        });
+        }
       }
 
       return (

--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.jsx
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _find from "lodash/find";
 import _isObject from "lodash/isObject";
@@ -152,13 +151,15 @@ export const WithCurrentProject = function (WrappedComponent, options = {}) {
               // the child challenges have parent projects that haven't been
               // fetched yet. We need to fetch those so we can show their names.
               const missingProjects = [];
-              _each(result?.entities?.challenges, (challenge) => {
-                if (!_isObject(challenge.parent)) {
-                  if (!this.props.entities.projects[challenge.parent]) {
-                    missingProjects.push(challenge.parent);
+              if (result?.entities?.challenges) {
+                for (const challenge of Object.values(result.entities.challenges)) {
+                  if (!_isObject(challenge.parent)) {
+                    if (!this.props.entities.projects[challenge.parent]) {
+                      missingProjects.push(challenge.parent);
+                    }
                   }
                 }
-              });
+              }
               if (missingProjects.length > 0) {
                 this.props.fetchProjectsById(missingProjects);
               }

--- a/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.jsx
+++ b/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _isEqual from "lodash/isEqual";
 import _omit from "lodash/omit";
 import _values from "lodash/values";
@@ -59,11 +58,13 @@ const WithManageableProjects = function (WrappedComponent, includeChallenges = f
           // Since we only fetched a small portion of the total projects in the
           // database we need to make sure we also fetch the projects that are pinned.
           let missingProjects = [];
-          _each(this.props.pinnedProjects, (pinnedProject) => {
+
+          for (const pinnedProject of this.props.pinnedProjects) {
             if (!this.props.entities.projects[pinnedProject]) {
               missingProjects.push(pinnedProject);
             }
-          });
+          }
+
           if (missingProjects.length > 0) {
             this.props.fetchProjectsById(missingProjects);
 

--- a/src/components/AdminPane/HOCs/WithProjectManagement/WithProjectManagement.js
+++ b/src/components/AdminPane/HOCs/WithProjectManagement/WithProjectManagement.js
@@ -44,9 +44,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   deleteChallenges: (challengeIds, callback = () => null) => {
     const projectId = ownProps.match.params.projectId;
 
-    challengeIds.forEach((id) => {
+    for (const id of challengeIds) {
       dispatch(deleteChallenge(id));
-    });
+    }
 
     callback(projectId);
   },

--- a/src/components/AdminPane/HOCs/WithTaskPropertyStyleRules/WithTaskPropertyStyleRules.jsx
+++ b/src/components/AdminPane/HOCs/WithTaskPropertyStyleRules/WithTaskPropertyStyleRules.jsx
@@ -1,5 +1,4 @@
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 import _fill from "lodash/fill";
 import _filter from "lodash/filter";
 import _isEmpty from "lodash/isEmpty";
@@ -127,8 +126,8 @@ export const WithTaskPropertyStyleRules = function (WrappedComponent) {
 
     render() {
       const errors = this.state.validationErrors;
-      _each(this.state.styleRules, (rule, index) => {
-        _each(rule.styles, (style) => {
+      for (const [index, rule] of this.state.styleRules.entries()) {
+        for (const style of rule.styles) {
           if (style.styleName && !style.styleValue) {
             // Missing style value
             errors[index].push(PROPERTY_RULE_ERRORS.missingStyleValue);
@@ -136,15 +135,10 @@ export const WithTaskPropertyStyleRules = function (WrappedComponent) {
             // Missing syle name
             errors[index].push(PROPERTY_RULE_ERRORS.missingStyleName);
           }
-        });
-      });
-
-      let hasAnyStyleErrors = false;
-      _each(errors, (e) => {
-        if (!_isEmpty(e)) {
-          hasAnyStyleErrors = true;
         }
-      });
+      }
+
+      let hasAnyStyleErrors = errors.some((e) => !_isEmpty(e));
 
       return (
         <WrappedComponent

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Presets.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Presets.js
@@ -1,9 +1,6 @@
 import idPresets from "@openstreetmap/id-tagging-schema/dist/preset_categories.json";
-import _each from "lodash/each";
-import _find from "lodash/find";
 import _isEmpty from "lodash/isEmpty";
 import _reduce from "lodash/reduce";
-import _toPairs from "lodash/toPairs";
 
 /**
  * Prepares presets received from the server to the representation expected by
@@ -88,7 +85,9 @@ export const definedPresets = (challengeData, definedCategories) => {
  * Remove preset category top-level fields from the challenge
  */
 export const prunePresetCategories = (challengeData, activeCategories) => {
-  _each(activeCategories, (categoryName) => delete challengeData[categoryName]);
+  for (const categoryName of activeCategories) {
+    delete challengeData[categoryName];
+  }
 };
 
 /**
@@ -97,14 +96,14 @@ export const prunePresetCategories = (challengeData, activeCategories) => {
  */
 export const categorizePresetStrings = (presetStrings) => {
   const categorized = {};
-  _each(presetStrings, (preset) => {
-    // eslint-disable-next-line no-unused-vars
-    const parentCategory = _find(_toPairs(idPresets), ([categoryName, category]) => {
-      return category.members.indexOf(preset) !== -1;
+
+  for (const preset of presetStrings) {
+    const parentCategory = Object.entries(idPresets).find(([_, category]) => {
+      return category.members.includes(preset);
     });
 
     if (!parentCategory) {
-      return;
+      continue;
     }
 
     const categoryName = parentCategory[0];
@@ -112,7 +111,7 @@ export const categorizePresetStrings = (presetStrings) => {
       categorized[categoryName] = [];
     }
     categorized[categoryName].push(preset);
-  });
+  }
 
   return categorized;
 };

--- a/src/components/ChallengeProgress/ChallengeProgress.jsx
+++ b/src/components/ChallengeProgress/ChallengeProgress.jsx
@@ -1,7 +1,6 @@
 import { ResponsiveBar } from "@nivo/bar";
 import classNames from "classnames";
 import _chunk from "lodash/chunk";
-import _each from "lodash/each";
 import _isEqual from "lodash/isEqual";
 import _isObject from "lodash/isObject";
 import _map from "lodash/map";
@@ -224,12 +223,13 @@ export class ChallengeProgress extends Component {
 
   calculateChallengeStats(taskActions, orderedStatuses, localizedStatuses) {
     let challengeStats = {};
-    _each(orderedStatuses, (status) => {
+
+    for (const status of orderedStatuses) {
       challengeStats[localizedStatuses[keysByStatus[status]]] = {
         count: taskActions[keysByStatus[status]],
         percent: this.percent(taskActions[keysByStatus[status]], taskActions.total),
       };
-    });
+    }
 
     return challengeStats;
   }
@@ -240,12 +240,12 @@ export class ChallengeProgress extends Component {
       [availableLabel]: this.percent(taskActions.available, taskActions.total),
     };
 
-    _each(orderedStatuses, (status) => {
+    for (const status of orderedStatuses) {
       completionData[localizedStatuses[keysByStatus[status]]] = this.percent(
         taskActions[keysByStatus[status]],
         taskActions.total,
       );
-    });
+    }
 
     return completionData;
   }

--- a/src/components/CommentList/CommentList.jsx
+++ b/src/components/CommentList/CommentList.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import { parseISO } from "date-fns";
-import _each from "lodash/each";
 import _isObject from "lodash/isObject";
 import _map from "lodash/map";
 import _reverse from "lodash/reverse";
@@ -33,20 +32,18 @@ export default class CommentList extends Component {
     // Show in descending order, with the most recent comment first.
     let sortedComments = [];
 
-    if (this.props.comments?.length !== 0) {
-      commentDates = new Map();
-      _each(this.props.comments, (comment) =>
-        commentDates.set(comment.id, parseISO(comment.created)),
+    if (this.props.comments?.length > 0) {
+      commentDates = new Map(
+        this.props.comments.map((comment) => [comment.id, parseISO(comment.created)]),
       );
 
       // Show in descending order, with the most recent comment first.
       sortedComments = _reverse(
         _sortBy(this.props.comments, (comment) => commentDates.get(comment.id).getTime()),
       );
-    } else {
-      commentDates = new Map();
-      _each(this.props.taskComments, (comment) =>
-        commentDates.set(comment.id, parseISO(comment.created)),
+    } else if (this.props.taskComments?.length > 0) {
+      commentDates = new Map(
+        this.props.taskComments.map((comment) => [comment.id, parseISO(comment.created)]),
       );
 
       // Show in descending order, with the most recent comment first.

--- a/src/components/CountrySelector/CountrySelector.jsx
+++ b/src/components/CountrySelector/CountrySelector.jsx
@@ -1,6 +1,3 @@
-import _each from "lodash/each";
-import _map from "lodash/map";
-import _sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { Component } from "react";
 import { FormattedMessage, injectIntl } from "react-intl";
@@ -63,14 +60,14 @@ const CountryButton = function (props) {
 };
 
 const ListCountryItems = function (props) {
-  const countryList = _sortBy(
-    _each(supportedCountries(), (country) => {
+  const countryList = supportedCountries()
+    .map((country) => {
       country.name = props.intl.formatMessage(countryMessages[country.countryCode]);
-    }),
-    "name",
-  );
+      return country;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 
-  const menuItems = _map(countryList, (country) => (
+  const menuItems = countryList.map((country) => (
     <li key={country.countryCode}>
       <a onClick={() => props.pickCountry(country.countryCode, props.closeDropdown)}>
         {country.name}

--- a/src/components/HOCs/WithConfigurableColumns/WithConfigurableColumns.jsx
+++ b/src/components/HOCs/WithConfigurableColumns/WithConfigurableColumns.jsx
@@ -1,5 +1,4 @@
 import _clone from "lodash/clone";
-import _each from "lodash/each";
 import _find from "lodash/find";
 import _get from "lodash/get";
 import _isEqual from "lodash/isEqual";
@@ -69,7 +68,8 @@ export default function (
       // allColumns that is not already in the addedColumn list.
       const availableColumns = {};
       let availableColumnsKeys = _pull(_keys(allColumns), ...addedColumnsKeys);
-      _each(availableColumnsKeys, (column) => {
+
+      for (const column of availableColumnsKeys) {
         availableColumns[column] = allColumns[column];
         let message = column;
 
@@ -79,28 +79,24 @@ export default function (
         }
 
         availableColumns[column].message = message;
-      });
+      }
 
       // Next if we are including task properties as columns we need to add those
       if (includeTaskPropertyKeys) {
-        // For all the task property keys we want to add them to the
-        // availableColumns if they are not already in the addedColumns.
-        // As we add them, we indicate they are a task property with a : in
-        // front (this lets us treat them as strings when necessary, such as in
-        // the user settings, but still lets us identify them as task properties).
-        _each(this.props.taskPropertyKeys, (propKey) => {
+        for (const propKey of this.props.taskPropertyKeys) {
           if (!_find(addedColumnsKeys, (k) => k === `:${propKey}`)) {
             // Task Properties get italicized to visually distinguish them
             availableColumns[`:${propKey}`] = {
               message: <span className="mr-italic">{propKey}</span>,
             };
           }
-        });
+        }
       }
 
       // Now we need to internalize the addedColumns as well.
       const addedColumns = {};
-      _each(addedColumnsKeys, (column) => {
+
+      for (const column of addedColumnsKeys) {
         if (allColumns[column]) {
           addedColumns[column] = allColumns[column];
           if (columnMessages[`${column}Label`]) {
@@ -118,7 +114,7 @@ export default function (
             addedColumns[column] = { message: column };
           }
         }
-      });
+      }
 
       // Store our newly setup columns.
       this.setState({ availableColumns, addedColumns });
@@ -156,7 +152,7 @@ export default function (
       // our key, then we will stick the columnKey on the end.
       let keyAdded = false;
 
-      _each(this.state.availableColumns, (value, key) => {
+      for (const [key, value] of Object.entries(this.state.availableColumns)) {
         // If our columnKey to add is not a task property column and we are
         // starting to copy over the :taskPropertyColumns in the list then
         // we insert our new columnKey first before continuing on.
@@ -165,7 +161,7 @@ export default function (
           keyAdded = true;
         }
         newColumns[key] = value;
-      });
+      }
 
       // if !keyAdded then the columnKey didn't get added in the list yet, either
       // because it's a task property column itself or the list doesn't contain
@@ -186,12 +182,12 @@ export default function (
 
       // Fetch the item from the originalIndex
       let savedItem = null;
-      _each(this.state.addedColumns, (column, key) => {
+      for (const [key, column] of Object.entries(this.state.addedColumns)) {
         if (index === originalIndex) {
           savedItem = { key: key, column: column };
         }
         index += 1;
-      });
+      }
 
       // Insert item at new index. To do this we will run through our column
       // list and copy each one to the newColumnMap. If we run across the
@@ -201,7 +197,7 @@ export default function (
       // moving item is being moved up or down.
       const newColumnMap = {};
       index = 0;
-      _each(this.state.addedColumns, (column, key) => {
+      for (const [key, column] of Object.entries(this.state.addedColumns)) {
         if (index === newIndex) {
           // Our item is being moved up in the list.
           if (newIndex < originalIndex) {
@@ -217,7 +213,7 @@ export default function (
           newColumnMap[key] = column;
         }
         index += 1;
-      });
+      }
 
       this.setState({ addedColumns: newColumnMap });
     };

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.jsx
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _isPlainObject from "lodash/isPlainObject";
 import _isString from "lodash/isString";
 import _omit from "lodash/omit";
@@ -310,9 +309,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
     saveTaskTags: (task, tags) => {
       if (task.bundleId) {
         dispatch(fetchTaskBundle(task.bundleId), false).then((taskBundle) => {
-          _each(taskBundle.tasks, (task) => {
+          for (const task of taskBundle.tasks) {
             dispatch(updateTaskTags(task.id, tags));
-          });
+          }
         });
       } else {
         dispatch(updateTaskTags(task.id, tags));

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.jsx
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.jsx
@@ -1,7 +1,6 @@
 import { format } from "date-fns";
 import _cloneDeep from "lodash/cloneDeep";
 import _debounce from "lodash/debounce";
-import _each from "lodash/each";
 import _isEmpty from "lodash/isEmpty";
 import _isEqual from "lodash/isEqual";
 import _keys from "lodash/keys";
@@ -212,7 +211,14 @@ export const WithFilterCriteria = function (
 
       // These values will come in as comma-separated strings and need to be turned
       // into number arrays
-      _each(["status", "reviewStatus", "metaReviewStatus", "priorities", "boundingBox"], (key) => {
+      const keysToSplit = [
+        "status",
+        "reviewStatus",
+        "metaReviewStatus",
+        "priorities",
+        "boundingBox",
+      ];
+      for (const key of keysToSplit) {
         if (criteria[key] !== undefined && key === "boundingBox") {
           if (typeof criteria[key] === "string") {
             criteria[key] = criteria[key].split(",").map((x) => parseFloat(x));
@@ -222,7 +228,7 @@ export const WithFilterCriteria = function (
             criteria.filters[key] = criteria.filters[key].split(",").map((x) => _toInteger(x));
           }
         }
-      });
+      }
 
       if (!criteria?.filters?.status) {
         this.updateIncludedFilters(props);
@@ -249,7 +255,14 @@ export const WithFilterCriteria = function (
 
       // These values will come in as comma-separated strings and need to be turned
       // into number arrays
-      _each(["status", "reviewStatus", "metaReviewStatus", "priorities", "boundingBox"], (key) => {
+      const keysToSplit = [
+        "status",
+        "reviewStatus",
+        "metaReviewStatus",
+        "priorities",
+        "boundingBox",
+      ];
+      for (const key of keysToSplit) {
         if (criteria[key] !== undefined && key === "boundingBox") {
           if (typeof criteria[key] === "string") {
             criteria[key] = criteria[key].split(",").map((x) => parseFloat(x));
@@ -259,7 +272,7 @@ export const WithFilterCriteria = function (
             criteria.filters[key] = criteria.filters[key].split(",").map((x) => _toInteger(x));
           }
         }
-      });
+      }
 
       if (!criteria?.filters?.status) {
         this.updateIncludedFilters(props);

--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.jsx
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.jsx
@@ -1,6 +1,5 @@
 import _assignWith from "lodash/assignWith";
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _fromPairs from "lodash/fromPairs";
 import _isEmpty from "lodash/isEmpty";
@@ -325,7 +324,8 @@ export default function WithFilteredClusteredTasks(
 
       // These values will come in as comma-separated strings and need to be turned
       // into number arrays
-      _each(["status", "reviewStatus", "metaReviewStatus", "priorities"], (key) => {
+      const keysToSplit = ["status", "reviewStatus", "metaReviewStatus", "priorities"];
+      for (const key of keysToSplit) {
         if (criteria?.filters?.[key] !== undefined && !this.props.taskId) {
           if (typeof criteria.filters[key] === "string") {
             criteria.filters[key] = criteria.filters[key].split(",").map((x) => _toInteger(x));
@@ -341,7 +341,7 @@ export default function WithFilteredClusteredTasks(
           }
           loadFromSavedFilters = true;
         }
-      });
+      }
 
       if (useURLFilters || loadFromSavedFilters) {
         const filteredTasks = this.filterTasks(
@@ -362,9 +362,9 @@ export default function WithFilteredClusteredTasks(
             : (initialFilters?.statuses ??
               _fromPairs(_map(TaskStatus, (status) => [status, false])));
 
-        _each(criteria.filters.status, (status) => {
+        for (const status of criteria.filters.status) {
           includeStatuses[status] = true;
-        });
+        }
 
         this.setState(
           Object.assign(

--- a/src/components/HOCs/WithMapBoundedTasks/WithMapBoundedTasks.jsx
+++ b/src/components/HOCs/WithMapBoundedTasks/WithMapBoundedTasks.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _find from "lodash/find";
 import _map from "lodash/map";
@@ -66,7 +65,10 @@ export const WithMapBoundedTasks = function (WrappedComponent, mapType, matchCha
       }
 
       const allowedChallenges = new Set();
-      _each(this.props.challenges, (challenge) => allowedChallenges.add(challenge.id));
+
+      for (const challenge of this.props.challenges) {
+        allowedChallenges.add(challenge.id);
+      }
 
       const filteredTasks = _filter(mapBoundedTasks.tasks, (task) =>
         allowedChallenges.has(task.parentId),

--- a/src/components/HOCs/WithPagedProjects/WithPagedProjects.jsx
+++ b/src/components/HOCs/WithPagedProjects/WithPagedProjects.jsx
@@ -1,5 +1,4 @@
 import _differenceBy from "lodash/differenceBy";
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _find from "lodash/find";
 import _isEmpty from "lodash/isEmpty";
@@ -58,10 +57,7 @@ export default function (
         // Now we want pinned projects first followed by the rest of the sorted projects
         pagedProjects = pinnedProjects.concat(pagedProjects);
       } else {
-        // Otherwise sort by the fuzzy search score. We want to promote high
-        // challenge scores to their parent projects so they show up in an
-        // appropriate place in the list
-        _each(this.props.filteredChallenges, (c) => {
+        for (const c of this.props.filteredChallenges) {
           const parent = _find(
             pagedProjects,
             (p) => p.id === (_isObject(c.parent) ? c.parent.id : c.parent),
@@ -69,7 +65,7 @@ export default function (
           if (parent && (!parent.score || c.score > parent.score)) {
             parent.score = c.score;
           }
-        });
+        }
 
         pagedProjects = _sortBy(pagedProjects, (p) => p.score);
         pagedProjects = _slice(pagedProjects, 0, numberResultsToShow);

--- a/src/components/HOCs/WithPublicWidgetWorkspaces/WithPublicWidgetWorkspaces.jsx
+++ b/src/components/HOCs/WithPublicWidgetWorkspaces/WithPublicWidgetWorkspaces.jsx
@@ -1,5 +1,4 @@
 import _assign from "lodash/assign";
-import _each from "lodash/each";
 import { Component } from "react";
 import { Redirect } from "react-router";
 import { generateWidgetId, widgetDescriptor } from "../../../services/Widget/Widget";
@@ -63,7 +62,7 @@ export const WithPublicWidgetWorkspacesInternal = function (
       // Generate a simple layout if none provided, with one widget per row
       if (configuration.layout.length === 0) {
         let nextY = 0;
-        _each(configuration.widgets, (widgetConf, index) => {
+        for (const [index, widgetConf] of configuration.widgets.entries()) {
           configuration.layout.push({
             i: `${index}`,
             x: 0,
@@ -77,11 +76,11 @@ export const WithPublicWidgetWorkspacesInternal = function (
           });
 
           nextY += widgetConf.defaultHeight;
-        });
+        }
       } else {
         // A layout was provided. If heights and/or widths were omitted or don't meet
         // current minimums, fill them in from the widget descriptors
-        _each(configuration.layout, (widgetLayout, index) => {
+        for (const [index, widgetLayout] of configuration.layout.entries()) {
           if (!configuration.widgets || !configuration.widgets[index]) {
             return;
           }
@@ -105,7 +104,7 @@ export const WithPublicWidgetWorkspacesInternal = function (
           ) {
             widgetLayout.h = descriptor.minHeight;
           }
-        });
+        }
       }
 
       return configuration;

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.jsx
@@ -1,5 +1,4 @@
 import _debounce from "lodash/debounce";
-import _each from "lodash/each";
 import _isEmpty from "lodash/isEmpty";
 import PropTypes from "prop-types";
 import queryString from "query-string";
@@ -159,11 +158,11 @@ export const WithSearchRoute = function (WrappedComponent, searchGroup) {
 
 export const executeRouteSearch = (routeCriteria, searchString) => {
   const searchCriteria = queryString.parse(searchString);
-  _each(searchCriteria, (value, key) => {
+  for (const [key, value] of Object.entries(searchCriteria)) {
     if (routeCriteria[key] && !_isEmpty(value)) {
       routeCriteria[key](value);
     }
-  });
+  }
 };
 
 /**
@@ -177,17 +176,9 @@ export const debouncedUpdateHistory = _debounce(
 );
 
 export const addSearchCriteriaToRoute = (history, newCriteria) => {
-  const searchCriteria = queryString.parse(history.location.search);
-
-  _each(newCriteria, (value, key) => {
-    if (value === undefined) {
-      delete searchCriteria[key];
-    } else {
-      searchCriteria[key] = value;
-    }
-  });
-
-  const newRoute = `${history.location.pathname}?${queryString.stringify(searchCriteria)}`;
+  const oldCriteria = queryString.parse(history.location.search);
+  const newQueryString = queryString.stringify({ ...oldCriteria, ...newCriteria });
+  const newRoute = `${history.location.pathname}?${newQueryString}`;
   debouncedUpdateHistory(history, newRoute);
 };
 
@@ -220,9 +211,9 @@ export const addBoundsToRoute = (history, boundsType, bounds, locationFilter) =>
 export const removeSearchCriteriaFromRoute = (history, criteriaKeys) => {
   const searchCriteria = queryString.parse(history.location.search);
 
-  _each(criteriaKeys, (key) => {
+  for (const key of criteriaKeys) {
     delete searchCriteria[key];
-  });
+  }
 
   const newRoute = `${history.location.pathname}?${queryString.stringify(searchCriteria)}`;
   history.replace(newRoute);

--- a/src/components/HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks.jsx
+++ b/src/components/HOCs/WithSelectedClusteredTasks/WithSelectedClusteredTasks.jsx
@@ -1,5 +1,3 @@
-import _each from "lodash/each";
-import _isEmpty from "lodash/isEmpty";
 import { Component } from "react";
 
 /**
@@ -46,7 +44,11 @@ export default function WithSelectedClusteredTasks(WrappedComponent) {
      * of tasks (or single-task clusters)
      */
     selectTasks = (tasks) => {
-      if (_isEmpty(tasks) || (this.state.allSelected && this.state.deselectedTasks.size === 0)) {
+      if (
+        !tasks ||
+        tasks.length === 0 ||
+        (this.state.allSelected && this.state.deselectedTasks.size === 0)
+      ) {
         // Nothing to do
         return;
       }
@@ -55,9 +57,11 @@ export default function WithSelectedClusteredTasks(WrappedComponent) {
       // otherwise we need to remove from the deselectedTasks map
       if (!this.state.allSelected) {
         const selectedTasks = new Map(this.state.selectedTasks);
-        _each(tasks, (task) => selectedTasks.set(task.id, task));
 
-        // Ensure main task stays selected if present
+        for (const task of tasks) {
+          selectedTasks.set(task.id, task);
+        }
+
         if (this.props.task?.id) {
           selectedTasks.set(this.props.task.id, this.props.task);
         }
@@ -65,11 +69,10 @@ export default function WithSelectedClusteredTasks(WrappedComponent) {
         this.setState({ selectedTasks });
       } else {
         const deselectedTasks = new Map(this.state.deselectedTasks);
-        _each(tasks, (task) => {
-          if (deselectedTasks.has(task.id)) {
-            deselectedTasks.delete(task.id);
-          }
-        });
+
+        for (const task of tasks) {
+          deselectedTasks.delete(task.id);
+        }
 
         // Ensure main task is never in deselected list
         if (this.props.task?.id) {
@@ -85,7 +88,11 @@ export default function WithSelectedClusteredTasks(WrappedComponent) {
      * array of tasks (or single-task clusters)
      */
     deselectTasks = (tasks) => {
-      if (_isEmpty(tasks) || (!this.state.allSelected && this.state.selectedTasks.size === 0)) {
+      if (
+        !tasks ||
+        tasks.length === 0 ||
+        (this.state.allSelected && this.state.deselectedTasks.size === 0)
+      ) {
         // Nothing to do
         return;
       }
@@ -97,15 +104,18 @@ export default function WithSelectedClusteredTasks(WrappedComponent) {
       // otherwise we need to remove from the selectedTasks map
       if (this.state.allSelected) {
         const deselectedTasks = new Map(this.state.deselectedTasks);
-        _each(tasksToDeselect, (task) => deselectedTasks.set(task.id, task));
+
+        for (const task of tasksToDeselect) {
+          deselectedTasks.set(task.id, task);
+        }
+
         this.setState({ deselectedTasks });
       } else {
         const selectedTasks = new Map(this.state.selectedTasks);
-        _each(tasksToDeselect, (task) => {
-          if (selectedTasks.has(task.id)) {
-            selectedTasks.delete(task.id);
-          }
-        });
+
+        for (const task of tasksToDeselect) {
+          selectedTasks.delete(task.id);
+        }
 
         // Ensure main task stays selected
         if (this.props.task?.id) {

--- a/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.jsx
+++ b/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.jsx
@@ -1,5 +1,3 @@
-import _each from "lodash/each";
-import _get from "lodash/get";
 import _isObject from "lodash/isObject";
 import { Component } from "react";
 import AsMappableTask from "../../../interactions/Task/AsMappableTask";
@@ -17,7 +15,7 @@ import { TaskStatus } from "../../../services/Task/TaskStatus/TaskStatus";
 export default function WithTaskMarkers(WrappedComponent, tasksProp = "clusteredTasks") {
   class _WithTaskMarkers extends Component {
     render() {
-      const challengeTasks = _get(this.props, tasksProp);
+      const challengeTasks = this.props[tasksProp];
 
       // Only create markers for allowed statuses OR [created, skipped, or too-hard tasks]
       const allowedStatuses = this.props.allowedStatuses || [
@@ -27,13 +25,9 @@ export default function WithTaskMarkers(WrappedComponent, tasksProp = "clustered
       ];
 
       const markers = [];
-      if (_isObject(challengeTasks)) {
-        if (Array.isArray(challengeTasks.tasks) && challengeTasks.tasks.length > 0) {
-          _each(challengeTasks.tasks, (task) => {
-            if (allowedStatuses.indexOf(task.status) === -1) {
-              return;
-            }
-
+      if (_isObject(challengeTasks) && Array.isArray(challengeTasks.tasks)) {
+        for (const task of challengeTasks.tasks) {
+          if (allowedStatuses.includes(task.status)) {
             const nearestToCenter = AsMappableTask(task).nearestPointToCenter();
             markers.push({
               position: [
@@ -52,7 +46,7 @@ export default function WithTaskMarkers(WrappedComponent, tasksProp = "clustered
                 reviewStatus: task.reviewStatus,
               },
             });
-          });
+          }
         }
       }
 

--- a/src/components/HOCs/WithTaskPropertyKeys/WithTaskPropertyKeys.jsx
+++ b/src/components/HOCs/WithTaskPropertyKeys/WithTaskPropertyKeys.jsx
@@ -10,7 +10,8 @@ import { fetchPropertyKeys } from "../../../services/Challenge/Challenge";
 export const WithTaskPropertyKeys = function (WrappedComponent) {
   return class extends Component {
     state = {
-      taskPropertyKeys: null,
+      taskPropertyKeys: [],
+      loadingPropertyKeys: false,
     };
 
     getTaskPropertyKeys = () => {
@@ -21,15 +22,11 @@ export const WithTaskPropertyKeys = function (WrappedComponent) {
         fetchPropertyKeys(challengeId)
           .then((results) => {
             this.setState({ loadingPropertyKeys: false, taskPropertyKeys: _sortBy(results) });
-            return results;
           })
           .catch((error) => {
             console.log(error);
             this.setState({ loadingPropertyKeys: false, taskPropertyKeys: [] });
           });
-        return [];
-      } else {
-        return [];
       }
     };
 

--- a/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.jsx
+++ b/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.jsx
@@ -130,7 +130,7 @@ export const WithWidgetWorkspacesInternal = function (
       // Generate a simple layout if none provided, with one widget per row
       if (configuration.layout.length === 0) {
         let nextY = 0;
-        configuration.widgets.forEach((widgetConf) => {
+        for (const widgetConf of configuration.widgets) {
           configuration.layout.push({
             i: generateWidgetId(),
             x: 0,
@@ -144,11 +144,11 @@ export const WithWidgetWorkspacesInternal = function (
           });
 
           nextY += widgetConf.defaultHeight;
-        });
+        }
       } else {
         // A layout was provided. If heights and/or widths were omitted or don't meet
         // current minimums, fill them in from the widget descriptors
-        configuration.layout.forEach((widgetLayout, index) => {
+        for (const [index, widgetLayout] of configuration.layout.entries()) {
           if (!configuration.widgets || !configuration.widgets[index]) {
             return;
           }
@@ -172,7 +172,7 @@ export const WithWidgetWorkspacesInternal = function (
           ) {
             widgetLayout.h = descriptor.minHeight;
           }
-        });
+        }
       }
 
       // Make sure workspace is upgraded to latest data model

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -2,7 +2,6 @@ import { differenceInSeconds, parseISO } from "date-fns";
 import _compact from "lodash/compact";
 import _concat from "lodash/concat";
 import _debounce from "lodash/debounce";
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _get from "lodash/get";
 import _isEmpty from "lodash/isEmpty";
@@ -117,10 +116,7 @@ export class TaskAnalysisTableInternal extends Component {
       direction: tableState.sorted[0].desc ? "DESC" : "ASC",
     };
 
-    const filters = {};
-    _each(tableState.filtered, (pair) => {
-      filters[pair.id] = pair.value;
-    });
+    const filters = Object.fromEntries(tableState.filtered.map(({ id, value }) => [id, value]));
 
     this.props.updateCriteria({
       sortCriteria,

--- a/src/components/TaskClusterMap/MapMarkers.jsx
+++ b/src/components/TaskClusterMap/MapMarkers.jsx
@@ -1,6 +1,5 @@
 import _cloneDeep from "lodash/cloneDeep";
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _isEmpty from "lodash/isEmpty";
 import _isEqual from "lodash/isEqual";
@@ -160,14 +159,15 @@ const Markers = (props) => {
     }
 
     const refreshed = new Map();
-    _each(props.taskMarkers, (marker) => {
+
+    for (const marker of props.taskMarkers) {
       if (spidered.has(marker.options.taskId)) {
         refreshed.set(marker.options.taskId, {
           ...spidered.get(marker.options.taskId),
           icon: marker.icon,
         });
       }
-    });
+    }
 
     setSpidered(refreshed);
   };
@@ -220,7 +220,9 @@ const Markers = (props) => {
       centerPointPx,
       CLUSTER_ICON_PIXELS,
     );
-    _each([...updateSpidered.values()], (s) => (s.position = map.layerPointToLatLng(s.positionPx)));
+    for (const s of updateSpidered.values()) {
+      s.position = map.layerPointToLatLng(s.positionPx);
+    }
     setSpidered(updateSpidered);
   };
 

--- a/src/components/TaskHistoryList/TaskHistoryList.jsx
+++ b/src/components/TaskHistoryList/TaskHistoryList.jsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import _each from "lodash/each";
 import _find from "lodash/find";
 import _kebabCase from "lodash/kebabCase";
 import _map from "lodash/map";
@@ -66,116 +65,79 @@ export class TaskHistoryList extends Component {
     let userType = null;
     let errorTags = null;
 
-    _each(
-      _sortBy(this.props.taskHistory, (h) => new Date(h.timestamp)),
-      (log, index) => {
-        // We are moving on to a new set of actions so let's push
-        // this set of entries
-        if (
-          lastTimestamp !== null &&
-          (entries.length > 0 || startedAtEntry) &&
-          Math.abs(new Date(log.timestamp) - lastTimestamp) > 1000
-        ) {
-          combinedLogs.push({
-            timestamp: lastTimestamp,
-            duration: duration,
-            entry: entries,
-            username: username,
-            status: updatedStatus,
-            userType: userType,
-            errorTags: errorTags,
-          });
-          if (startedAtEntry) {
-            combinedLogs.push(startedAtEntry);
-            startedAtEntry = null;
-          }
-          entries = [];
-          updatedStatus = null;
-          duration = null;
-          userType = null;
-          errorTags = null;
+    const sortedLogs = _sortBy(this.props.taskHistory, (h) => new Date(h.timestamp));
+    for (const [index, log] of sortedLogs.entries()) {
+      // We are moving on to a new set of actions so let's push
+      // this set of entries
+      if (
+        lastTimestamp !== null &&
+        (entries.length > 0 || startedAtEntry) &&
+        Math.abs(new Date(log.timestamp) - lastTimestamp) > 1000
+      ) {
+        combinedLogs.push({
+          timestamp: lastTimestamp,
+          duration: duration,
+          entry: entries,
+          username: username,
+          status: updatedStatus,
+          userType: userType,
+          errorTags: errorTags,
+        });
+        if (startedAtEntry) {
+          combinedLogs.push(startedAtEntry);
+          startedAtEntry = null;
         }
-        lastTimestamp = new Date(log.timestamp);
+        entries = [];
+        updatedStatus = null;
+        duration = null;
+        userType = null;
+        errorTags = null;
+      }
+      lastTimestamp = new Date(log.timestamp);
 
-        switch (log.actionType) {
-          case TaskHistoryAction.comment:
-            logEntry = commentEntry(log, this.props, index);
-            username = log?.user?.username;
-            break;
-          case TaskHistoryAction.review:
-          case TaskHistoryAction.metaReview:
-            if (log.reviewStatus === TaskReviewStatus.needed) {
-              username =
-                TaskHistoryAction.review === log.actionType
-                  ? log?.reviewRequestedBy?.username
-                  : log?.metaReviewRequestedBy?.username;
-              logEntry = reviewEntry(log, this.props, index);
-            } else {
-              logEntry = null;
-              const isMetaReview = log.actionType === TaskHistoryAction.metaReview;
-              updatedStatus = (
-                <ReviewStatusLabel
-                  {...this.props}
-                  isMetaReview={isMetaReview}
-                  intlMessage={
-                    isMetaReview
-                      ? messagesByMetaReviewStatus[log.reviewStatus]
-                      : messagesByReviewStatus[log.reviewStatus]
-                  }
-                  className={`mr-review-${_kebabCase(keysByReviewStatus[log.reviewStatus])}`}
-                  showDot
-                />
-              );
-              username =
-                log.reviewStatus === TaskReviewStatus.disputed ||
-                log.reviewStatus === TaskReviewStatus.needed
-                  ? log?.reviewRequestedBy?.username
-                  : log?.reviewedBy?.username;
-              userType =
-                log.actionType === TaskHistoryAction.metaReview
-                  ? META_REVIEWER_TYPE
-                  : REVIEWER_TYPE;
-              errorTags = log.errorTags;
-              if (log.startedAt) {
-                duration = new Date(log.timestamp) - new Date(log.startedAt);
-
-                //add an additional entry for when review was started
-                const startedReviewAtEntry = {
-                  timestamp: log.startedAt,
-                  ignoreAtticOffset: true,
-                  entry: [
-                    <li className="mr-mb-4" key={"start-" + index}>
-                      <div>
-                        <span
-                          className="mr-mr-2"
-                          style={{ color: AsColoredHashable(username).hashColor }}
-                        >
-                          {username}
-                        </span>{" "}
-                        <FormattedMessage {...messages.startedReviewOnLabel} />
-                      </div>
-                    </li>,
-                  ],
-                };
-
-                combinedLogs.push(startedReviewAtEntry);
-              }
-            }
-            break;
-          case TaskHistoryAction.update:
-            logEntry = updateEntry(log, this.props, index);
-            username = log?.user?.username;
-            break;
-          case TaskHistoryAction.status:
-          default:
+      switch (log.actionType) {
+        case TaskHistoryAction.comment:
+          logEntry = commentEntry(log, this.props, index);
+          username = log?.user?.username;
+          break;
+        case TaskHistoryAction.review:
+        case TaskHistoryAction.metaReview:
+          if (log.reviewStatus === TaskReviewStatus.needed) {
+            username =
+              TaskHistoryAction.review === log.actionType
+                ? log?.reviewRequestedBy?.username
+                : log?.metaReviewRequestedBy?.username;
+            logEntry = reviewEntry(log, this.props, index);
+          } else {
             logEntry = null;
-            username = log?.user?.username;
-            userType = MAPPER_TYPE;
-            updatedStatus = statusEntry(log, this.props, index);
-            if (log.startedAt || log.oldStatus === TASK_STATUS_CREATED) {
-              // Add a "Started At" entry into the history
-              startedAtEntry = {
-                timestamp: log.startedAt || log.timestamp,
+            const isMetaReview = log.actionType === TaskHistoryAction.metaReview;
+            updatedStatus = (
+              <ReviewStatusLabel
+                {...this.props}
+                isMetaReview={isMetaReview}
+                intlMessage={
+                  isMetaReview
+                    ? messagesByMetaReviewStatus[log.reviewStatus]
+                    : messagesByReviewStatus[log.reviewStatus]
+                }
+                className={`mr-review-${_kebabCase(keysByReviewStatus[log.reviewStatus])}`}
+                showDot
+              />
+            );
+            username =
+              log.reviewStatus === TaskReviewStatus.disputed ||
+              log.reviewStatus === TaskReviewStatus.needed
+                ? log?.reviewRequestedBy?.username
+                : log?.reviewedBy?.username;
+            userType =
+              log.actionType === TaskHistoryAction.metaReview ? META_REVIEWER_TYPE : REVIEWER_TYPE;
+            errorTags = log.errorTags;
+            if (log.startedAt) {
+              duration = new Date(log.timestamp) - new Date(log.startedAt);
+
+              //add an additional entry for when review was started
+              const startedReviewAtEntry = {
+                timestamp: log.startedAt,
                 ignoreAtticOffset: true,
                 entry: [
                   <li className="mr-mb-4" key={"start-" + index}>
@@ -186,21 +148,54 @@ export class TaskHistoryList extends Component {
                       >
                         {username}
                       </span>{" "}
-                      <FormattedMessage {...messages.startedOnLabel} />
+                      <FormattedMessage {...messages.startedReviewOnLabel} />
                     </div>
                   </li>,
                 ],
               };
-            }
 
-            if (log.startedAt) {
-              duration = new Date(log.timestamp) - new Date(log.startedAt);
+              combinedLogs.push(startedReviewAtEntry);
             }
-            break;
-        }
-        entries.unshift(logEntry);
-      },
-    );
+          }
+          break;
+        case TaskHistoryAction.update:
+          logEntry = updateEntry(log, this.props, index);
+          username = log?.user?.username;
+          break;
+        case TaskHistoryAction.status:
+        default:
+          logEntry = null;
+          username = log?.user?.username;
+          userType = MAPPER_TYPE;
+          updatedStatus = statusEntry(log, this.props, index);
+          if (log.startedAt || log.oldStatus === TASK_STATUS_CREATED) {
+            // Add a "Started At" entry into the history
+            startedAtEntry = {
+              timestamp: log.startedAt || log.timestamp,
+              ignoreAtticOffset: true,
+              entry: [
+                <li className="mr-mb-4" key={"start-" + index}>
+                  <div>
+                    <span
+                      className="mr-mr-2"
+                      style={{ color: AsColoredHashable(username).hashColor }}
+                    >
+                      {username}
+                    </span>{" "}
+                    <FormattedMessage {...messages.startedOnLabel} />
+                  </div>
+                </li>,
+              ],
+            };
+          }
+
+          if (log.startedAt) {
+            duration = new Date(log.timestamp) - new Date(log.startedAt);
+          }
+          break;
+      }
+      entries.unshift(logEntry);
+    }
 
     if (entries.length > 0) {
       combinedLogs.push({
@@ -219,7 +214,8 @@ export class TaskHistoryList extends Component {
     }
 
     const contributors = [];
-    _each(combinedLogs, (log) => {
+
+    for (const log of combinedLogs) {
       // Don't add a contributor twice
       if (
         log.userType &&
@@ -227,7 +223,7 @@ export class TaskHistoryList extends Component {
       ) {
         contributors.push(log);
       }
-    });
+    }
 
     const contributorEntries = (
       <ol className="mr-list-decimal mr-pl-4">

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -345,39 +345,39 @@ export class ActiveTaskControls extends Component {
         ? this.props.getUserAppSetting(this.props.user, "isEditMode")
         : false;
       if (!_isEmpty(this.props.activeKeyboardShortcuts?.[hiddenShortcutGroup]) && editMode) {
-        hiddenShortcuts.forEach((shortcut) => {
+        for (const shortcut of hiddenShortcuts) {
           this.props.deactivateKeyboardShortcut(
             hiddenShortcutGroup,
             shortcut,
             this.handleKeyboardShortcuts,
           );
-        });
+        }
       } else if (
         _isEmpty(this.props.activeKeyboardShortcuts?.[hiddenShortcutGroup]) &&
         this.props.keyboardShortcutGroups &&
         this.props.activateKeyboardShortcut &&
         !editMode
       ) {
-        hiddenShortcuts.forEach((shortcut) => {
+        for (const shortcut of hiddenShortcuts) {
           this.props.activateKeyboardShortcut(
             hiddenShortcutGroup,
             _pick(this.props.keyboardShortcutGroups.taskCompletion, shortcut),
             this.handleKeyboardShortcuts,
           );
-        });
+        }
       }
     }
   }
 
   componentWillUnmount() {
     if (!_isEmpty(this.props.activeKeyboardShortcuts?.[hiddenShortcutGroup])) {
-      hiddenShortcuts.forEach((shortcut) => {
+      for (const shortcut of hiddenShortcuts) {
         this.props.deactivateKeyboardShortcut(
           hiddenShortcutGroup,
           shortcut,
           this.handleKeyboardShortcuts,
         );
-      });
+      }
     }
   }
 

--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -5,7 +5,6 @@ import classNames from "classnames";
 import L from "leaflet";
 import _clone from "lodash/clone";
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _flatten from "lodash/flatten";
 import _isEmpty from "lodash/isEmpty";
 import _isObject from "lodash/isObject";
@@ -193,7 +192,8 @@ export const TaskMapContent = (props) => {
         // multiple features in a layer could match. Detect them and then
         // put them into an intuitive order
         const intraLayerMatches = [];
-        _each(layer._layers, (featureLayer) => {
+
+        for (const featureLayer of Object.values(layer._layers)) {
           if (featureLayer.toGeoJSON) {
             const featureGeojson = featureLayer.toGeoJSON();
             // Look for an overlap between the click and the feature. However, since marker
@@ -230,7 +230,7 @@ export const TaskMapContent = (props) => {
               });
             }
           }
-        });
+        }
 
         if (intraLayerMatches.length > 0) {
           for (const match of orderedFeatureLayers(intraLayerMatches)) {
@@ -465,9 +465,9 @@ export const TaskMapContent = (props) => {
   const generateDirectionalityMarkers = () => {
     const markers = [];
     const allFeatures = features;
-    _each(allFeatures, (feature, featureIndex) => {
+    for (const [featureIndex, feature] of allFeatures.entries()) {
       if (!feature.properties || !feature.properties.oneway) {
-        return;
+        continue;
       }
 
       const styles = AsSimpleStyleableFeature(
@@ -498,7 +498,7 @@ export const TaskMapContent = (props) => {
           );
         }
       }
-    });
+    }
 
     setDirectionalityIndicators({
       id: "directionality-indicators",

--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -233,9 +233,9 @@ export const TaskMapContent = (props) => {
         });
 
         if (intraLayerMatches.length > 0) {
-          orderedFeatureLayers(intraLayerMatches).forEach((match) => {
+          for (const match of orderedFeatureLayers(intraLayerMatches)) {
             candidateLayers.set(match.description, match);
-          });
+          }
         }
       }
     });

--- a/src/components/TaskPropertyQueryBuilder/TaskPropertyRules.js
+++ b/src/components/TaskPropertyQueryBuilder/TaskPropertyRules.js
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _slice from "lodash/slice";
 import _values from "lodash/values";
@@ -276,11 +275,11 @@ export const validatePropertyRules = (rule, errors = []) => {
         }
 
         if (rule.valueType === "number") {
-          _each(rule.value, (v) => {
+          for (const v of Array.isArray(rule.value) ? rule.value : [rule.value]) {
             if (isNaN(v)) {
               errors.push(PROPERTY_RULE_ERRORS.notNumericValue);
             }
-          });
+          }
         }
       }
     }

--- a/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.jsx
+++ b/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.jsx
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _remove from "lodash/remove";
 import { Component, createRef } from "react";
 import { FormattedMessage } from "react-intl";
@@ -63,7 +62,7 @@ export default class TaskHistoryWidget extends Component {
     let earliestDate = null;
     const usernames = [];
 
-    _each(this.props.task.history, (log) => {
+    for (const log of this.props.task.history) {
       if (!earliestDate || log.timestamp < earliestDate) {
         earliestDate = log.timestamp;
       }
@@ -72,7 +71,7 @@ export default class TaskHistoryWidget extends Component {
       if (username && usernames.indexOf(username) === -1) {
         usernames.push(username);
       }
-    });
+    }
 
     viewOSMCha(this.bbox(), earliestDate, usernames);
   };

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -92,11 +92,11 @@ export class AsMappableTask {
 
     let allProperties = {};
 
-    features.forEach((feature) => {
+    for (const feature of features) {
       if (feature?.properties) {
         allProperties = Object.assign(allProperties, feature.properties);
       }
-    });
+    }
 
     return allProperties;
   }
@@ -117,11 +117,11 @@ export class AsMappableTask {
 
     let allProperties = [];
 
-    features.forEach((feature) => {
+    for (const feature of features) {
       if (feature?.properties) {
         allProperties.push(feature);
       }
-    });
+    }
 
     return allProperties;
   }

--- a/src/interactions/TaskCluster/AsSpiderableMarkers.js
+++ b/src/interactions/TaskCluster/AsSpiderableMarkers.js
@@ -1,6 +1,5 @@
 import { Point } from "leaflet";
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 
 const MAX_CIRCLE_MARKERS = 8;
 const CIRCLE_START_ANGLE = (Math.PI * 2) / 12;
@@ -31,7 +30,7 @@ export class AsSpiderableMarkers {
     const legLengthPx = circumferencePx / (Math.PI * 2); // radius from circumference
     const angleStep = (Math.PI * 2) / affectedMarkers.length;
 
-    _each(affectedMarkers, (marker, index) => {
+    for (const [index, marker] of affectedMarkers.entries()) {
       const relocatedMarker = _cloneDeep(marker);
       const angle = CIRCLE_START_ANGLE + index * angleStep;
       relocatedMarker.originalPosition = relocatedMarker.position;
@@ -40,7 +39,7 @@ export class AsSpiderableMarkers {
         centerPointPx.y + legLengthPx * Math.sin(angle),
       );
       spideredMarkers.set(relocatedMarker.options.taskId, relocatedMarker);
-    });
+    }
 
     return spideredMarkers;
   }
@@ -51,7 +50,7 @@ export class AsSpiderableMarkers {
     let legLengthPx = SPIRAL_LENGTH_START;
     let angle = 0;
 
-    _each(affectedMarkers, (marker, index) => {
+    for (const [index, marker] of affectedMarkers.entries()) {
       const relocatedMarker = _cloneDeep(marker);
       angle += SPIRAL_FOOT_SEPARATION / legLengthPx + index * 0.0005;
       relocatedMarker.originalPosition = relocatedMarker.position;
@@ -61,7 +60,7 @@ export class AsSpiderableMarkers {
       );
       legLengthPx += Math.PI * 2 * (SPIRAL_LENGTH_FACTOR / angle);
       spideredMarkers.set(relocatedMarker.options.taskId, relocatedMarker);
-    });
+    }
 
     return spideredMarkers;
   }

--- a/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
+++ b/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
@@ -2,7 +2,6 @@ import L from "leaflet";
 import "leaflet-vectoricon";
 import { getType } from "@turf/invariant";
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _flatten from "lodash/flatten";
 import _fromPairs from "lodash/fromPairs";
@@ -140,9 +139,9 @@ export class AsSimpleStyleableFeature {
       return;
     }
 
-    _each(lineStyles, (styleValue, styleName) => {
+    for (const [styleName, styleValue] of Object.entries(lineStyles)) {
       layer.setStyle({ [simplestyleLineToLeafletMapping[styleName]]: styleValue });
-    });
+    }
   }
 
   /**
@@ -177,7 +176,7 @@ export class AsSimpleStyleableFeature {
 
     let useCustomMarker = false;
 
-    _each(pointStyles, (styleValue, styleName) => {
+    for (const [styleName, styleValue] of Object.entries(pointStyles)) {
       switch (styleName) {
         case "marker-color":
           useCustomMarker = true;
@@ -206,7 +205,7 @@ export class AsSimpleStyleableFeature {
         default:
           break;
       }
-    });
+    }
 
     // If the layer already has one of our svg markers, make sure to clean it
     // up or else Leaflet has a tendencey to render dup markers

--- a/src/interactions/User/AsManager.js
+++ b/src/interactions/User/AsManager.js
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _filter from "lodash/filter";
 import _isObject from "lodash/isObject";
 import _map from "lodash/map";
@@ -142,20 +141,23 @@ export class AsManager extends AsEndUser {
 
     const projectChallenges = new Set();
 
-    _each(challenges, (challenge) => {
+    for (const challenge of challenges) {
       // handle both normalized and denormalized challenges
       if (projectIds.indexOf(challenge?.parent?.id ?? challenge.parent) !== -1) {
         projectChallenges.add(challenge);
       }
 
-      _each(challenge.virtualParents, (vp) => {
-        if (projectIds.indexOf(_isObject(vp) ? vp.id : vp) !== -1) {
-          if (!projectChallenges.has(challenge)) {
-            projectChallenges.add(challenge);
+      if (challenge.virtualParents) {
+        for (const vp of challenge.virtualParents) {
+          if (projectIds.indexOf(_isObject(vp) ? vp.id : vp) !== -1) {
+            if (!projectChallenges.has(challenge)) {
+              projectChallenges.add(challenge);
+            }
           }
         }
-      });
-    });
+      }
+    }
+
     return [...projectChallenges];
   }
 

--- a/src/pages/Inbox/Inbox.jsx
+++ b/src/pages/Inbox/Inbox.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import Fuse from "fuse.js";
-import _each from "lodash/each";
 import _kebabCase from "lodash/kebabCase";
 import _map from "lodash/map";
 import _reject from "lodash/reject";
@@ -249,13 +248,13 @@ const columns = (tableProps) => [
         </option>,
       ];
 
-      _each(NotificationType, (type) => {
+      for (const [name, value] of Object.entries(NotificationType)) {
         options.push(
-          <option key={keysByNotificationType[type]} value={type}>
-            {tableProps.intl.formatMessage(messagesByNotificationType[type])}
+          <option key={name} value={value}>
+            {tableProps.intl.formatMessage(messagesByNotificationType[value])}
           </option>,
         );
-      });
+      }
 
       return (
         <select

--- a/src/pages/Inbox/NotificationHooks.js
+++ b/src/pages/Inbox/NotificationHooks.js
@@ -1,4 +1,3 @@
-import _each from "lodash/each";
 import _find from "lodash/find";
 import _groupBy from "lodash/groupBy";
 import _map from "lodash/map";
@@ -39,9 +38,13 @@ export const useNotificationSelection = (notifications) => {
       const targetNotifications = Array.isArray(thread) ? thread : [notification];
       const updatedSelections = new Set(selectedNotifications);
       if (allNotificationsInThreadSelected(targetNotifications)) {
-        _each(targetNotifications, (target) => updatedSelections.delete(target.id));
+        for (const target of targetNotifications) {
+          updatedSelections.delete(target.id);
+        }
       } else {
-        _each(targetNotifications, (target) => updatedSelections.add(target.id));
+        for (const target of targetNotifications) {
+          updatedSelections.add(target.id);
+        }
       }
 
       setSelectedNotifications(updatedSelections);

--- a/src/pages/Inbox/NotificationHooks.js
+++ b/src/pages/Inbox/NotificationHooks.js
@@ -5,11 +5,11 @@ import _map from "lodash/map";
 import { useCallback, useMemo, useState } from "react";
 
 export const useNotificationSelection = (notifications) => {
-  notifications.forEach((notification) => {
+  for (const notification of notifications) {
     if (!notification.taskId && notification.challengeId) {
       notification.taskId = notification.challengeName;
     }
-  });
+  }
 
   const [groupByTask, setGroupByTask] = useState(true);
   const [selectedNotifications, setSelectedNotifications] = useState(new Set());

--- a/src/pages/Profile/UserSettings/NotificationSettingsSchema.jsx
+++ b/src/pages/Profile/UserSettings/NotificationSettingsSchema.jsx
@@ -93,11 +93,10 @@ export const jsSchema = (intl) => {
 
   // items are generated as array from all subscription and count types
   const notificationObject = {};
-  items
-    .filter((item) => Boolean(item.name))
-    .forEach((item) => {
-      notificationObject[item.name] = item;
-    });
+
+  for (const item of items.filter((item) => Boolean(item.name))) {
+    notificationObject[item.name] = item;
+  }
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",

--- a/src/pages/Profile/UserSettings/UserSettings.jsx
+++ b/src/pages/Profile/UserSettings/UserSettings.jsx
@@ -2,8 +2,6 @@ import Form from "@rjsf/core";
 import _cloneDeep from "lodash/cloneDeep";
 import _countBy from "lodash/countBy";
 import _debounce from "lodash/debounce";
-import _each from "lodash/each";
-import _find from "lodash/find";
 import _findLastIndex from "lodash/findLastIndex";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
@@ -84,16 +82,16 @@ class UserSettings extends Component {
       // matching new mappings with the server generated id.
       if (updatedUser?.settings?.customBasemaps) {
         const serverBasemaps = updatedUser?.settings?.customBasemaps;
-        _each(settingsFormData.customBasemaps, (basemap) => {
-          if (
-            !basemap.id &&
-            !_isEmpty(basemap.url) &&
-            !_isEmpty(basemap.name) &&
-            _find(serverBasemaps, (m) => m.name === basemap.name)
-          ) {
-            basemap.id = _find(serverBasemaps, (m) => m.name === basemap.name).id;
+
+        if (settingsFormData.customBasemaps) {
+          for (const basemap of settingsFormData.customBasemaps) {
+            let serverBasemap = serverBasemaps?.find((m) => m.name === basemap.name);
+
+            if (!basemap.id && !_isEmpty(basemap.url) && !_isEmpty(basemap.name) && serverBasemap) {
+              basemap.id = serverBasemap.id;
+            }
           }
-        });
+        }
       }
 
       // Save the customBasemaps frmo the server in state so we we can match
@@ -132,7 +130,7 @@ class UserSettings extends Component {
   validate = (formData, errors) => {
     // Validates that all custom basemap names are unique.
     const basemapNames = _countBy(formData.customBasemaps, (bm) => bm.name);
-    _each(basemapNames, (count, name) => {
+    for (const [name, count] of Object.entries(basemapNames)) {
       if (count > 1) {
         const badIndex = _findLastIndex(formData.customBasemaps, (bm) => bm.name === name);
         if (errors.customBasemaps[badIndex]) {
@@ -141,7 +139,7 @@ class UserSettings extends Component {
           );
         }
       }
-    });
+    }
 
     return errors;
   };

--- a/src/pages/Profile/UserSettings/UserSettings.jsx
+++ b/src/pages/Profile/UserSettings/UserSettings.jsx
@@ -63,11 +63,11 @@ class UserSettings extends Component {
         editableUser.customBasemaps,
         (data) => _isEmpty(_trim(data.name)) || _isEmpty(_trim(data.url)),
       );
-      editableUser.customBasemaps.forEach((data) => {
+      for (const data of editableUser.customBasemaps) {
         if (!data.id) {
           data.id = -1;
         }
-      });
+      }
     }
 
     editableUser.normalizeDefaultBasemap(LayerSources, editableUser.customBasemaps);

--- a/src/pages/Review/TasksReview/TasksReviewTable.jsx
+++ b/src/pages/Review/TasksReview/TasksReviewTable.jsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import { parseISO } from "date-fns";
 import _cloneDeep from "lodash/cloneDeep";
 import _debounce from "lodash/debounce";
-import _each from "lodash/each";
 import _isEqual from "lodash/isEqual";
 import _isObject from "lodash/isObject";
 import _kebabCase from "lodash/kebabCase";
@@ -102,10 +101,7 @@ export class TaskReviewTable extends Component {
       direction: tableState.sorted[0].desc ? "DESC" : "ASC",
     };
 
-    const filters = {};
-    _each(tableState.filtered, (pair) => {
-      filters[pair.id] = pair.value;
-    });
+    const filters = Object.fromEntries(tableState.filtered.map(({ id, value }) => [id, value]));
 
     // Determine if we can search by challenge Id or do name search
     if (filters.challenge) {
@@ -836,15 +832,15 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
         </option>,
       ];
 
-      _each(TaskStatus, (status) => {
-        if (isReviewableStatus(status)) {
+      for (const [name, value] of Object.entries(TaskStatus)) {
+        if (isReviewableStatus(value)) {
           options.push(
-            <option key={keysByStatus[status]} value={status}>
-              {props.intl.formatMessage(messagesByStatus[status])}
+            <option key={name} value={value}>
+              {props.intl.formatMessage(messagesByStatus[value])}
             </option>,
           );
         }
-      });
+      }
 
       return (
         <select
@@ -884,13 +880,13 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
         </option>,
       ];
 
-      _each(TaskPriority, (priority) => {
+      for (const [name, value] of Object.entries(TaskPriority)) {
         options.push(
-          <option key={keysByPriority[priority]} value={priority}>
-            {props.intl.formatMessage(messagesByPriority[priority])}
+          <option key={name} value={value}>
+            {props.intl.formatMessage(messagesByPriority[value])}
           </option>,
         );
-      });
+      }
 
       return (
         <select
@@ -1266,19 +1262,19 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
       ];
 
       if (props.reviewTasksType === ReviewTasksType.metaReviewTasks) {
-        _each([TaskReviewStatus.approved, TaskReviewStatus.approvedWithFixes], (status) =>
+        for (const status of [TaskReviewStatus.approved, TaskReviewStatus.approvedWithFixes]) {
           options.push(
             <option key={keysByReviewStatus[status]} value={status}>
               {props.intl.formatMessage(messagesByReviewStatus[status])}
             </option>,
-          ),
-        );
+          );
+        }
       } else if (
         props.reviewTasksType === ReviewTasksType.reviewedByMe ||
         props.reviewTasksType === ReviewTasksType.myReviewedTasks ||
         props.reviewTasksType === ReviewTasksType.allReviewedTasks
       ) {
-        _each(TaskReviewStatus, (status) => {
+        for (const status of Object.values(TaskReviewStatus)) {
           if (status !== TaskReviewStatus.unnecessary) {
             options.push(
               <option key={keysByReviewStatus[status]} value={status}>
@@ -1286,9 +1282,9 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
               </option>,
             );
           }
-        });
+        }
       } else {
-        _each(TaskReviewStatus, (status) => {
+        for (const status of Object.values(TaskReviewStatus)) {
           if (isNeedsReviewStatus(status)) {
             options.push(
               <option key={keysByReviewStatus[status]} value={status}>
@@ -1296,7 +1292,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
               </option>,
             );
           }
-        });
+        }
       }
 
       return (
@@ -1363,7 +1359,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
             {props.intl.formatMessage(messages.metaUnreviewed)}
           </option>,
         );
-        _each(TaskReviewStatus, (status) => {
+        for (const status of Object.values(TaskReviewStatus)) {
           if (status !== TaskReviewStatus.unnecessary && isMetaReviewStatus(status)) {
             options.push(
               <option key={keysByReviewStatus[status]} value={status}>
@@ -1371,7 +1367,7 @@ export const setupColumnTypes = (props, openComments, data, criteria) => {
               </option>,
             );
           }
-        });
+        }
       }
 
       return (

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -3,7 +3,6 @@ import geojsontoosm from "geojsontoosm";
 import _clone from "lodash/clone";
 import _cloneDeep from "lodash/cloneDeep";
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _flatten from "lodash/flatten";
 import _fromPairs from "lodash/fromPairs";
 import _groupBy from "lodash/groupBy";
@@ -181,11 +180,13 @@ export const challengeResultEntity = function (normalizedChallengeResults) {
  * Add or update challenge data in the redux store
  */
 export const receiveChallenges = function (normalizedEntities, status = RequestStatus.success) {
-  _each(normalizedEntities.challenges, (c) => {
-    if (c.dataOriginDate) {
-      c.dataOriginDate = format(parseISO(c.dataOriginDate), "yyyy-MM-dd");
+  if (normalizedEntities.challenges) {
+    for (const c of Object.values(normalizedEntities.challenges)) {
+      if (c.dataOriginDate) {
+        c.dataOriginDate = format(parseISO(c.dataOriginDate), "yyyy-MM-dd");
+      }
     }
-  });
+  }
 
   return {
     type: RECEIVE_CHALLENGES,
@@ -253,9 +254,17 @@ export const fetchPreferredChallenges = function (limit = RESULTS_PER_PAGE) {
         const result = normalizedResults.result;
         const challenges = normalizedResults.entities.challenges;
 
-        _each(result.popular, (challenge) => (challenges[challenge].popular = true));
-        _each(result.newest, (challenge) => (challenges[challenge].newest = true));
-        _each(result.featured, (challenge) => (challenges[challenge].featured = true));
+        for (const challenge of result.popular) {
+          challenges[challenge].popular = true;
+        }
+
+        for (const challenge of result.newest) {
+          challenges[challenge].newest = true;
+        }
+
+        for (const challenge of result.featured) {
+          challenges[challenge].featured = true;
+        }
 
         dispatch(receiveChallenges(normalizedResults.entities));
 
@@ -854,13 +863,11 @@ export const fetchChallenges = function (challengeIds, suppressReceive = false) 
     })
       .execute()
       .then((normalizedResults) => {
-        // If a challenge has no virtual parents then the field will not be set
-        // by server, so we need to indicate it's empty
-        _each(normalizedResults.entities.challenges, (challenge) => {
+        for (const challenge of normalizedResults.entities.challenges) {
           if (challenge.virtualParents === undefined) {
             challenge.virtualParents = [];
           }
-        });
+        }
 
         if (!suppressReceive) {
           dispatch(receiveChallenges(normalizedResults.entities));

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -1212,9 +1212,9 @@ export const moveChallenges = function (challengeIds, toProjectId) {
     })
       .execute()
       .then(() => {
-        challengeIds.forEach((id) => {
+        for (const id of challengeIds) {
           fetchChallenge(id)(dispatch);
-        });
+        }
       })
       .catch((error) => {
         if (isSecurityError(error)) {
@@ -1376,7 +1376,7 @@ const removeChallengeKeywords = function (challengeId, oldKeywords = []) {
 const reduceChallengesFurther = function (mergedState, oldState, challengeEntities) {
   // The generic reduction will merge arrays and objects, but for some fields
   // we want to simply overwrite with the latest data.
-  challengeEntities.forEach((entity) => {
+  for (const entity of challengeEntities) {
     // Until we implement undelete, ignore deleted challenges.
     if (entity.deleted) {
       delete mergedState[entity.id];
@@ -1414,7 +1414,7 @@ const reduceChallengesFurther = function (mergedState, oldState, challengeEntiti
     if (Array.isArray(entity.presets)) {
       mergedState[entity.id].presets = entity.presets;
     }
-  });
+  }
 };
 
 // redux reducers

--- a/src/services/Challenge/ChallengeLocation/ChallengeLocation.js
+++ b/src/services/Challenge/ChallengeLocation/ChallengeLocation.js
@@ -1,6 +1,5 @@
 import bbox from "@turf/bbox";
 import _concat from "lodash/concat";
-import _each from "lodash/each";
 import _fromPairs from "lodash/fromPairs";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";
@@ -49,13 +48,14 @@ export const challengePassesLocationFilter = function (challengeFilters, challen
 
   // Or if the challenge is listed in the TaskClusters or in the Map Bounded Tasks
   let validChallenges = [];
-  _each(props.mapBoundedTasks?.tasks, (task) => {
-    validChallenges = _concat(validChallenges, task.parentId);
-  });
 
-  _each(props.taskClusters?.clusters, (cluster) => {
+  for (const task of props.mapBoundedTasks?.tasks) {
+    validChallenges = _concat(validChallenges, task.parentId);
+  }
+
+  for (const cluster of props.taskClusters?.clusters) {
     validChallenges = _concat(validChallenges, cluster.challengeIds);
-  });
+  }
 
   if (validChallenges.indexOf(challenge.id) > -1) {
     return true;

--- a/src/services/Challenge/CooperativeType/CooperativeType.test.js
+++ b/src/services/Challenge/CooperativeType/CooperativeType.test.js
@@ -11,10 +11,10 @@ describe("isCooperative", () => {
   });
 
   test("returns true for valid, active types", () => {
-    _values(CooperativeType).forEach((cooperativeType) => {
+    for (const cooperativeType of Object.values(CooperativeType)) {
       if (cooperativeType !== CooperativeType.none) {
         expect(isCooperative(cooperativeType)).toBe(true);
       }
-    });
+    }
   });
 });

--- a/src/services/Challenge/CooperativeType/CooperativeType.test.js
+++ b/src/services/Challenge/CooperativeType/CooperativeType.test.js
@@ -1,4 +1,3 @@
-import _values from "lodash/values";
 import { CooperativeType, isCooperative } from "./CooperativeType";
 
 describe("isCooperative", () => {

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -351,7 +351,7 @@ export const osmObjectParams = function (
 ) {
   const allTasks = Array.isArray(task) ? task : [task];
   let objects = [];
-  allTasks.forEach((task) => {
+  for (const task of allTasks) {
     if (task.geometries?.features) {
       objects = objects.concat(
         _compact(
@@ -395,7 +395,7 @@ export const osmObjectParams = function (
         ),
       );
     }
-  });
+  }
 
   return objects.join(joinSeparator);
 };
@@ -663,7 +663,9 @@ export const sendJOSMCommand = function (uri) {
 const executeJOSMBatch = async function (commands, transmissionDelay = 1000) {
   // For Safari we execute all the commands immediately
   if (window.safari) {
-    commands.forEach((command) => command());
+    for (const command of commands) {
+      command();
+    }
     return;
   }
 

--- a/src/services/Mapillary/Mapillary.js
+++ b/src/services/Mapillary/Mapillary.js
@@ -115,14 +115,14 @@ export const nextMapillaryPageUrl = function (resultContext) {
       console.log("Link Header:", linkHeader);
 
       if (linkHeader) {
-        linkHeader.split(",").forEach((link) => {
+        for (const link of linkHeader.split(",")) {
           const match = link.match(/<([^>]+)>\s*rel="([^"]+)"/);
           if (match) {
             const url = match[1];
             const rel = match[2];
             links[rel] = { url };
           }
-        });
+        }
       }
 
       console.log("Parsed Links:", links);

--- a/src/services/OSM/OSM.test.jsx
+++ b/src/services/OSM/OSM.test.jsx
@@ -45,9 +45,9 @@ describe("OSM Service Functions", () => {
         { username: "", expected: `${baseURL}/user/` },
       ];
 
-      testCases.forEach(({ username, expected }) => {
+      for (const { username, expected } of testCases) {
         expect(osmUserProfileURL(username)).toBe(expected);
-      });
+      }
     });
   });
 
@@ -58,7 +58,7 @@ describe("OSM Service Functions", () => {
       500: AppErrors.osm.fetchFailure,
     };
 
-    Object.entries(statusToError).forEach(([status, error]) => {
+    for (const [status, error] of Object.entries(statusToError)) {
       test(`should handle ${status} error`, async () => {
         global.fetch.mockResolvedValueOnce({
           ok: false,
@@ -66,7 +66,7 @@ describe("OSM Service Functions", () => {
         });
         await expect(fetchOSMData("0,0,1,1")).rejects.toEqual(error);
       });
-    });
+    }
 
     test("should handle network error", async () => {
       global.fetch.mockRejectedValueOnce(new Error("Network Error"));
@@ -82,7 +82,7 @@ describe("OSM Service Functions", () => {
       { xml: `<osm><unknown id="1"></unknown></osm>`, expectedLength: 1 },
     ];
 
-    testXMLResponses.forEach(({ expectedLength }) => {
+    for (const { expectedLength } of testXMLResponses) {
       test(`should resolve with XML response of length ${expectedLength}`, async () => {
         const emptyXML = "<osm></osm>";
         global.fetch.mockResolvedValueOnce({
@@ -97,7 +97,7 @@ describe("OSM Service Functions", () => {
 
         expect(elements.length).toBe(expectedLength);
       });
-    });
+    }
 
     describe("handleOSMError", () => {
       const errorCases = [
@@ -107,12 +107,12 @@ describe("OSM Service Functions", () => {
         { status: 418, error: AppErrors.osm.fetchFailure }, // Unknown status
       ];
 
-      errorCases.forEach(({ status, error }) => {
+      for (const { status, error } of errorCases) {
         test(`should handle ${status} error`, async () => {
           global.fetch.mockResolvedValueOnce({ ok: false, status });
           await expect(fetchOSMData("0,0,1,1")).rejects.toEqual(error);
         });
-      });
+      }
     });
   });
 
@@ -123,7 +123,7 @@ describe("OSM Service Functions", () => {
       500: AppErrors.osm.fetchFailure,
     };
 
-    Object.entries(statusToError).forEach(([status, error]) => {
+    for (const [status, error] of Object.entries(statusToError)) {
       test(`should handle ${status} error`, async () => {
         global.fetch.mockResolvedValueOnce({
           ok: false,
@@ -131,7 +131,7 @@ describe("OSM Service Functions", () => {
         });
         await expect(fetchOSMElement("node/12345")).rejects.toEqual(error);
       });
-    });
+    }
 
     test("should handle network error", async () => {
       global.fetch.mockRejectedValueOnce(new Error("Network Error"));
@@ -224,7 +224,7 @@ describe("OSM Service Functions", () => {
       },
     ];
 
-    testCases.forEach(({ history, changesetsXML, expectedLength }) => {
+    for (const { history, changesetsXML, expectedLength } of testCases) {
       test("should handle changesets correctly", async () => {
         global.fetch
           .mockResolvedValueOnce({
@@ -240,7 +240,7 @@ describe("OSM Service Functions", () => {
 
         expect(result).toHaveLength(expectedLength);
 
-        result.forEach((element, index) => {
+        for (const [index, element] of result.entries()) {
           const originalChangeset = history.elements[index].changeset;
 
           // If the changeset was found in the XML response, it should be an object
@@ -256,9 +256,9 @@ describe("OSM Service Functions", () => {
             // If not found in XML, it should remain as a number
             expect(element.changeset).toBe(originalChangeset);
           }
-        });
+        }
       });
-    });
+    }
 
     test("should handle missing changesets gracefully", async () => {
       const mockHistory = {
@@ -281,10 +281,10 @@ describe("OSM Service Functions", () => {
       const history = await fetchOSMElementHistory("way/12345", true);
 
       expect(history).toHaveLength(2);
-      history.forEach((element, index) => {
+      for (const [index, element] of history.entries()) {
         // When no changeset data is found, the original number should be preserved
         expect(element.changeset).toBe(mockHistory.elements[index].changeset);
-      });
+      }
     });
 
     test("should handle null changeset values", async () => {
@@ -408,7 +408,7 @@ describe("OSM Service Functions", () => {
       500: AppErrors.osm.fetchFailure,
     };
 
-    Object.entries(statusToError).forEach(([status, error]) => {
+    for (const [status, error] of Object.entries(statusToError)) {
       test(`should handle ${status} error`, async () => {
         global.fetch.mockResolvedValueOnce({
           ok: false,
@@ -416,7 +416,7 @@ describe("OSM Service Functions", () => {
         });
         await expect(fetchOSMChangesets(["123"])).rejects.toEqual(error);
       });
-    });
+    }
 
     test("should handle network error", async () => {
       global.fetch.mockRejectedValueOnce(new Error("Network Error"));

--- a/src/services/OpenStreetCam/OpenStreetCam.js
+++ b/src/services/OpenStreetCam/OpenStreetCam.js
@@ -1,5 +1,3 @@
-import _each from "lodash/each";
-
 const API_URI = "https://openstreetcam.org/1.0";
 
 /**
@@ -118,6 +116,8 @@ const formDataToObject = function (formData) {
  */
 const objectToFormData = function (serialized) {
   const formData = new FormData();
-  _each(serialized, (value, key) => formData.set(key, value));
+  for (const [key, value] of Object.entries(serialized)) {
+    formData.set(key, value);
+  }
   return formData;
 };

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -512,7 +512,7 @@ export const deleteProject = function (projectId, immediate = false) {
 const reduceProjectsFurther = function (mergedState, oldState, projectEntities) {
   // The generic reduction will merge arrays and objects, but for some
   // fields we want to simply overwrite with the latest data.
-  projectEntities.forEach((entity) => {
+  for (const entity of projectEntities) {
     // Ignore deleted projects.
     if (entity.deleted) {
       delete mergedState[entity.id];
@@ -530,7 +530,7 @@ const reduceProjectsFurther = function (mergedState, oldState, projectEntities) 
     if (Array.isArray(entity.teamManagers)) {
       mergedState[entity.id].teamManagers = entity.teamManagers;
     }
-  });
+  }
 };
 
 export const projectEntities = function (state, action) {

--- a/src/services/SearchCriteria/SearchCriteria.js
+++ b/src/services/SearchCriteria/SearchCriteria.js
@@ -1,7 +1,5 @@
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 import _isString from "lodash/isString";
-import _keys from "lodash/keys";
 import _toInteger from "lodash/toInteger";
 import _values from "lodash/values";
 import queryString from "query-string";
@@ -45,12 +43,12 @@ export function buildSearchCriteria(searchParams, defaultCriteria) {
 export function buildSearchURL(searchCriteria) {
   const params = {};
 
-  _each(_keys(searchCriteria), (key) => {
+  for (const key of Object.keys(searchCriteria)) {
     if (typeof searchCriteria[key] === "object") {
       if (key === "boundingBox") {
         params.boundingBox = _values(searchCriteria.boundingBox).join();
       } else {
-        _each(_keys(searchCriteria[key]), (subkey) => {
+        for (const subkey of Object.keys(searchCriteria[key])) {
           if (searchCriteria[key][subkey] !== undefined && searchCriteria[key][subkey] !== null) {
             // taskPropertySearch is a json object
             if (subkey === "taskPropertySearch") {
@@ -59,12 +57,12 @@ export function buildSearchURL(searchCriteria) {
               params[`${key}.${subkey}`] = searchCriteria[key][subkey];
             }
           }
-        });
+        }
       }
     } else if (searchCriteria[key] !== undefined && searchCriteria[key] !== null) {
       params[key] = searchCriteria[key];
     }
-  });
+  }
 
   return "?" + new URLSearchParams(params).toString();
 }
@@ -87,7 +85,7 @@ export function buildSearchCriteriafromURL(searchURL) {
     return value;
   };
 
-  _each(_keys(parsedURL), (key) => {
+  for (const key of Object.keys(parsedURL)) {
     const result = key.match(/(\w+)\.(\w+)/);
     if (result) {
       const primaryKey = result[1];
@@ -102,7 +100,7 @@ export function buildSearchCriteriafromURL(searchURL) {
     } else {
       searchCriteria[key] = massageValue(parsedURL[key]);
     }
-  });
+  }
 
   return searchCriteria;
 }

--- a/src/services/Server/WebSocketClient.js
+++ b/src/services/Server/WebSocketClient.js
@@ -127,7 +127,9 @@ export default class WebSocketClient {
     }
 
     // Transmit any queued messages
-    this.queuedMessages.forEach((message) => this.websocket.send(message));
+    for (const message of this.queuedMessages) {
+      this.websocket.send(message);
+    }
     this.queuedMessages = [];
   }
 

--- a/src/services/Task/ClusteredTask.js
+++ b/src/services/Task/ClusteredTask.js
@@ -1,5 +1,4 @@
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 import _set from "lodash/set";
 import _uniqBy from "lodash/uniqBy";
 import { v1 as uuidv1 } from "uuid";
@@ -83,8 +82,9 @@ export const augmentClusteredTasks = function (
       ignoreLocked,
     )(dispatch).then((result) => {
       if (result) {
-        // Add parent field
-        _each(result.tasks, (task) => (task.parent = challengeId));
+        for (const task of result.tasks) {
+          task.parent = challengeId;
+        }
 
         return dispatch(
           receiveClusteredTasks(

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -1329,11 +1329,11 @@ export const simulatedEntities = function (task) {
 const reduceTasksFurther = function (mergedState, oldState, taskEntities) {
   // The generic reduction will merge arrays and objects, but for some fields
   // we want to simply overwrite with the latest data.
-  taskEntities.forEach((entity) => {
+  for (const entity of taskEntities) {
     if (Array.isArray(entity.tags)) {
       mergedState[entity.id].tags = entity.tags;
     }
-  });
+  }
 };
 
 // redux reducers

--- a/src/services/Templating/Templating.jsx
+++ b/src/services/Templating/Templating.jsx
@@ -1,5 +1,4 @@
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _find from "lodash/find";
 import _isEmpty from "lodash/isEmpty";
 import _isString from "lodash/isString";
@@ -46,11 +45,12 @@ export const expandTemplatingInJSX = function (jsxNode, props) {
             // Let short-code handlers have an opportunity to normalize the content
             // prior to tokenization
             let content = child;
-            _each(shortCodeHandlers, (handler) => {
+
+            for (const handler of shortCodeHandlers) {
               if (handler.normalizeContent) {
                 content = handler.normalizeContent(content, props);
               }
-            });
+            }
 
             if (!containsShortCode(content)) {
               return child;

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -1,6 +1,5 @@
 import { startOfDay, subMonths } from "date-fns";
 import _cloneDeep from "lodash/cloneDeep";
-import _each from "lodash/each";
 import _isObject from "lodash/isObject";
 import _keys from "lodash/keys";
 import _map from "lodash/map";
@@ -471,13 +470,13 @@ export const fetchTopChallenges = function (userId, startDate, limit = 5) {
             _reverse(_sortBy(_toPairs(challenges), (idAndChallenge) => idAndChallenge[1].activity)),
             (idAndChallenge) => parseInt(idAndChallenge[0], 10),
           );
-        }
 
-        // Remove the user-specific activity score before adding this challenge
-        // to the general redux store.
-        _each(challenges, (challenge) => {
-          delete challenge.activity;
-        });
+          // Remove the user-specific activity score before adding this challenge
+          // to the general redux store.
+          for (const challenge of Object.values(challenges)) {
+            delete challenge.activity;
+          }
+        }
 
         userCache.set(
           variables,

--- a/src/services/VirtualChallenge/VirtualChallenge.js
+++ b/src/services/VirtualChallenge/VirtualChallenge.js
@@ -166,7 +166,6 @@ const reduceVirtualChallengesFurther = function (mergedState, oldState, virtualC
     // Ignore deleted and expired virtual challenges
     if (entity.deleted || entity.expired < now) {
       delete mergedState[entity.id];
-      return;
     }
   }
 };

--- a/src/services/VirtualChallenge/VirtualChallenge.js
+++ b/src/services/VirtualChallenge/VirtualChallenge.js
@@ -162,13 +162,13 @@ export const saveVirtualChallenge = function (dispatch, endpoint) {
  */
 const reduceVirtualChallengesFurther = function (mergedState, oldState, virtualChallengeEntities) {
   const now = Date.now();
-  virtualChallengeEntities.forEach((entity) => {
+  for (const entity of virtualChallengeEntities) {
     // Ignore deleted and expired virtual challenges
     if (entity.deleted || entity.expired < now) {
       delete mergedState[entity.id];
       return;
     }
-  });
+  }
 };
 
 export const virtualChallengeEntities = genericEntityReducer(

--- a/src/services/Widget/Widget.js
+++ b/src/services/Widget/Widget.js
@@ -1,7 +1,6 @@
 import FileSaver from "file-saver";
 import _cloneDeep from "lodash/cloneDeep";
 import _compact from "lodash/compact";
-import _each from "lodash/each";
 import _find from "lodash/find";
 import _findIndex from "lodash/findIndex";
 import _intersection from "lodash/intersection";
@@ -225,7 +224,7 @@ export const pruneDecommissionedWidgets = (originalGridConfiguration) => {
 export const pruneWidgets = (gridConfiguration, widgetKeys) => {
   let prunedConfiguration = gridConfiguration;
 
-  _each(widgetKeys, (widgetKey) => {
+  for (const widgetKey of widgetKeys) {
     const widgetIndex = _findIndex(prunedConfiguration.widgets, { widgetKey });
     if (widgetIndex !== -1) {
       // If we haven't made a fresh copy of gridConfiguration yet, do so now
@@ -236,7 +235,7 @@ export const pruneWidgets = (gridConfiguration, widgetKeys) => {
       prunedConfiguration.widgets.splice(widgetIndex, 1);
       prunedConfiguration.layout.splice(widgetIndex, 1);
     }
-  });
+  }
 
   return prunedConfiguration;
 };
@@ -290,11 +289,17 @@ export const addWidgetToGrid = (gridConfiguration, widgetKey, defaultConfigurati
 export const ensurePermanentWidgetsAdded = (gridConfiguration, defaultConfiguration) => {
   let updatedConfiguration = gridConfiguration;
 
-  _each(gridConfiguration.permanentWidgets, (widgetKey) => {
-    if (!_find(updatedConfiguration.widgets, { widgetKey })) {
-      updatedConfiguration = addWidgetToGrid(updatedConfiguration, widgetKey, defaultConfiguration);
+  if (gridConfiguration.permanentWidgets) {
+    for (const widgetKey of gridConfiguration.permanentWidgets) {
+      if (!_find(updatedConfiguration.widgets, { widgetKey })) {
+        updatedConfiguration = addWidgetToGrid(
+          updatedConfiguration,
+          widgetKey,
+          defaultConfiguration,
+        );
+      }
     }
-  });
+  }
 
   return updatedConfiguration;
 };
@@ -342,10 +347,10 @@ export const importRecommendedConfiguration = (recommendedLayout) => {
   );
   delete importedConfiguration.widgetKeys;
 
-  _each(
-    importedConfiguration.layout,
-    (taskWidgetLayout) => (taskWidgetLayout.i = generateWidgetId()),
-  );
+  for (const taskWidgetLayout of importedConfiguration.layout) {
+    taskWidgetLayout.i = generateWidgetId();
+  }
+
   return importedConfiguration;
 };
 
@@ -393,10 +398,10 @@ export const importWorkspaceConfiguration = (workspaceName, importFile) => {
         );
         delete importedConfiguration.widgetKeys;
 
-        _each(
-          importedConfiguration.layout,
-          (widgetLayout) => (widgetLayout.i = generateWidgetId()),
-        );
+        for (const widgetLayout of importedConfiguration.layout) {
+          widgetLayout.i = generateWidgetId();
+        }
+
         resolve(importedConfiguration);
       } catch (error) {
         reject(error);


### PR DESCRIPTION
This PR removes all instances of `Array.forEach` and lodash's `_each` function, preferring to use plain `for` loops in these cases. There are a few reasons ordinary loops are preferable to these functions:

- Clarity: `forEach` looks like `map`, `filter`, etc at first glance, but a crucial difference is that `forEach` usually mutates external state while `map` and `filter` return new arrays but don't (or shouldn't) cause side effects. Using plain for loops instead makes it more obvious that mutation is occurring.
- Performance: for loops are faster (they can be more reliably optimized by the JIT)
- Debuggability: placing a breakpoint in a `forEach` isn't as useful as placing one in a for loop due to the extra stack frames and the inability to directly control the iteration

There's one more reason to prefer for loops over lodash's `_each` specifically: `_each` has varying behavior depending on the type of its first argument, and therefore doesn't play nicely with Typescript. `_each(arr, (v) => ...)` iterates over the array's elements, but `_each(obj, (v) => ...)` iterates over the object's _values_ (not keys!). Using a for loop requires you to be explicit, calling `Object.keys()` or `Object.values()` or `arr.entries()`, which disambiguates the type of the loop variable and makes typechecking of the loop body more useful.

Other things to note when reviewing this PR:
- `_each()` is a no-op when the iterable is `null` or `undefined`. In contrast, trying to loop over `null` or `undefined` with `for` will throw a TypeError. In places where it appeared to be possible for the iterable to be nullish, I added a conditional guard around the loop.
- Both `arr.forEach` and `_each(arr)` will pass the element of the array as the first argument and the index as the second. I've transformed cases where the second argument was used into `for (const [idx, value] of arr.entries())`
- `_each(obj)` invokes its callback with an object value as the first argument and the corresponding object key as the second argument. I've transformed these cases using `Object.values()` or `Object.entries()` depending on whether or not the second (key) argument was used.
- In a handful of places a `return` in a `forEach`/`_each` callback has been turned into a `continue` which has the same effect in a for loop.