### PR TITLE
fix issue where feature layer gets messed up when locator overlay layer is added

### DIFF
--- a/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.jsx
+++ b/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.jsx
@@ -60,7 +60,7 @@ const SourcedTileLayerInternal = (props) => {
 
   const normalizedLayer = normalizeLayer(props.source);
 
-  // Skip rendering if the tile URL has unresolved template variables (e.g. {apikey})
+  // Skip rendering if the tile URLhas unresolved template variables (e.g. {apikey})
   if (normalizedLayer.url) {
     const unresolvedVars = normalizedLayer.url.match(/\{(?!s|x|y|z|r\})[a-zA-Z_]+\}/g);
     if (unresolvedVars?.length > 0) {


### PR DESCRIPTION
This fixes a bug with the locator overlay that would cause the markers on the task map to be rendered wrongly.