### PR TITLE
Show MR tags in review pane without requiring a refresh

### DIFF
--- a/src/components/ReviewTaskControls/ReviewTaskControls.jsx
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.jsx
@@ -164,13 +164,15 @@ export class ReviewTaskControls extends Component {
     );
     const tags = uniqueTagsArray.join(",");
 
-    if (tags.length > 0 && this.state.tags === null) {
+    // Empty `state.tags` (null or "") means the user hasn't edited yet, so
+    // it's safe to mirror in whatever the loaded task tags are once they arrive.
+    if (tags.length > 0 && !this.state.tags) {
       this.setState({ tags: tags });
     }
 
     if (prevProps.task.id !== this.props.task.id) {
-      // Clear tags if we are on a new task
-      this.setState({ tags: tags ?? null });
+      // Reset on task switch so the next task's tags can populate fresh.
+      this.setState({ tags: tags || null });
     }
   }
 

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -470,7 +470,7 @@ export const loadNextReviewTask = function (criteria = {}, lastTaskId, asMetaRev
   );
 
   return function (dispatch) {
-    const params = { sort, order, ...searchParameters, asMetaReview };
+    const params = { sort, order, ...searchParameters, asMetaReview, includeTags: true };
     if (Number.isFinite(lastTaskId)) {
       params.lastTaskId = lastTaskId;
     }
@@ -497,7 +497,7 @@ export const fetchTaskForReview = function (taskId, includeMapillary = false) {
     return new Endpoint(api.task.startReview, {
       schema: taskSchema(),
       variables: { id: taskId },
-      params: { mapillary: includeMapillary },
+      params: { mapillary: includeMapillary, includeTags: true },
     })
       .execute()
       .then((normalizedResults) => {


### PR DESCRIPTION
Backend pr: https://github.com/maproulette/maproulette-backend/pull/1249
Request `includeTags=true` when fetching a task for review (both `fetchTaskForReview` and `loadNextReviewTask`) so the tags arrive with the task payload from the matching backend change.

Also fix a state-tracking bug in `ReviewTaskControls.componentDidUpdate`: the task-switch branch could set `state.tags` to `""` (empty string) when the next task arrived without tags, after which the `state.tags === null` guard prevented later-arriving tags from ever populating. Use `!state.tags` and `tags || null` so empty-string state is treated the same as null.
