### PR TITLE
bump to v3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [v3.17.0] - 2025-06-4
+Released with [maproulette-backend_v4.7.9](https://github.com/maproulette/maproulette-backend/releases/tag/v4.7.9)
+
+## What's Changed
+* upgrade react-leaflet-markercluster to v4.2.1 by @CollinBeczak in https://github.com/maproulette/maproulette3/pull/2658
+* Fix link color in footer version links by @jake-low in https://github.com/maproulette/maproulette3/pull/2655
+* add ability to focus on task in TaskPropertiesWidget by @jschwarz2030 in https://github.com/maproulette/maproulette3/pull/2652
+
+**Full Changelog**: https://github.com/maproulette/maproulette3/compare/v3.17.0...v3.17.1
+
 ## [v3.17.0] - 2025-06-2
 Released with [maproulette-backend_v4.7.9](https://github.com/maproulette/maproulette-backend/releases/tag/v4.7.9)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maproulette3",
-  "version": "3.16.13",
+  "version": "3.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maproulette3",
-      "version": "3.16.13",
+      "version": "3.17.1",
       "dependencies": {
         "@apollo/client": "^3.5.4",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maproulette3",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What's Changed
* upgrade react-leaflet-markercluster to v4.2.1 by @CollinBeczak in https://github.com/maproulette/maproulette3/pull/2658
* Fix link color in footer version links by @jake-low in https://github.com/maproulette/maproulette3/pull/2655
* add ability to focus on task in TaskPropertiesWidget by @jschwarz2030 in https://github.com/maproulette/maproulette3/pull/2652

**Full Changelog**: https://github.com/maproulette/maproulette3/compare/v3.17.0...v3.17.1
Released with [maproulette-backend_v4.7.9](https://github.com/maproulette/maproulette-backend/releases/tag/v4.7.9)
