### PR TITLE
Default Task tables to OSM property columns

### DIFF
--- a/src/components/HOCs/WithConfigurableColumns/WithConfigurableColumns.jsx
+++ b/src/components/HOCs/WithConfigurableColumns/WithConfigurableColumns.jsx
@@ -97,18 +97,18 @@ export default function (
       const addedColumns = {};
 
       for (const column of addedColumnsKeys) {
-        if (allColumns[column]) {
+        // Task Properties (`:propKey`) get italicized — they don't appear in
+        // allColumns since they're discovered dynamically per challenge.
+        if (column.startsWith(":")) {
+          addedColumns[column] = {
+            message: <span className="mr-italic">{column.slice(1)}</span>,
+          };
+        } else if (allColumns[column]) {
           addedColumns[column] = allColumns[column];
           if (columnMessages[`${column}Label`]) {
             addedColumns[column].message = this.props.intl.formatMessage(
               columnMessages[`${column}Label`],
             );
-          }
-          // Task Properties get italicized
-          else if (column.startsWith(":")) {
-            addedColumns[column] = {
-              message: <span className="mr-italic">{column.slice(1)}</span>,
-            };
           } else {
             // No internationalized label found for this column
             addedColumns[column] = { message: column };

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.jsx
@@ -57,7 +57,18 @@ const ALL_COLUMNS = Object.assign(
     : null,
 );
 
-const DEFAULT_COLUMNS = ["featureId", "id", "status", "priority", "controls", "comments"];
+const DEFAULT_COLUMNS = [
+  "id",
+  "status",
+  "priority",
+  ":access",
+  ":osmid",
+  ":userid",
+  ":changeset",
+  ":timestamp",
+  "controls",
+  "comments",
+];
 
 /**
  * TaskAnalysisTable renders a table of tasks using react-table.  Rendering is
@@ -190,30 +201,26 @@ export const TaskAnalysisTableInternal = (props) => {
 
     const baseColumns = [columnTypes.expander];
 
+    const findColumn = (column) => {
+      if (typeof column === "string" && column.startsWith(":")) {
+        const key = column.slice(1);
+        return {
+          id: key,
+          Header: key,
+          Cell: ({ row }) => {
+            const display = row.original.geometries?.features?.[0]?.properties?.[key];
+            return row.original ? <div>{display ?? ""}</div> : null;
+          },
+          disableSortBy: true,
+        };
+      }
+      return columnTypes[column];
+    };
+
     if (Array.isArray(props.showColumns) && props.showColumns.length > 0) {
-      return [
-        ...baseColumns,
-        ...props.showColumns.map((columnId) => columnTypes[columnId]).filter(Boolean),
-      ];
+      return [...baseColumns, ...props.showColumns.map(findColumn).filter(Boolean)];
     } else {
       // For default view, add expander, selected, and any custom columns
-      const findColumn = (column) => {
-        if (column.startsWith(":")) {
-          const key = column.slice(1);
-          return {
-            id: key,
-            Header: key,
-            Cell: ({ row }) => {
-              const display = row.original.geometries?.features?.[0]?.properties?.[key];
-              return row.original ? <div>{display ?? ""}</div> : null;
-            },
-            disableSortBy: true,
-          };
-        } else {
-          return columnTypes[column];
-        }
-      };
-
       return [
         ...baseColumns,
         columnTypes.selected,

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.jsx
@@ -720,8 +720,29 @@ const BundleInterface = (props) => {
           totalTasksInChallenge={calculateTasksInChallenge(props)}
           showColumns={
             taskBundle
-              ? ["featureId", "id", "status", "priority", "editBundle"]
-              : ["selected", "featureId", "id", "status", "priority", "comments"]
+              ? [
+                  "id",
+                  "status",
+                  "priority",
+                  ":access",
+                  ":osmid",
+                  ":userid",
+                  ":changeset",
+                  ":timestamp",
+                  "editBundle",
+                ]
+              : [
+                  "selected",
+                  "id",
+                  "status",
+                  "priority",
+                  ":access",
+                  ":osmid",
+                  ":userid",
+                  ":changeset",
+                  ":timestamp",
+                  "comments",
+                ]
           }
           customHeaderControls={
             !taskBundle &&


### PR DESCRIPTION
Drop `featureId` (now redundant with renamed "OSM ID") and seed the default column set for the Manage Challenge task table and the "Work on Multiple Tasks Together" widget with the OSM properties most commonly inspected in the Task Properties widget: access, osmid, userid, changeset, timestamp.

- TaskAnalysisTable: DEFAULT_COLUMNS now includes the `:`-prefixed task-property columns alongside id/status/priority/controls/comments
- TaskBundleWidget: explicit showColumns updated for both bundled and unbundled states
- TaskAnalysisTable: extract findColumn so the showColumns branch resolves `:`-prefixed task properties (previously only the default branch handled them, so explicit lists silently dropped property cols)
- WithConfigurableColumns: handle `:`-prefixed columns when seeding addedColumns from defaults (previously gated behind allColumns[column] which is always false for dynamic property keys)