### PR TITLE
Fix markdown shortcode regex dropping text around inner brackets

### DIFF
--- a/src/services/Templating/Templating.jsx
+++ b/src/services/Templating/Templating.jsx
@@ -24,8 +24,10 @@ const shortCodeHandlers = [
 // Short codes are surrounded by brackets, but -- to avoid confusion with
 // Markdown links -- cannot be immediately followed by an open parenthesees
 // (hence the lookahead at the end). Alternatively, triple curly braces can be
-// used
-const shortCodeRegex = /(\{\{\{[^}]+}}})|(\[[^\]]+\])(?=[^(]|$)/;
+// used. The bracket form excludes `[` from its content so the regex matches
+// the innermost brackets and leaves surrounding text (e.g. `[[way 1]]` or
+// `[note [way 1]]`) intact rather than greedily swallowing it.
+const shortCodeRegex = /(\{\{\{[^}]+}}})|(\[[^\][]+\])(?=[^(]|$)/;
 
 /**
  * Determines if the given string content contains one or more short-codes


### PR DESCRIPTION
The shortcode tokenizer regex allowed `[` inside bracketed content, so input like `[HIDDEN TEXT [way 2343242]]` was matched as one shortcode and OSMElementHandler then extracted only the OSM element, silently dropping the surrounding text. The `[[way 1]]` form lost one bracket the same way.

Excluding `[` from the inner character class makes the regex match only the innermost brackets, leaving surrounding text untouched.