### PR TITLE
replace deprecated react-beautiful-dnd dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@apollo/client": "^3.5.4",
         "@changey/react-leaflet-markercluster": "^4.0.0-rc1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@mapbox/geo-viewport": "^0.4.0",
         "@nivo/bar": "^0.98.0",
         "@nivo/core": "^0.98.0",
@@ -56,7 +59,6 @@
         "prop-types": "^15.6.0",
         "query-string": "^6.13.1",
         "react": "^17.0.2",
-        "react-beautiful-dnd": "^13.0.0",
         "react-burger-menu": "^3.1.0",
         "react-calendar-heatmap": "^1.6.3",
         "react-copy-to-clipboard": "^5.0.1",
@@ -808,6 +810,59 @@
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -5330,15 +5385,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-color-keywords": {
@@ -11142,12 +11188,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "license": "MIT"
-    },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -11189,26 +11229,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-beautiful-dnd": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
-      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-burger-menu": {
@@ -14625,15 +14645,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/use-memo-one": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "dependencies": {
     "@apollo/client": "^3.5.4",
     "@changey/react-leaflet-markercluster": "^4.0.0-rc1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@mapbox/geo-viewport": "^0.4.0",
     "@nivo/bar": "^0.98.0",
     "@nivo/core": "^0.98.0",
@@ -78,7 +81,6 @@
     "prop-types": "^15.6.0",
     "query-string": "^6.13.1",
     "react": "^17.0.2",
-    "react-beautiful-dnd": "^13.0.0",
     "react-burger-menu": "^3.1.0",
     "react-calendar-heatmap": "^1.6.3",
     "react-copy-to-clipboard": "^5.0.1",

--- a/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
+++ b/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
@@ -1,22 +1,22 @@
-import _map from "lodash/map";
-import PropTypes from "prop-types";
-import { Component } from "react";
 import {
   DndContext,
-  closestCenter,
   KeyboardSensor,
   PointerSensor,
+  closestCenter,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
 import {
-  arrayMove,
   SortableContext,
+  arrayMove,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import _map from "lodash/map";
+import PropTypes from "prop-types";
+import { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import External from "../External/External";
 import Modal from "../Modal/Modal";

--- a/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
+++ b/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
@@ -8,7 +8,6 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
-  arrayMove,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,

--- a/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
+++ b/src/components/ConfigureColumnsModal/ConfigureColumnsModal.jsx
@@ -1,11 +1,54 @@
 import _map from "lodash/map";
 import PropTypes from "prop-types";
 import { Component } from "react";
-import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { FormattedMessage } from "react-intl";
 import External from "../External/External";
 import Modal from "../Modal/Modal";
 import messages from "./Messages";
+
+// SortableItem component for draggable columns
+const SortableItem = ({ column, columnKey, onRemove }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: columnKey,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <div className="mr-flex">
+        <div className="mr-flex-grow mr-text-base mr-text-white mr-my-2">{column.message}</div>
+
+        {!column.permanent && (
+          <div className="mr-text-sm mr-text-green-lighter mr-my-2">
+            <button className="mr-text-current" onClick={() => onRemove(columnKey)}>
+              <FormattedMessage {...messages.removeLabel} />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 /**
  * ConfigureColumnsModal renders a modal for configuring table columns
@@ -13,13 +56,25 @@ import messages from "./Messages";
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
 export default class ConfigureColumnsModal extends Component {
-  onDragEnd = (result) => {
-    // dropped outside the list or on itself
-    if (!result.destination || result.source.index === result.destination.index) {
+  handleDragEnd = (event) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
       return;
     }
 
-    this.props.reorderAddedColumn(result.source.index, result.destination.index);
+    // Find indexes for the source and destination
+    let sourceIndex = -1;
+    let destinationIndex = -1;
+
+    Object.keys(this.props.addedColumns).forEach((key, index) => {
+      if (key === active.id) sourceIndex = index;
+      if (key === over.id) destinationIndex = index;
+    });
+
+    if (sourceIndex !== -1 && destinationIndex !== -1) {
+      this.props.reorderAddedColumn(sourceIndex, destinationIndex);
+    }
   };
 
   close = () => {
@@ -27,38 +82,50 @@ export default class ConfigureColumnsModal extends Component {
     this.props.onClose();
   };
 
-  buildDraggableColumnList() {
-    let index = -1;
-    return _map(this.props.addedColumns, (column, key) => {
-      index += 1;
-      return (
-        <Draggable key={`added-${key}`} draggableId={key} index={index}>
-          {(provided) => (
-            <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
-              <div className="mr-flex">
-                <div className="mr-flex-grow mr-text-base mr-text-white mr-my-2">
-                  {column.message}
-                </div>
+  buildSortableColumnList() {
+    const columnItems = [];
+    const columnIds = [];
 
-                {!column.permanent && (
-                  <div className="mr-text-sm mr-text-green-lighter mr-my-2">
-                    <button
-                      className="mr-text-current"
-                      onClick={() => this.props.removeColumn(key)}
-                    >
-                      <FormattedMessage {...messages.removeLabel} />
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </Draggable>
+    Object.entries(this.props.addedColumns).forEach(([key, column]) => {
+      columnItems.push(
+        <SortableItem
+          key={`added-${key}`}
+          column={column}
+          columnKey={key}
+          onRemove={this.props.removeColumn}
+        />,
       );
+      columnIds.push(key);
     });
+
+    return { columnItems, columnIds };
   }
 
   render() {
+    // Wrap DndContext in a function component since hooks can't be used in class components
+    const DraggableColumnList = () => {
+      const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+          coordinateGetter: sortableKeyboardCoordinates,
+        }),
+      );
+
+      const { columnItems, columnIds } = this.buildSortableColumnList();
+
+      return (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={this.handleDragEnd}
+        >
+          <SortableContext items={columnIds} strategy={verticalListSortingStrategy}>
+            {columnItems}
+          </SortableContext>
+        </DndContext>
+      );
+    };
+
     const availableColumns = _map(this.props.availableColumns, (column, key) => (
       <li key={`available-${key}`} className="mr-flex mr-my-4">
         <div className="mr-flex-grow mr-text-base mr-text-white">{column.message}</div>
@@ -103,16 +170,7 @@ export default class ConfigureColumnsModal extends Component {
                     </div>
                   </header>
                   <div className="mr-card-widget__content">
-                    <DragDropContext onDragEnd={this.onDragEnd}>
-                      <Droppable droppableId="added-column-droppable">
-                        {(provided) => (
-                          <div {...provided.droppableProps} ref={provided.innerRef}>
-                            {this.buildDraggableColumnList(provided)}
-                            {provided.placeholder}
-                          </div>
-                        )}
-                      </Droppable>
-                    </DragDropContext>
+                    <DraggableColumnList />
                   </div>
                 </section>
               </div>
@@ -135,4 +193,5 @@ ConfigureColumnsModal.propTypes = {
   addedColumns: PropTypes.object.isRequired,
   availableColumns: PropTypes.object.isRequired,
   reorderAddedColumn: PropTypes.func.isRequired,
+  removeColumn: PropTypes.func.isRequired,
 };

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -15,7 +15,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import classNames from "classnames";
-import _clone from "lodash/clone";
 import _filter from "lodash/filter";
 import _isEmpty from "lodash/isEmpty";
 import _map from "lodash/map";

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -6,7 +6,22 @@ import _map from "lodash/map";
 import _sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { Component, Fragment } from "react";
-import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { FormattedMessage } from "react-intl";
 import AsEndUser from "../../../interactions/User/AsEndUser";
 import { DEFAULT_OVERLAY_ORDER } from "../../../services/VisibleLayer/LayerSources";
@@ -15,6 +30,35 @@ import WithLayerSources from "../../HOCs/WithLayerSources/WithLayerSources";
 import WithVisibleLayer from "../../HOCs/WithVisibleLayer/WithVisibleLayer";
 import SvgSymbol from "../../SvgSymbol/SvgSymbol";
 import messages from "./Messages";
+
+// SortableItem component for draggable overlays
+const SortableOverlayItem = ({ overlay, canReorderLayers }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: overlay.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div className="mr-relative mr-my-2 mr-flex mr-justify-between">
+        <div>{overlay.component}</div>
+        {canReorderLayers && (
+          <div {...attributes} {...listeners}>
+            <SvgSymbol
+              sym="reorder-icon"
+              className="mr-mt-6px mr-w-6 mr-h-6 mr-fill-green-light"
+              viewBox="0 0 96 96"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 /**
  * LayerToggle presents a control for selecting the desired map layer/tiles.
@@ -55,23 +99,35 @@ export class LayerToggle extends Component {
     return overlays;
   };
 
-  overlayReordered = (overlays, result) => {
+  handleDragEnd = (event) => {
     if (!this.props.user || !this.props.updateUserAppSetting) {
       return;
     }
 
+    const { active, over } = event;
+
     // dropped outside the list or on itself
-    if (!result.destination || result.source.index === result.destination.index) {
+    if (!over || active.id === over.id) {
       return;
     }
 
-    const layers = _clone(overlays);
-    const movedLayer = layers.splice(result.source.index, 1)[0];
-    layers.splice(result.destination.index, 0, movedLayer);
+    const overlays = this.orderedOverlays();
 
-    this.props.updateUserAppSetting(this.props.user.id, {
-      mapOverlayOrder: _map(layers, "id"),
+    // Find indexes for the source and destination
+    let sourceIndex = -1;
+    let destinationIndex = -1;
+
+    overlays.forEach((layer, index) => {
+      if (layer.id === active.id) sourceIndex = index;
+      if (layer.id === over.id) destinationIndex = index;
     });
+
+    if (sourceIndex !== -1 && destinationIndex !== -1) {
+      const newOverlays = arrayMove(overlays, sourceIndex, destinationIndex);
+      this.props.updateUserAppSetting(this.props.user.id, {
+        mapOverlayOrder: _map(newOverlays, "id"),
+      });
+    }
   };
 
   render() {
@@ -95,6 +151,37 @@ export class LayerToggle extends Component {
     const overlays = this.orderedOverlays();
     const canReorderLayers =
       AsEndUser(this.props.user).isLoggedIn() && this.props.updateUserAppSetting;
+
+    // Wrap DndContext in a function component since hooks can't be used in class components
+    const DraggableOverlayList = () => {
+      const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+          coordinateGetter: sortableKeyboardCoordinates,
+        }),
+      );
+
+      return (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={this.handleDragEnd}
+        >
+          <SortableContext
+            items={overlays.map((overlay) => overlay.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {_map(overlays, (overlay) => (
+              <SortableOverlayItem
+                key={overlay.id}
+                overlay={overlay}
+                canReorderLayers={canReorderLayers}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      );
+    };
 
     return (
       <Dropdown
@@ -120,53 +207,7 @@ export class LayerToggle extends Component {
               <hr className="mr-h-px mr-my-4 mr-bg-white-15" />
             )}
             <div>
-              <DragDropContext onDragEnd={(result) => this.overlayReordered(overlays, result)}>
-                <Droppable
-                  droppableId="overlay-droppable"
-                  renderClone={(provided, snapshot, rubric) => (
-                    <div ref={provided.innerRef} {...provided.draggableProps}>
-                      <div className="mr-relative mr-my-2 mr-flex mr-justify-between">
-                        <div className="mr-text-sm">{overlays[rubric.source.index].component}</div>
-                        {canReorderLayers && (
-                          <div {...provided.dragHandleProps}>
-                            <SvgSymbol
-                              sym="reorder-icon"
-                              className="mr-mt-6px mr-w-6 mr-h-6 mr-fill-green-light"
-                              viewBox="0 0 96 96"
-                            />
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                >
-                  {(provided) => (
-                    <div {...provided.droppableProps} ref={provided.innerRef}>
-                      {_map(overlays, (overlay, index) => (
-                        <Draggable key={overlay.id} draggableId={overlay.id} index={index}>
-                          {(provided) => (
-                            <div ref={provided.innerRef} {...provided.draggableProps}>
-                              <div className="mr-relative mr-my-2 mr-flex mr-justify-between">
-                                <div>{overlay.component}</div>
-                                {canReorderLayers && (
-                                  <div {...provided.dragHandleProps}>
-                                    <SvgSymbol
-                                      sym="reorder-icon"
-                                      className="mr-mt-6px mr-w-6 mr-h-6 mr-fill-green-light"
-                                      viewBox="0 0 96 96"
-                                    />
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          )}
-                        </Draggable>
-                      ))}
-                      {provided.placeholder}
-                    </div>
-                  )}
-                </Droppable>
-              </DragDropContext>
+              <DraggableOverlayList />
             </div>
           </Fragment>
         )}

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.jsx
@@ -1,3 +1,19 @@
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import classNames from "classnames";
 import _clone from "lodash/clone";
 import _filter from "lodash/filter";
@@ -6,22 +22,6 @@ import _map from "lodash/map";
 import _sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { Component, Fragment } from "react";
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import { FormattedMessage } from "react-intl";
 import AsEndUser from "../../../interactions/User/AsEndUser";
 import { DEFAULT_OVERLAY_ORDER } from "../../../services/VisibleLayer/LayerSources";


### PR DESCRIPTION
Refactor drag-and-drop functionality in ConfigureColumnsModal and LayerToggle components

- Replace react-beautiful-dnd with @dnd-kit for improved drag-and-drop experience.
- Implement sortable lists for configuring columns and layer toggles.
- Remove deprecated react-beautiful-dnd dependencies from package.json and package-lock.json.
- Update related components to utilize new drag-and-drop logic.