### PR TITLE
fix task map animations between tasks

### DIFF
--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -451,7 +451,7 @@ export const TaskMapContent = (props) => {
       animator.reset();
       map.off("click", handleMapClick);
     };
-  }, []);
+  }, [props.task.id]);
 
   useEffect(() => {
     setOsmData(null);


### PR DESCRIPTION
This pr makes it so that the animations work when going to a new task from another task. This issues was fixed by updating the animations on task.id change instead of on component mount.