### PR TITLE
Fix completion state not being saved in completion workflow

### DIFF
--- a/src/components/ReviewTaskControls/ReviewTaskControls.jsx
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.jsx
@@ -42,7 +42,7 @@ export class ReviewTaskControls extends Component {
   setComment = (comment) => this.setState({ comment });
   setTags = (tags) => this.setState({ tags });
 
-  onConfirm = (alternateCriteria) => {
+  onConfirm = async (alternateCriteria) => {
     if (this.state.tags) {
       this.props.saveTaskTags(this.props.task, this.state.tags);
     }
@@ -59,19 +59,22 @@ export class ReviewTaskControls extends Component {
 
     const errorTags = this.state.errorTags?.length ? this.state.errorTags : undefined;
 
-    this.props.updateTaskReviewStatus(
-      this.props.task,
-      this.state.reviewStatus,
-      this.state.comment,
-      null,
-      this.state.loadBy,
-      history,
-      this.props.taskBundle,
-      requestedNextTask,
-      null,
-      errorTags,
-    );
-    this.setState({ confirmingTask: false, comment: "", errorTags: [] });
+    try {
+      await this.props.updateTaskReviewStatus(
+        this.props.task,
+        this.state.reviewStatus,
+        this.state.comment,
+        null,
+        this.state.loadBy,
+        history,
+        this.props.taskBundle,
+        requestedNextTask,
+        null,
+        errorTags,
+      );
+    } finally {
+      this.setState({ confirmingTask: false, comment: "", errorTags: [] });
+    }
   };
 
   handleChangeErrorTag = (e, i) => {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -198,9 +198,9 @@ export class ActiveTaskControls extends Component {
       if (taskStatus === TASK_STATUS_FIXED && disableTaskConfirm) {
         this.setState(
           {
-            osmComment: `${
-              this.props.task.parent.checkinComment
-            }${constructChangesetUrl(this.props.task)}`,
+            osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(
+              this.props.task,
+            )}`,
             confirmingStatus: taskStatus,
             submitRevision,
           },
@@ -211,9 +211,9 @@ export class ActiveTaskControls extends Component {
       } else {
         this.setState({
           confirmingTask: this.props.task,
-          osmComment: `${
-            this.props.task.parent.checkinComment
-          }${constructChangesetUrl(this.props.task)}`,
+          osmComment: `${this.props.task.parent.checkinComment}${constructChangesetUrl(
+            this.props.task,
+          )}`,
           confirmingStatus: taskStatus,
           submitRevision,
         });
@@ -221,9 +221,12 @@ export class ActiveTaskControls extends Component {
     }
   };
 
-  confirmCompletion = () => {
-    this.complete(this.state.confirmingStatus);
-    this.resetConfirmation();
+  confirmCompletion = async () => {
+    try {
+      await this.complete(this.state.confirmingStatus);
+    } finally {
+      this.resetConfirmation();
+    }
   };
 
   resetConfirmation = () => {
@@ -413,8 +416,8 @@ export class ActiveTaskControls extends Component {
     const editMode = disableRapid
       ? false
       : this.props.getUserAppSetting
-        ? this.props.getUserAppSetting(this.props.user, "isEditMode")
-        : false;
+      ? this.props.getUserAppSetting(this.props.user, "isEditMode")
+      : false;
 
     const needsRevised = this.props.task.reviewStatus === TaskReviewStatus.rejected;
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.jsx
@@ -416,8 +416,8 @@ export class ActiveTaskControls extends Component {
     const editMode = disableRapid
       ? false
       : this.props.getUserAppSetting
-      ? this.props.getUserAppSetting(this.props.user, "isEditMode")
-      : false;
+        ? this.props.getUserAppSetting(this.props.user, "isEditMode")
+        : false;
 
     const needsRevised = this.props.task.reviewStatus === TaskReviewStatus.rejected;
 


### PR DESCRIPTION
This PR resolves a bug where local state, such as mr tags and comments, in the task confirmation modal were not being saved. This occurred because the reset functionality was prematurely clearing local data before the completion workflow had finished.