### PR TITLE
Add top tags buttons

### DIFF
--- a/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.jsx
+++ b/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.jsx
@@ -17,6 +17,7 @@ import {
 } from "../../../../Custom/RJSFFormFieldAdapter/RJSFFormFieldAdapter";
 import WithTaskTags from "../../../../HOCs/WithTaskTags/WithTaskTags";
 import KeywordAutosuggestInput from "../../../../KeywordAutosuggestInput/KeywordAutosuggestInput";
+import TopTagSuggestions from "../../../../TopTagSuggestions";
 import WithCurrentChallenge from "../../../HOCs/WithCurrentChallenge/WithCurrentChallenge";
 import WithCurrentProject from "../../../HOCs/WithCurrentProject/WithCurrentProject";
 import WithCurrentTask from "../../../HOCs/WithCurrentTask/WithCurrentTask";
@@ -128,13 +129,27 @@ export class EditTask extends Component {
         );
 
         return (
-          <KeywordAutosuggestInput
-            {...props}
-            inputClassName="mr-p-2 mr-border-2 mr-border-grey-light-more mr-text-grey mr-rounded"
-            tagType={"tasks"}
-            preferredResults={preferredTags}
-            placeholder={this.props.intl.formatMessage(messages.addTagsPlaceholder)}
-          />
+          <div>
+            <KeywordAutosuggestInput
+              {...props}
+              inputClassName="mr-p-2 mr-border-2 mr-border-grey-light-more mr-text-grey mr-rounded"
+              tagType={"tasks"}
+              preferredResults={preferredTags}
+              placeholder={this.props.intl.formatMessage(messages.addTagsPlaceholder)}
+            />
+
+            {/* Show top tag suggestions from challenge */}
+            {this.props.challenge && (
+              <TopTagSuggestions
+                challengeId={this.props.challenge.id}
+                currentTags={props.formData}
+                onAddTag={(tag) => {
+                  const currentTags = props.formData || "";
+                  props.onChange(currentTags ? `${currentTags},${tag}` : tag);
+                }}
+              />
+            )}
+          </div>
         );
       },
     };

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.jsx
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.jsx
@@ -36,6 +36,7 @@ import Modal from "../Modal/Modal";
 import TaskCommentInput from "../TaskCommentInput/TaskCommentInput";
 import TaskNearbyList from "../TaskPane/TaskNearbyList/TaskNearbyList";
 import TaskReviewNearbyList from "../TaskPane/TaskNearbyList/TaskReviewNearbyList";
+import TopTagSuggestions from "../TopTagSuggestions";
 import AdjustFiltersOverlay from "./AdjustFiltersOverlay";
 import InstructionsOverlay from "./InstructionsOverlay";
 import messages from "./Messages";
@@ -371,6 +372,15 @@ export class TaskConfirmationModal extends Component {
                       limitToPreferred={limitTags}
                       placeholder={this.props.intl.formatMessage(messages.addTagsPlaceholder)}
                     />
+
+                    {/* Show top tag suggestions from challenge */}
+                    {this.props.task && this.props.task.parent && (
+                      <TopTagSuggestions
+                        challengeId={this.props.task.parent.id}
+                        currentTags={this.props.tags}
+                        onAddTag={this.handleAddTag}
+                      />
+                    )}
 
                     {this.props.submitComment && (
                       <div className="mr-my-1 mr-flex mr-justify-end">

--- a/src/components/TaskTags/TaskTags.jsx
+++ b/src/components/TaskTags/TaskTags.jsx
@@ -8,6 +8,7 @@ import External from "../External/External";
 import KeywordAutosuggestInput from "../KeywordAutosuggestInput/KeywordAutosuggestInput";
 import Modal from "../Modal/Modal";
 import SvgSymbol from "../SvgSymbol/SvgSymbol";
+import TopTagSuggestions from "../TopTagSuggestions";
 import messages from "./Messages";
 
 export class TaskTags extends Component {
@@ -96,6 +97,15 @@ export class TaskTags extends Component {
                   limitToPreferred={limitTags}
                   placeholder={this.props.intl.formatMessage(messages.addTagsPlaceholder)}
                 />
+
+                {/* Show top tag suggestions from challenge */}
+                {this.props.task && this.props.task.parent && (
+                  <TopTagSuggestions
+                    challengeId={this.props.task.parent.id}
+                    currentTags={this.props.tags}
+                    onAddTag={this.handleAddTag}
+                  />
+                )}
               </div>
               <div className="mr-flex mr-justify-end mr-items-center mr-mt-8">
                 <button

--- a/src/components/TopTagSuggestions/Messages.js
+++ b/src/components/TopTagSuggestions/Messages.js
@@ -1,0 +1,15 @@
+import { defineMessages } from "react-intl";
+
+/**
+ * Internationalized messages for use with TopTagSuggestions
+ */
+export default defineMessages({
+  loading: {
+    id: "TopTags.loading",
+    defaultMessage: "Loading popular tags...",
+  },
+  topTagsLabel: {
+    id: "TopTags.label",
+    defaultMessage: "Popular tags on this challenge:",
+  },
+});

--- a/src/components/TopTagSuggestions/index.js
+++ b/src/components/TopTagSuggestions/index.js
@@ -1,0 +1,2 @@
+import TopTagSuggestions from "./index.jsx";
+export default TopTagSuggestions;

--- a/src/components/TopTagSuggestions/index.jsx
+++ b/src/components/TopTagSuggestions/index.jsx
@@ -1,0 +1,78 @@
+import _isEmpty from "lodash/isEmpty";
+import { useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
+import { fetchTopTags } from "../../services/Challenge/TopTags";
+import messages from "./Messages";
+
+/**
+ * TopTagSuggestions displays the most popular tags for a challenge
+ * and allows users to quickly add them to their task
+ *
+ * @param {Object} props - Component props
+ * @param {number} props.challengeId - The id of the challenge to fetch top tags for
+ * @param {string} props.currentTags - Comma-separated string of current tags
+ * @param {Function} props.onAddTag - Callback function when a tag is clicked
+ */
+const TopTagSuggestions = (props) => {
+  const [loading, setLoading] = useState(true);
+  const [tags, setTags] = useState([]);
+
+  useEffect(() => {
+    if (props.challengeId) {
+      setLoading(true);
+      fetchTopTags(props.challengeId)
+        .then((topTags) => {
+          if (topTags) {
+            setTags(topTags);
+          }
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    }
+  }, [props.challengeId]);
+
+  // Don't render if there are no tags
+  if (!loading && _isEmpty(tags)) {
+    return null;
+  }
+
+  // Parse current tags to avoid duplicates
+  const currentTagsArray = props.currentTags ? props.currentTags.split(/,\s*/) : [];
+
+  return (
+    <div className="mr-mt-4">
+      {loading ? (
+        <span className="mr-text-sm mr-text-grey-light">
+          <FormattedMessage {...messages.loading} />
+        </span>
+      ) : (
+        <>
+          <div className="mr-text-sm mr-text-grey-light mr-mb-1">
+            <FormattedMessage {...messages.topTagsLabel} />
+          </div>
+          <div className="mr-flex mr-flex-wrap">
+            {tags.map((tag) => {
+              const isAlreadyAdded = currentTagsArray.includes(tag.name);
+
+              return (
+                <button
+                  key={tag.id}
+                  className={`mr-button mr-button--small mr-py-1 mr-text-xs mr-mr-2 mr-mb-2 ${
+                    isAlreadyAdded ? "mr-button--disabled" : ""
+                  }`}
+                  onClick={() => !isAlreadyAdded && props.onAddTag(tag.name)}
+                  disabled={isAlreadyAdded}
+                  title={isAlreadyAdded ? "Already added" : `Add tag: ${tag.name}`}
+                >
+                  <span>{tag.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TopTagSuggestions;

--- a/src/services/Challenge/TopTags.js
+++ b/src/services/Challenge/TopTags.js
@@ -1,0 +1,23 @@
+import _values from "lodash/values";
+import _map from "lodash/map";
+import Endpoint from "../Server/Endpoint";
+import { defaultRoutes as api } from "../Server/Server";
+
+/**
+ * Fetch top tags for a challenge
+ */
+export const fetchTopTags = function (challengeId) {
+  return new Endpoint(api.challenge.topTags, {
+    schema: {},
+    variables: { id: challengeId },
+  })
+    .execute()
+    .then((response) => {
+      // The API returns an object with numeric keys, convert to array
+      return response?.result ? Object.values(response.result) : [];
+    })
+    .catch((error) => {
+      console.log(error.response || error);
+      return [];
+    });
+};

--- a/src/services/Challenge/TopTags.js
+++ b/src/services/Challenge/TopTags.js
@@ -1,5 +1,5 @@
-import _values from "lodash/values";
 import _map from "lodash/map";
+import _values from "lodash/values";
 import Endpoint from "../Server/Endpoint";
 import { defaultRoutes as api } from "../Server/Server";
 

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -85,6 +85,7 @@ const apiRoutes = (factory) => {
       removeSnapshot: factory.delete("/snapshot/:id"),
       snapshot: factory.get("/snapshot/:id"),
       archive: factory.post("/challenge/:id/archive"),
+      topTags: factory.get("/challenge/:id/topTags"),
     },
     virtualChallenge: {
       single: factory.get("/virtualchallenge/:id"),


### PR DESCRIPTION
This pr implements a new feature in the task confirmation modal that displays the top 3 tags used in the challenge. The top 3 tags will be displayed as buttons that users can use to quickly add relevant mr tags.

<img width="1728" height="983" alt="Screenshot 2025-08-04 at 10 22 32 PM" src="https://github.com/user-attachments/assets/995738a7-8724-4fb5-9cb4-6c11d0220407" />
