### PR TITLE
add goToFeature effect in taskCluster map

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1519,6 +1519,7 @@
   "Widgets.TaskNearbyMap.tooltip.taskCountLabel": "Tasks: {count}",
   "Widgets.TaskPropertiesWidget.collapseAll": "Collapse All",
   "Widgets.TaskPropertiesWidget.expandAll": "Expand All",
+  "Widgets.TaskPropertiesWidget.goToFeatureOnMap": "Go to feature on map",
   "Widgets.TaskPropertiesWidget.label": "Task Properties",
   "Widgets.TaskPropertiesWidget.task.label": "Task {taskId}",
   "Widgets.TaskReviewWidget.label": "Task Review",

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -56,6 +56,7 @@ export const CLUSTER_ICON_PIXELS = 40;
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
 export const TaskClusterMap = (props) => {
+  const { workspaceContext, setWorkspaceContext } = props;
   const [currentBounds, setCurrentBounds] = useState(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [currentZoom, setCurrentZoom] = useState();
@@ -164,6 +165,27 @@ export const TaskClusterMap = (props) => {
     useEffect(() => {
       map.invalidateSize();
     }, [props.widgetLayout?.w, props.widgetLayout?.h]);
+
+    useEffect(() => {
+      if (workspaceContext?.taskMapBounds && workspaceContext?.taskPropertyClicked) {
+        const isTaskInBundle =
+          props.taskBundle?.tasks?.some((t) => t.id === workspaceContext.taskMapTask?.id) ||
+          workspaceContext.taskMapTask?.id === props.task?.id;
+
+        if (isTaskInBundle) {
+          map.setView(workspaceContext.taskMapBounds.getCenter(), workspaceContext.taskMapZoom);
+          setWorkspaceContext({
+            taskPropertyClicked: false,
+          });
+        }
+      }
+    }, [
+      workspaceContext?.taskMapBounds,
+      workspaceContext?.taskMapZoom,
+      workspaceContext?.taskMapTask?.id,
+      workspaceContext?.taskPropertyClicked,
+    ]);
+
     return null;
   };
 

--- a/src/components/TaskClusterMap/TaskClusterMap.jsx
+++ b/src/components/TaskClusterMap/TaskClusterMap.jsx
@@ -174,17 +174,16 @@ export const TaskClusterMap = (props) => {
 
         if (isTaskInBundle) {
           map.setView(workspaceContext.taskMapBounds.getCenter(), workspaceContext.taskMapZoom);
+          // Ensure markers are refetched after changing the map view
+          if (props.updateBounds) {
+            props.updateBounds(workspaceContext.taskMapBounds, workspaceContext.taskMapZoom, true);
+          }
           setWorkspaceContext({
             taskPropertyClicked: false,
           });
         }
       }
-    }, [
-      workspaceContext?.taskMapBounds,
-      workspaceContext?.taskMapZoom,
-      workspaceContext?.taskMapTask?.id,
-      workspaceContext?.taskPropertyClicked,
-    ]);
+    }, [workspaceContext?.taskPropertyClicked]);
 
     return null;
   };

--- a/src/components/Widgets/TaskPropertiesWidget/Messages.js
+++ b/src/components/Widgets/TaskPropertiesWidget/Messages.js
@@ -28,4 +28,9 @@ export default defineMessages({
     id: "Widgets.TaskPropertiesWidget.collapseAll",
     defaultMessage: "Collapse All",
   },
+
+  goToFeatureOnMap: {
+    id: "Widgets.TaskPropertiesWidget.goToFeatureOnMap",
+    defaultMessage: "Go to feature on map",
+  },
 });

--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.jsx
@@ -64,10 +64,11 @@ const TaskPropertiesWidget = (props) => {
                       taskMapZoom: 18,
                       taskMapTask: task,
                       taskMapBoundsUpdate: Date.now(),
+                      taskPropertyClicked: true,
                     });
                   }}
                 >
-                  Go to feature on map
+                  <FormattedMessage {...messages.goToFeatureOnMap} />
                 </button>
               )}
               <PropertyList


### PR DESCRIPTION
an extension of https://github.com/maproulette/maproulette3/pull/2652, allowing easier navigation to the desired node by clicking on helper buttons in the TaskPropertiesWidget.  Now ClusterMaps are included.