### PR TITLE
Add UI controls to mark notifications as unread

### DIFF
--- a/src/components/HOCs/WithUserNotifications/WithUserNotifications.jsx
+++ b/src/components/HOCs/WithUserNotifications/WithUserNotifications.jsx
@@ -5,6 +5,7 @@ import {
   deleteNotifications,
   fetchUserNotifications,
   markNotificationsRead,
+  markNotificationsUnread,
 } from "../../../services/User/User";
 
 const WithUserNotifications = (WrappedComponent) =>
@@ -21,6 +22,7 @@ export const mapDispatchToProps = (dispatch) =>
     {
       fetchUserNotifications,
       markNotificationsRead,
+      markNotificationsUnread,
       deleteNotifications,
     },
     dispatch,

--- a/src/pages/Inbox/HeaderNotifications.jsx
+++ b/src/pages/Inbox/HeaderNotifications.jsx
@@ -57,6 +57,14 @@ class HeaderNotifications extends Component {
                 <FormattedMessage {...messages.markSelectedReadLabel} />
               </button>
             </li>
+            <li className="mr-mr-3 mr-pr-3 mr-border-r mr-border-grey-light">
+              <button
+                onClick={this.props.markUnreadSelected}
+                className="mr-text-current hover:mr-text-yellow mr-transition"
+              >
+                <FormattedMessage {...messages.markSelectedUnreadLabel} />
+              </button>
+            </li>
             <li>
               <button
                 onClick={this.props.deleteSelected}
@@ -74,6 +82,7 @@ class HeaderNotifications extends Component {
 
 HeaderNotifications.propTypes = {
   markReadSelected: PropTypes.func.isRequired,
+  markUnreadSelected: PropTypes.func.isRequired,
   deleteSelected: PropTypes.func.isRequired,
 };
 

--- a/src/pages/Inbox/Inbox.jsx
+++ b/src/pages/Inbox/Inbox.jsx
@@ -44,7 +44,13 @@ const DEFAULT_PAGINATION = {
 };
 
 const Inbox = (props) => {
-  const { user, notifications, markNotificationsRead, deleteNotifications } = props;
+  const {
+    user,
+    notifications,
+    markNotificationsRead,
+    markNotificationsUnread,
+    deleteNotifications,
+  } = props;
 
   const {
     groupByTask,
@@ -86,6 +92,20 @@ const Inbox = (props) => {
       deselectAll();
     }
   }, [selectedNotifications, markNotificationsRead, deselectAll, user]);
+
+  const markUnreadSelected = useCallback(() => {
+    if (selectedNotifications.size > 0) {
+      markNotificationsUnread(user.id, [...selectedNotifications.values()]);
+      deselectAll();
+    }
+  }, [selectedNotifications, markNotificationsUnread, deselectAll, user]);
+
+  const markNotificationUnread = useCallback(
+    (notification) => {
+      markNotificationsUnread(user.id, [notification.id]);
+    },
+    [user, markNotificationsUnread],
+  );
 
   const deleteNotification = useCallback(
     (notification) => {
@@ -310,7 +330,7 @@ const Inbox = (props) => {
         disableFilters: true,
         Cell: ({ row }) => (
           <div className="mr-cell-content">
-            <ol className="mr-list-reset mr-links-green-lighter mr-inline-flex mr-justify-between mr-font-normal">
+            <ol className="mr-list-reset mr-links-green-lighter mr-inline-flex mr-justify-between mr-font-normal mr-space-x-2">
               <li>
                 <a
                   className={linkStyles}
@@ -319,11 +339,24 @@ const Inbox = (props) => {
                   <FormattedMessage {...messages.openNotificationLabel} />
                 </a>
               </li>
+              {row.original.isRead && (
+                <li>
+                  <a
+                    className={`${linkStyles} hover:mr-text-yellow`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      markNotificationUnread(row.original);
+                    }}
+                  >
+                    <FormattedMessage {...messages.markSelectedUnreadLabel} />
+                  </a>
+                </li>
+              )}
             </ol>
           </div>
         ),
-        width: 100,
-        minWidth: 80,
+        width: 140,
+        minWidth: 120,
         disableSortBy: true,
       },
     ],
@@ -337,6 +370,7 @@ const Inbox = (props) => {
       toggleNotificationSelection,
       threads,
       readNotification,
+      markNotificationUnread,
       props.intl,
     ],
   );
@@ -391,6 +425,7 @@ const Inbox = (props) => {
           toggleGroupByTask={toggleGroupByTask}
           refreshNotifications={props.refreshNotifications}
           markReadSelected={markReadSelected}
+          markUnreadSelected={markUnreadSelected}
           deleteSelected={deleteSelected}
         />
         <TableWrapper>

--- a/src/pages/Inbox/Messages.js
+++ b/src/pages/Inbox/Messages.js
@@ -34,6 +34,11 @@ export default defineMessages({
     defaultMessage: "Mark Read",
   },
 
+  markSelectedUnreadLabel: {
+    id: "Inbox.controls.markSelectedUnread.label",
+    defaultMessage: "Mark Unread",
+  },
+
   deleteSelectedLabel: {
     id: "Admin.ManageChallengeSnapshots.deleteSnapshot.label",
     defaultMessage: "Delete",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -186,6 +186,7 @@ const apiRoutes = (factory) => {
       updateNotificationSubscriptions: factory.put("/user/:userId/notificationSubscriptions"),
       notifications: factory.get("/user/:userId/notifications"),
       markNotificationsRead: factory.put("/user/:userId/notifications"),
+      markNotificationsUnread: factory.put("/user/:userId/notifications/unread"),
       deleteNotifications: factory.put("/user/:userId/notifications/delete"),
       announcements: factory.get("/user/announcements"),
       challengeLeaderboard: factory.get("/data/user/challengeLeaderboard"),

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -577,6 +577,22 @@ export const markNotificationsRead = function (userId, notificationIds) {
 };
 
 /**
+ * Mark notifications as unread
+ */
+export const markNotificationsUnread = function (userId, notificationIds) {
+  return function (dispatch) {
+    return new Endpoint(api.user.markNotificationsUnread, {
+      variables: { userId },
+      json: { notificationIds },
+    })
+      .execute()
+      .then(() => {
+        return fetchUserNotifications(userId)(dispatch);
+      });
+  };
+};
+
+/**
  * Delete notifications
  */
 export const deleteNotifications = function (userId, notificationIds) {


### PR DESCRIPTION
Dependent on: tbd
Adds user interface controls to mark notifications in the inbox as unread. Users can now mark notifications as unread both individually and in bulk.

<img width="205" alt="Screenshot 2025-07-01 at 9 49 09 AM" src="https://github.com/user-attachments/assets/e827c714-fdd6-4808-85c7-d485e5e104b9" />
