### PR TITLE
fix Tasks removed from MapRoulette dashboard if all are marked as "Disabled" bug

### DIFF
--- a/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.jsx
+++ b/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.jsx
@@ -156,7 +156,7 @@ export class ViewChallengeTasks extends Component {
       if (rule?.rules) {
         return rule.rules.map((r) => parseBoundsRule(r, priorityLevel, priorityBounds));
       }
-      if (rule.type === "bounds") {
+      if (rule?.type === "bounds") {
         return priorityBounds.push({
           boundingBox: rule.value.replace("location.", ""),
           priorityLevel,


### PR DESCRIPTION
Disabled tasks in MapRoulette usually display in the Create & Manage section. However if all tasks are marked as Disabled, no tasks are displayed. This is an issue when users want to edit tasks after marking them all as disable. This pr resolves this issue.