### PR TITLE
Enhance leaderboard functionality by deduplicating entries based on userId.

### DIFF
--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.jsx
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.jsx
@@ -39,7 +39,16 @@ const WithLeaderboard = function (WrappedComponent, initialMonthsPast = 1, initi
         const merged = _clone(this.state.leaderboard);
         if (merged) {
           merged.splice(userLeaderboard[0].rank - 1, userLeaderboard.length, ...userLeaderboard);
-          this.setState({ leaderboard: merged });
+          // Deduplicate by userId, keeping the first occurrence at the correct
+          // rank position. This prevents duplicate entries when the user already
+          // appeared in the initially fetched leaderboard at a different index.
+          const seen = new Set();
+          const deduped = merged.filter((entry) => {
+            if (seen.has(entry.userId)) return false;
+            seen.add(entry.userId);
+            return true;
+          });
+          this.setState({ leaderboard: deduped });
         }
       }
     };

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -201,6 +201,7 @@ export const initializeLeaderboardParams = function (
   endDate,
 ) {
   if (numberMonths === CURRENT_MONTH) {
+    params.monthDuration = CURRENT_MONTH;
     params.start = startOfMonth(new Date()).toISOString();
     params.end = endOfDay(new Date()).toISOString();
   } else if (numberMonths === CUSTOM_RANGE && startDate && endDate) {


### PR DESCRIPTION
This ensures that users only appear once in the leaderboard at their correct rank position. Additionally, update leaderboard initialization parameters to set month duration correctly for the current month.

related: https://github.com/maproulette/maproulette-backend/pull/1217

should resolve: 
https://github.com/maproulette/maproulette3/issues/2791
https://github.com/maproulette/maproulette3/issues/2593