### PR TITLE
fix undefined variable in for loop bug

### DIFF
--- a/src/services/Challenge/ChallengeLocation/ChallengeLocation.js
+++ b/src/services/Challenge/ChallengeLocation/ChallengeLocation.js
@@ -49,12 +49,16 @@ export const challengePassesLocationFilter = function (challengeFilters, challen
   // Or if the challenge is listed in the TaskClusters or in the Map Bounded Tasks
   let validChallenges = [];
 
-  for (const task of props.mapBoundedTasks?.tasks) {
-    validChallenges = _concat(validChallenges, task.parentId);
+  if (props.mapBoundedTasks?.tasks) {
+    for (const task of props.mapBoundedTasks.tasks) {
+      validChallenges = _concat(validChallenges, task.parentId);
+    }
   }
 
-  for (const cluster of props.taskClusters?.clusters) {
-    validChallenges = _concat(validChallenges, cluster.challengeIds);
+  if (props.taskClusters?.clusters) {
+    for (const cluster of props.taskClusters.clusters) {
+      validChallenges = _concat(validChallenges, cluster.challengeIds);
+    }
   }
 
   if (validChallenges.indexOf(challenge.id) > -1) {


### PR DESCRIPTION
Undefined values cannot be used in for loops, as they will trigger a 'non-iterable value' error. This pull request addresses the issue by wrapping the for loops in an if statement to ensure that the values are defined before iteration, preventing the error from occurring.