### PR TITLE
Find and preprocess markdown links with mustache replacements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "@playwright/test": "^1.49.1",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/react-hooks": "^8.0.1",
         "@types/node": "^22.10.5",
         "@vitejs/plugin-react-swc": "^3.7.1",
         "@vitest/coverage-v8": "^2.1.9",
@@ -2858,6 +2859,37 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@turf/bbox": {
@@ -10996,6 +11028,23 @@
       },
       "peerDependencies": {
         "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@playwright/test": "^1.49.1",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/node": "^22.10.5",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "@vitest/coverage-v8": "^2.1.9",

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.js
@@ -28,7 +28,7 @@ const usePropertyReplacement = (content, properties, allowPropertyReplacement = 
 
 // Match and process markdown links that contain mustache {{...}} replacements in the URL part
 function preProcessMarkdownLinks(content, properties) {
-  const urlRegex = /\][^\(]*\(([^)]*\{\{[^}]*\}\}[^)]*)\)/g;
+  const urlRegex = /\]\s*\(([^)]*\{\{[^}]*\}\}[^)]*)\)/g;
 
   return content.replace(urlRegex, (match, url) => {
     // Get the part before the opening parenthesis
@@ -37,7 +37,7 @@ function preProcessMarkdownLinks(content, properties) {
     const replacedContent = replacePropertyTags(url, properties, false, true);
 
     // Return the unchanged part + transformed URL in parentheses
-    return `${beforeParen}(${replacedContent})`;
+    return `](${replacedContent})`;
   });
 }
 

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
@@ -22,7 +22,7 @@ describe("usePropertyReplacement additional tests", () => {
   });
 
   it("only url encodes replacements in markdown links", () => {
-    const content = "{{nested.deep.key}} [link](https://example.com/{{nested.deep.key}})";  
+    const content = "{{nested.deep.key}} [link](https://example.com/{{nested.deep.key}})";
     const { result } = renderHook(() => usePropertyReplacement(content, properties, true, false));
     expect(result.current).toBe("deep value [link](https://example.com/deep%20value)");
   });
@@ -38,11 +38,13 @@ describe("usePropertyReplacement additional tests", () => {
     const { result } = renderHook(() => usePropertyReplacement(content, {}, false));
     expect(result.current).toBe("Hello, {{name}}!");
   });
+
   it("honors allowPropertyReplacement = false when data present", () => {
     const content = "Hello, {{name}}!";
     const { result } = renderHook(() => usePropertyReplacement(content, properties, false));
     expect(result.current).toBe("Hello, {{name}}!");
   });
+
   it("processes content with multiple nested properties", () => {
     const content = "Nested: {{nested.property}}, Deep: {{nested.deep.key}}";
     const { result } = renderHook(() => usePropertyReplacement(content, properties));

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
@@ -21,6 +21,12 @@ describe("usePropertyReplacement additional tests", () => {
     expect(result.current).toBe("[link](https://example.com/deep%20value)");
   });
 
+  it("only url encodes replacements in markdown links", () => {
+    const content = "{{nested.deep.key}} [link](https://example.com/{{nested.deep.key}})";  
+    const { result } = renderHook(() => usePropertyReplacement(content, properties, true, false));
+    expect(result.current).toBe("deep value [link](https://example.com/deep%20value)");
+  });
+
   it("handles empty properties object", () => {
     const content = "Hello, {{name}}!";
     const { result } = renderHook(() => usePropertyReplacement(content, {}));

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
@@ -21,6 +21,41 @@ describe("usePropertyReplacement additional tests", () => {
     expect(result.current).toBe("[link](https://example.com/deep%20value)");
   });
 
+  it("performs basic url encoded replacement in markdown link", () => {
+    const content = "[link](https://example.com/{{name}})";
+    const expected = "[link](https://example.com/Test%20Name)";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(expected);
+  });
+
+  it("ignores whitespace between link text and URL in markdown link", () => {
+    const content = "[link]    (https://example.com/{{name}})";
+    const expected = "[link](https://example.com/Test%20Name)";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(expected);
+  });
+
+  it("falls through to preexisting replacement behavior for invalid link format", () => {
+    const content = "[link] hello there (https://example.com/{{name}})";
+    const expected = "[link] hello there (https://example.com/Test Name)";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(expected);
+  });
+
+  it("does not url encode standalone replacements outside markdown links", () => {
+    const content = "[link](https://example.com/) blab blah {{name}} blah [another link](https://example.com/)";
+    const expected = "[link](https://example.com/) blab blah Test Name blah [another link](https://example.com/)";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(expected);
+  });
+
+  it("does not url encode standalone replacements when no markdown links are present", () => {
+    const content = "hello there (foo {{name}})";
+    const expected = "hello there (foo Test Name)";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(expected);
+  });
+
   it("only url encodes replacements in markdown links", () => {
     const content = "{{nested.deep.key}} [link](https://example.com/{{nested.deep.key}})";
     const { result } = renderHook(() => usePropertyReplacement(content, properties, true, false));

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.test.js
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { describe, expect, it } from "vitest";
+import usePropertyReplacement from "./UsePropertyReplacement";
+
+describe("usePropertyReplacement additional tests", () => {
+  const properties = {
+    name: "Test Name",
+    id: "123",
+    nested: {
+      property: "nested value",
+      deep: {
+        key: "deep value"
+      }
+    },
+    special: "value with special characters: !@#$%^&*()"
+  };
+
+  it("url encodes markdown link replacements", () => {
+    const content = "[link](https://example.com/{{nested.deep.key}})";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe("[link](https://example.com/deep%20value)");
+  });
+
+  it("handles empty properties object", () => {
+    const content = "Hello, {{name}}!";
+    const { result } = renderHook(() => usePropertyReplacement(content, {}));
+    expect(result.current).toBe("Hello, !");
+  });
+
+  it("honors allowPropertyReplacement = false when data missing", () => {
+    const content = "Hello, {{name}}!";
+    const { result } = renderHook(() => usePropertyReplacement(content, {}, false));
+    expect(result.current).toBe("Hello, {{name}}!");
+  });
+  it("honors allowPropertyReplacement = false when data present", () => {
+    const content = "Hello, {{name}}!";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties, false));
+    expect(result.current).toBe("Hello, {{name}}!");
+  });
+  it("processes content with multiple nested properties", () => {
+    const content = "Nested: {{nested.property}}, Deep: {{nested.deep.key}}";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe("Nested: nested value, Deep: deep value");
+  });
+
+  it("handles content with no mustache tags", () => {
+    const content = "This is plain text.";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe(content);
+  });
+
+  it("handles content with special characters in property values", () => {
+    const content = "Special: {{special}}";
+    const { result } = renderHook(() => usePropertyReplacement(content, properties));
+    expect(result.current).toBe("Special: value with special characters: !@#$%^&*()");
+  });
+});


### PR DESCRIPTION
A starting point and plausible solution for #1811
![image](https://github.com/user-attachments/assets/b547ed8e-5673-413c-9b31-ecfbe3e369e4)

![image](https://github.com/user-attachments/assets/4efe4c5b-96b0-4ece-9880-b80c018680cd)
