### PR TITLE
fix task count not showing up

### DIFF
--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -283,7 +283,7 @@ export const TaskClusterMap = (props) => {
             </div>
           </div>
         )}
-      {props.displayTaskCount && !props.mapZoomedOut && (
+      {!props.mapZoomedOut && (
         <div className="mr-absolute mr-top-0 mr-mt-3 mr-z-5 mr-w-full mr-flex mr-justify-center">
           <div className="mr-flex-col mr-items-center mr-bg-black-40 mr-text-white mr-rounded">
             <div className="mr-py-2 mr-px-3 mr-text-center">


### PR DESCRIPTION
A recently added PR, https://github.com/maproulette/maproulette3/pull/2524, removed a variable, `displayTaskCount`, but that variable was still being used as a condition, which was now undefined and always evaluated as false. This led to a bug where the task count at the top of the map was not being displayed. Removing this condition fixes the issue.