### PR TITLE
fix initial filters bug on review table

### DIFF
--- a/src/components/HOCs/WithReviewTasks/WithReviewTasks.jsx
+++ b/src/components/HOCs/WithReviewTasks/WithReviewTasks.jsx
@@ -82,28 +82,14 @@ export const WithReviewTasks = function (WrappedComponent) {
         searchOnCriteria.invertFields = this.state.criteria[props.reviewTasksType].invertFields;
       }
 
-      // Only apply defaults that would affect the URL if we're not skipping URL update
-      // This prevents adding default parameters to the URL on initial load
-      if (!skipURLUpdate) {
-        if (searchOnCriteria.savedChallengesOnly === undefined) {
-          searchOnCriteria.savedChallengesOnly =
-            this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly;
-        }
-        if (searchOnCriteria.excludeOtherReviewers === undefined) {
-          // Exclude reviews assigned to other reviewers by default
-          searchOnCriteria.excludeOtherReviewers =
-            this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
-        }
-      } else {
-        // On initial load, preserve the original values or use existing state values
-        if (searchOnCriteria.savedChallengesOnly === undefined) {
-          searchOnCriteria.savedChallengesOnly =
-            this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly ?? false;
-        }
-        if (searchOnCriteria.excludeOtherReviewers === undefined) {
-          searchOnCriteria.excludeOtherReviewers =
-            this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
-        }
+      if (searchOnCriteria.savedChallengesOnly === undefined) {
+        searchOnCriteria.savedChallengesOnly =
+          this.state.criteria[this.props.reviewTasksType]?.savedChallengesOnly;
+      }
+      if (searchOnCriteria.excludeOtherReviewers === undefined) {
+        // Exclude reviews assigned to other reviewers by default
+        searchOnCriteria.excludeOtherReviewers =
+          this.state.criteria[this.props.reviewTasksType]?.excludeOtherReviewers ?? true;
       }
 
       // We need to update our list of challenges since some challenges may
@@ -215,7 +201,6 @@ export const WithReviewTasks = function (WrappedComponent) {
         );
       }
       this.setState({ criteria: stateCriteria });
-      this.update(this.props, criteria, true);
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
Same issue talked about it https://github.com/maproulette/maproulette3/pull/2676. That previous pr didnt resolve the issue, so this pr reverts the changes from https://github.com/maproulette/maproulette3/pull/2676, and implements a fix for the review table filters issue indicated in that pr.