### PR TITLE
remove redundant expensive task/marker endpoint call

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.jsx
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.jsx
@@ -9,7 +9,7 @@ import _omit from "lodash/omit";
 import _pickBy from "lodash/pickBy";
 import _toInteger from "lodash/toInteger";
 import { Component } from "react";
-import { GLOBAL_MAPBOUNDS, fromLatLngBounds } from "../../../services/MapBounds/MapBounds";
+import { fromLatLngBounds } from "../../../services/MapBounds/MapBounds";
 import {
   buildSearchCriteriafromURL,
   buildSearchURL,
@@ -181,15 +181,6 @@ export const WithFilterCriteria = function (
       const criteria = typedCriteria || _cloneDeep(this.state.criteria);
 
       criteria.filters.archived = true;
-
-      // If we don't have bounds yet, we still want results so let's fetch all
-      // tasks globally for this challenge.
-      if (!criteria.boundingBox) {
-        if (skipInitialFetch || !challengeId) {
-          return;
-        }
-        criteria.boundingBox = GLOBAL_MAPBOUNDS;
-      }
 
       this.debouncedTasksFetch(challengeId, criteria, this.state.criteria.pageSize);
     };


### PR DESCRIPTION
I dont see a use for adding this condition, the endpoint works without the bounds, and the location filter is very expensive at the moment. This issue will require more investigation, but this is a good step in the right direction.

Example of slow query that took over 3 minutes:
```
default-dispatcher-160][AccessLogger] - Request 'PUT /api/v2/tasks/box/-180/-85/180/85?ca=true&cid=51256&excludeLocked=true&includeGeometries=true&includeTags=false&includeTotal=true&invf=&limit=20&mrStatus=0%2C1%2C2%2C3%2C5%2C6%2C7%2C-2%2C-1&order=DESC&page=0&priorities=0%2C1%2C2&sort=name&tStatus=0%2C1%2C2%2C3%2C4%2C5%2C6%2C9&trStatus=0%2C1%2C2%2C3%2C4%2C5%2C6%2C7%2C-1' [org.maproulette.framework.controller.TaskController.getTasksInBoundingBox] 215825ms - Response 200
```