### PR TITLE
fix review table initial load state

### DIFF
--- a/src/components/HOCs/WithReviewTasks/WithReviewTasks.jsx
+++ b/src/components/HOCs/WithReviewTasks/WithReviewTasks.jsx
@@ -82,14 +82,28 @@ export const WithReviewTasks = function (WrappedComponent) {
         searchOnCriteria.invertFields = this.state.criteria[props.reviewTasksType].invertFields;
       }
 
-      if (searchOnCriteria.savedChallengesOnly === undefined) {
-        searchOnCriteria.savedChallengesOnly =
-          this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly;
-      }
-      if (searchOnCriteria.excludeOtherReviewers === undefined) {
-        // Exclude reviews assigned to other reviewers by default
-        searchOnCriteria.excludeOtherReviewers =
-          this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
+      // Only apply defaults that would affect the URL if we're not skipping URL update
+      // This prevents adding default parameters to the URL on initial load
+      if (!skipURLUpdate) {
+        if (searchOnCriteria.savedChallengesOnly === undefined) {
+          searchOnCriteria.savedChallengesOnly =
+            this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly;
+        }
+        if (searchOnCriteria.excludeOtherReviewers === undefined) {
+          // Exclude reviews assigned to other reviewers by default
+          searchOnCriteria.excludeOtherReviewers =
+            this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
+        }
+      } else {
+        // On initial load, preserve the original values or use existing state values
+        if (searchOnCriteria.savedChallengesOnly === undefined) {
+          searchOnCriteria.savedChallengesOnly =
+            this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly ?? false;
+        }
+        if (searchOnCriteria.excludeOtherReviewers === undefined) {
+          searchOnCriteria.excludeOtherReviewers =
+            this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
+        }
       }
 
       // We need to update our list of challenges since some challenges may


### PR DESCRIPTION
Fixes the review challenge flow issue where when a user clicks on the review link in the browse challenge page that the resulting table data doesn't have the correct filters(aka showing other challenges the the one the user was browsing)

<img width="1278" alt="Screenshot 2025-06-18 at 11 46 31 PM" src="https://github.com/user-attachments/assets/c97f48e2-1fe1-4534-b12b-e77600771ed3" />
<img width="1512" alt="Screenshot 2025-06-18 at 11 46 48 PM" src="https://github.com/user-attachments/assets/75275c4b-0c64-4a78-b70d-eec558cc1878" />
