### PR TITLE
Use tabular numerals in lock timer to prevent layout shift

### DIFF
--- a/src/components/TaskPane/TaskPane.jsx
+++ b/src/components/TaskPane/TaskPane.jsx
@@ -90,7 +90,7 @@ const TaskLockButton = ({ lockedAt, title, onClick }) => {
       aria-label={ariaLabel}
     >
       {lockedAt && (
-        <span className="mr-text-xs mr-mr-2">
+        <span className="mr-text-xs mr-tabular-nums mr-mr-2">
           {isExpired ? (
             <FormattedMessage {...messages.taskLockExpiredLabel} />
           ) : (


### PR DESCRIPTION
Fixes #2882 