### PR TITLE
fix cloned challenge osmIdProperty issue

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
@@ -54,7 +54,7 @@ export const jsSchema = (intl, user, challengeData) => {
  * > proper markup
  */
 export const uiSchema = (intl, user, challengeData, extraErrors, options = {}) => {
-  const sourceReadOnly = !AsEditableChallenge(challengeData).hasZeroTasks();
+  const sourceReadOnly = AsEditableChallenge(challengeData).isSourceReadOnly();
   const isCollapsed = options.longForm && (options.collapsedGroups || []).indexOf(STEP_ID) === -1;
   const toggleCollapsed =
     options.longForm && options.toggleCollapsed


### PR DESCRIPTION
Before: !AsEditableChallenge(challengeData).hasZeroTasks() — only checked if the challenge had tasks, ignoring whether it was a new/cloned challenge
After: AsEditableChallenge(challengeData).isSourceReadOnly() — checks both !isNew() && !hasZeroTasks(), so cloned challenges (which have their ID removed and are treated as new) will have the osmIdProperty field editable

resolves: https://github.com/maproulette/maproulette3/issues/2698