### PR TITLE
use null check instead of undefined check for cooperativeWork property.

### DIFF
--- a/src/interactions/Task/AsCooperativeWork.js
+++ b/src/interactions/Task/AsCooperativeWork.js
@@ -18,7 +18,7 @@ export class AsCooperativeWork {
    * Determines if this represents a cooperative task
    */
   isCooperative() {
-    return this.cooperativeWork !== undefined;
+    return this.cooperativeWork != null;
   }
 
   /**


### PR DESCRIPTION
required for cooperative functionality to work after https://github.com/maproulette/maproulette-backend/pull/1236 is merged and deployed