### PR TITLE
fix map panning issue when zoomed out on task map

### DIFF
--- a/src/components/TaskPane/TaskMap/TaskMap.jsx
+++ b/src/components/TaskPane/TaskMap/TaskMap.jsx
@@ -73,7 +73,7 @@ const shortcutGroup = "layers";
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export const TaskMapContent = (props) => {
-  const { workspaceContext } = props;
+  const { workspaceContext, setWorkspaceContext } = props;
   const map = useMap();
   const [showTaskFeatures, setShowTaskFeatures] = useState(true);
   const [osmData, setOsmData] = useState(null);
@@ -90,20 +90,22 @@ export const TaskMapContent = (props) => {
   const [showMapControlsDrawer, setShowMapControlsDrawer] = useState(true);
 
   useEffect(() => {
-    if (workspaceContext?.taskMapBounds) {
+    if (workspaceContext?.taskMapBounds && workspaceContext?.taskPropertyClicked) {
       const isTaskInBundle =
         props.taskBundle?.tasks?.some((t) => t.id === workspaceContext.taskMapTask?.id) ||
         workspaceContext.taskMapTask?.id === props.task?.id;
 
       if (isTaskInBundle) {
         map.setView(workspaceContext.taskMapBounds.getCenter(), workspaceContext.taskMapZoom);
+        // Clear the flag after handling the property click
+        if (setWorkspaceContext) {
+          setWorkspaceContext({
+            taskPropertyClicked: false,
+          });
+        }
       }
     }
-  }, [
-    workspaceContext?.taskMapBounds,
-    workspaceContext?.taskMapZoom,
-    workspaceContext?.taskMapTask?.id,
-  ]);
+  }, [workspaceContext?.taskPropertyClicked]);
 
   const taskFeatures = () => {
     if ((props.taskBundle?.tasks?.length ?? 0) > 0) {


### PR DESCRIPTION
Issue: When a user was looking at a task, and zoomed out on the task map, the map would moving down on its own. This was due to a loop that would happen when the workspace context was updated to the current map view which would be slightly different than the users actual view causing the map to move, which would cause the workspace context to update again and do that all over again.

This pr fixes the root cause of that issue