### PR TITLE
Temporarily disable Bing imagery integration for debugging purposes

### DIFF
--- a/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.jsx
+++ b/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { TileLayer } from "react-leaflet";
-import { BingLayer } from "react-leaflet-bing-v2/src/index.js";
+// import { BingLayer } from "react-leaflet-bing-v2/src/index.js";
 import AppErrors from "../../../services/Error/AppErrors";
 import {
   defaultLayerSource,
@@ -60,14 +60,16 @@ const SourcedTileLayer = (props) => {
   const normalizedLayer = normalizeLayer(props.source);
 
   if (normalizedLayer.type === "bing") {
-    return (
-      <BingLayer
-        key={normalizedLayer.id}
-        {...normalizedLayer}
-        type="Aerial"
-        attribution={attribution(normalizedLayer)}
-      />
-    );
+    // return (
+    //   <BingLayer
+    //     key={normalizedLayer.id}
+    //     {...normalizedLayer}
+    //     type="Aerial"
+    //     attribution={attribution(normalizedLayer)}
+    //   />
+    // );
+    console.error("Bing imagery is currently disabled to help debug a service issue");
+    return null;
   }
 
   return (


### PR DESCRIPTION
This is necessary to help debug an issue with Bing Imagery in MapRoulette (#2686). Our key seems to be being rate-limited, which prevents us from working on the issue in local development. As a quick-and-dirty workaround, I'm disabling Bing Imagery in production until we can determine the root cause.