### PR TITLE
Add task-lock-expiring-soon notification subscription

### DIFF
--- a/src/pages/Profile/Messages.js
+++ b/src/pages/Profile/Messages.js
@@ -272,6 +272,12 @@ export default defineMessages({
       "Receive a notification when your review status is updated by another reviewer.",
   },
 
+  taskUnlockWarningNotificationsDescription: {
+    id: "Profile.form.taskUnlockWarningNotifications.description",
+    defaultMessage:
+      "Receive an email shortly before one of your locked tasks is about to be auto-unlocked. Useful when working in an external editor like JOSM.",
+  },
+
   reviewCountNotificationsDescription: {
     id: "Profile.form.reviewCountNotifications.description",
     defaultMessage:

--- a/src/pages/Profile/UserSettings/NotificationSettingsSchema.jsx
+++ b/src/pages/Profile/UserSettings/NotificationSettingsSchema.jsx
@@ -115,6 +115,7 @@ export const jsSchema = (intl) => {
           team: notificationObject.team,
           follow: notificationObject.follow,
           metaReview: notificationObject.metaReview,
+          taskUnlockWarning: notificationObject.taskUnlockWarning,
           reviewCount: notificationObject.reviewCount,
           revisionCount: notificationObject.revisionCount,
         },
@@ -183,6 +184,10 @@ export const uiSchema = (intl) => {
       },
       metaReview: {
         "ui:help": intl.formatMessage(messages.metaReviewNotificationsDescription),
+        "ui:FieldTemplate": CustomNotificationFieldTemplate,
+      },
+      taskUnlockWarning: {
+        "ui:help": intl.formatMessage(messages.taskUnlockWarningNotificationsDescription),
         "ui:FieldTemplate": CustomNotificationFieldTemplate,
       },
       reviewCount: {

--- a/src/services/Notification/NotificationType/Messages.js
+++ b/src/services/Notification/NotificationType/Messages.js
@@ -64,6 +64,10 @@ export default defineMessages({
     id: "Notification.type.taskUnlockRequest",
     defaultMessage: "Task Unlock Request",
   },
+  taskUnlockWarning: {
+    id: "Notification.type.taskUnlockWarning",
+    defaultMessage: "Task Lock Expiring Soon",
+  },
 });
 
 export const subscriptionCountMessages = defineMessages({

--- a/src/services/Notification/NotificationType/NotificationType.js
+++ b/src/services/Notification/NotificationType/NotificationType.js
@@ -20,6 +20,7 @@ export const NOTIFICATION_TYPE_REVIEW_COUNT = 12;
 export const NOTIFICATION_TYPE_REVISION_COUNT = 13;
 export const NOTIFICATION_TYPE_CHALLENGE_COMMENT = 14;
 export const NOTIFICATION_TYPE_TASK_UNLOCK_REQUEST = 15;
+export const NOTIFICATION_TYPE_TASK_UNLOCK_WARNING = 16;
 
 export const NotificationType = Object.freeze({
   system: NOTIFICATION_TYPE_SYSTEM,
@@ -36,6 +37,7 @@ export const NotificationType = Object.freeze({
   metaReviewAgain: NOTIFICATION_TYPE_META_REVIEW_AGAIN,
   challengeComment: NOTIFICATION_TYPE_CHALLENGE_COMMENT,
   taskUnlockRequest: NOTIFICATION_TYPE_TASK_UNLOCK_REQUEST,
+  taskUnlockWarning: NOTIFICATION_TYPE_TASK_UNLOCK_WARNING,
 });
 
 export const NotificationSubscriptionType = Object.freeze({
@@ -48,6 +50,7 @@ export const NotificationSubscriptionType = Object.freeze({
   team: NOTIFICATION_TYPE_TEAM,
   follow: NOTIFICATION_TYPE_FOLLOW,
   metaReview: NOTIFICATION_TYPE_META_REVIEW,
+  taskUnlockWarning: NOTIFICATION_TYPE_TASK_UNLOCK_WARNING,
 });
 
 export const NotificationCountType = Object.freeze({


### PR DESCRIPTION
Mirrors the new backend `taskUnlockWarning` subscription so users can opt in to email warnings before their locked tasks auto-unlock. Defaults to "No Email"; users flip it to "Immediate Email" in their profile settings.