### PR TITLE
Fix link color in footer version links

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -64,7 +64,7 @@ class Footer extends Component {
                   <FormattedMessage {...messages.versionLabel} />{" "}
                   <a
                     href={frontendVersionUrl}
-                    className="mr-text-green-light mr-font-mono hover:mr-text-green-300 mr-transition-colors"
+                    className="mr-text-green-lighter mr-font-mono hover:mr-text-green-300 mr-transition-colors"
                   >
                     {frontendVersion}
                   </a>
@@ -74,7 +74,7 @@ class Footer extends Component {
                     <FormattedMessage {...messages.APIVersionLabel} />{" "}
                     <a
                       href={backendVersionUrl}
-                      className="mr-text-green-light mr-font-mono hover:mr-text-green-300 mr-transition-colors"
+                      className="mr-text-green-lighter mr-font-mono hover:mr-text-green-300 mr-transition-colors"
                     >
                       {backendVersion}
                     </a>

--- a/src/hooks/UsePropertyReplacement/UsePropertyReplacement.js
+++ b/src/hooks/UsePropertyReplacement/UsePropertyReplacement.js
@@ -31,11 +31,8 @@ function preProcessMarkdownLinks(content, properties) {
   const urlRegex = /\]\s*\(([^)]*\{\{[^}]*\}\}[^)]*)\)/g;
 
   return content.replace(urlRegex, (match, url) => {
-    // Get the part before the opening parenthesis
-    const beforeParen = match.substring(0, match.indexOf("("));
     // Transform the URL
     const replacedContent = replacePropertyTags(url, properties, false, true);
-
     // Return the unchanged part + transformed URL in parentheses
     return `](${replacedContent})`;
   });


### PR DESCRIPTION
They were a slightly darker green than other links, reducing contrast with the background.

Also fixes an unrelated linter warning that was introduced in a recent PR.