### PR TITLE
add geoJSON input for Priority Bounds on challenge create/edit form

### DIFF
--- a/src/components/Custom/RJSFFormFieldAdapter/CustomPriorityBoundsField.jsx
+++ b/src/components/Custom/RJSFFormFieldAdapter/CustomPriorityBoundsField.jsx
@@ -1,9 +1,9 @@
+import { getType } from "@turf/invariant";
+import { isFeature, isFeatureCollection } from "geojson-validation";
 import L from "leaflet";
 import { useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { MapContainer, TileLayer, useMap } from "react-leaflet";
-import { getType } from "@turf/invariant";
-import { isFeature, isFeatureCollection } from "geojson-validation";
 import SvgSymbol from "../../SvgSymbol/SvgSymbol";
 import messages from "./Messages";
 import BoundsSelector from "./components/BoundsSelector";
@@ -192,7 +192,6 @@ const CustomPriorityBoundsField = (props) => {
     }
   };
 
-
   // Handle file upload
   const handleFileUpload = async (file) => {
     setUploadFeedback(null);
@@ -208,20 +207,18 @@ const CustomPriorityBoundsField = (props) => {
     try {
       const text = await file.text();
       const geoJson = JSON.parse(text);
-  
+
       if (!isFeature(geoJson) && !isFeatureCollection(geoJson)) {
         throw new Error("Input must be a valid GeoJSON Feature or FeatureCollection");
       }
-  
+
       const features = getType(geoJson) === "Feature" ? [geoJson] : geoJson.features || [];
 
       const polygonFeatures = features.filter(
         (feature) =>
-          feature.type === "Feature" && 
-          feature.geometry && 
-          feature.geometry.type === "Polygon"
+          feature.type === "Feature" && feature.geometry && feature.geometry.type === "Polygon",
       );
-  
+
       if (polygonFeatures.length === 0) {
         throw new Error("No valid Polygon features found");
       }

--- a/src/components/Custom/RJSFFormFieldAdapter/Messages.js
+++ b/src/components/Custom/RJSFFormFieldAdapter/Messages.js
@@ -104,7 +104,8 @@ export default defineMessages({
   },
   geoJSONFormatInfo: {
     id: "CustomPriorityBoundsField.geoJSONFormatInfo",
-    defaultMessage: "Expects a GeoJSON Feature or FeatureCollection containing Polygon geometry(s).",
+    defaultMessage:
+      "Expects a GeoJSON Feature or FeatureCollection containing Polygon geometry(s).",
   },
   fileTypeError: {
     id: "CustomPriorityBoundsField.fileTypeError",


### PR DESCRIPTION
This pr allows users to make polygons for the task priority bounds feature using json.

<img width="765" height="283" alt="Screenshot 2025-10-02 at 4 54 01 PM" src="https://github.com/user-attachments/assets/17359b9c-fd17-45b7-9450-f3c666ff6f9e" />
<img width="828" height="329" alt="Screenshot 2025-10-02 at 4 54 25 PM" src="https://github.com/user-attachments/assets/f2e5cb7a-d9d6-49ed-86ae-9bc07b9453fd" />
[file].json layout:

```
{
  "features": [
    {
      "type": "Feature", 
      "geometry": { 
        "type": "Polygon", 
        "coordinates": [
          [
            [lng,lat],
            [lng,lat],
            [lng,lat],
            [lng,lat],
            ...
          ]
        ]
      }
    },
   {
      "type": "Feature", 
      "geometry": { 
        "type": "Polygon", 
        "coordinates": [
          [
            [lng,lat],
            [lng,lat],
            [lng,lat],
            ...
          ]
        ]
      }
    },
    ...
  ]
}
```