### PR TITLE
fix initial challenge clusters clicking behavior

### DIFF
--- a/src/components/TaskClusterMap/MapMarkers.jsx
+++ b/src/components/TaskClusterMap/MapMarkers.jsx
@@ -322,10 +322,8 @@ const Markers = (props) => {
    * Invoked when an individual task marker is clicked by the user.
    */
   const markerClicked = async (marker) => {
-    if (!props.loadingChallenge) {
-      if (marker.options.bounding && marker.options.numberOfPoints > 1) {
-        map.fitBounds(toLatLngBounds(bbox(marker.options.bounding)));
-      }
+    if (marker.options.bounding && marker.options.numberOfPoints > 1) {
+      map.fitBounds(toLatLngBounds(bbox(marker.options.bounding)));
     }
   };
 


### PR DESCRIPTION
This specifically fixes the initial cluster onclick event on the browse challenge page. Before the clusters were unclickable and the users would need to zoom or move the map to be able to click on the cluster. This pr remove the condition that was causing this bug.